### PR TITLE
fix broken link to functions location page in FGC

### DIFF
--- a/delete-user-data/extension.yaml
+++ b/delete-user-data/extension.yaml
@@ -66,7 +66,7 @@ params:
     description: >-
       Where should the extension be deployed? You usually want a location close to your database.
       For help selecting a location, refer to the
-      [location selection guide](https://firebase.google.com/docs/functions/locations#selecting-regions_firestore-storage).
+      [location selection guide](https://firebase.google.com/docs/functions/locations).
     options:
       - label: Iowa (us-central1)
         value: us-central1

--- a/delete-user-data/extension.yaml
+++ b/delete-user-data/extension.yaml
@@ -66,7 +66,7 @@ params:
     description: >-
       Where should the extension be deployed? You usually want a location close to your database.
       For help selecting a location, refer to the
-      [location selection guide](https://firebase.google.com/docs/functions/locations#selecting_regions_for_firestore_and_storage).
+      [location selection guide](https://firebase.google.com/docs/functions/locations#selecting-regions_firestore-storage).
     options:
       - label: Iowa (us-central1)
         value: us-central1

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -62,7 +62,7 @@ params:
     description: >-
       Where should the extension be deployed? You usually want a location close to your database.
       For help selecting a location, refer to the
-      [location selection guide](https://firebase.google.com/docs/functions/locations##selecting-regions_firestore-storage).
+      [location selection guide](https://firebase.google.com/docs/functions/locations).
     options:
       - label: Iowa (us-central1)
         value: us-central1

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -62,7 +62,7 @@ params:
     description: >-
       Where should the extension be deployed? You usually want a location close to your database.
       For help selecting a location, refer to the
-      [location selection guide](https://firebase.google.com/docs/functions/locations#selecting_regions_for_firestore_and_storage).
+      [location selection guide](https://firebase.google.com/docs/functions/locations##selecting-regions_firestore-storage).
     options:
       - label: Iowa (us-central1)
         value: us-central1

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -58,7 +58,7 @@ params:
     type: select
     label: Deployment location
     description: >-
-      Where should the extension be deployed?
+      Where should the extension be deployed? You usually want a location close to your database.
       For help selecting a location, refer to the
       [location selection guide](https://firebase.google.com/docs/functions/locations).
     options:

--- a/firestore-shorten-urls-bitly/extension.yaml
+++ b/firestore-shorten-urls-bitly/extension.yaml
@@ -58,7 +58,7 @@ params:
     description: >-
       Where should the extension be deployed? You usually want a location close to your database.
       For help selecting a location, refer to the
-      [location selection guide](https://firebase.google.com/docs/functions/locations#selecting_regions_for_firestore_and_storage).
+      [location selection guide](https://firebase.google.com/docs/functions/locations).
     options:
       - label: Iowa (us-central1)
         value: us-central1

--- a/firestore-translate-text/extension.yaml
+++ b/firestore-translate-text/extension.yaml
@@ -63,7 +63,7 @@ params:
     description: >-
       Where should the extension be deployed? You usually want a location close to your database.
       For help selecting a location, refer to the
-      [location selection guide](https://firebase.google.com/docs/functions/locations#selecting_regions_for_firestore_and_storage).
+      [location selection guide](https://firebase.google.com/docs/functions/locations#selecting-regions_firestore-storage).
     options:
       - label: Iowa (us-central1)
         value: us-central1

--- a/firestore-translate-text/extension.yaml
+++ b/firestore-translate-text/extension.yaml
@@ -63,7 +63,7 @@ params:
     description: >-
       Where should the extension be deployed? You usually want a location close to your database.
       For help selecting a location, refer to the
-      [location selection guide](https://firebase.google.com/docs/functions/locations#selecting-regions_firestore-storage).
+      [location selection guide](https://firebase.google.com/docs/functions/locations).
     options:
       - label: Iowa (us-central1)
         value: us-central1


### PR DESCRIPTION
- fix broken link to functions location page in firebase.google.com
- make link to top of page rather than to a section anchor
- add missing info about how to select a location