### PR TITLE
[firestore-translate-text] allow single language list

### DIFF
--- a/firestore-translate-text/extension.yaml
+++ b/firestore-translate-text/extension.yaml
@@ -90,7 +90,7 @@ params:
       For these codes, visit the [supported languages list](https://cloud.google.com/translate/docs/languages).
     default: en,es,de,fr
     example: en,es,de,fr
-    validationRegex: "^[a-zA-Z,-]+[a-zA-Z-]{2,}$"
+    validationRegex: "^[a-zA-Z,-]*[a-zA-Z-]{2,}$"
     validationErrorMessage:
       Languages must be a comma-separated list of ISO-639-1 language codes.
     required: true

--- a/firestore-translate-text/functions/src/config.ts
+++ b/firestore-translate-text/functions/src/config.ts
@@ -15,7 +15,9 @@
  */
 
 export default {
-  languages: new Set(process.env.LANGUAGES.split(",")),
+  languages: Array.from(
+    new Set(process.env.LANGUAGES.split(","))
+  ),
   location: process.env.LOCATION,
   inputFieldName: process.env.INPUT_FIELD_NAME,
   outputFieldName: process.env.OUTPUT_FIELD_NAME,

--- a/firestore-translate-text/functions/src/config.ts
+++ b/firestore-translate-text/functions/src/config.ts
@@ -15,7 +15,7 @@
  */
 
 export default {
-  languages: process.env.LANGUAGES.split(","),
+  languages: new Set(process.env.LANGUAGES.split(",")),
   location: process.env.LOCATION,
   inputFieldName: process.env.INPUT_FIELD_NAME,
   outputFieldName: process.env.OUTPUT_FIELD_NAME,

--- a/firestore-translate-text/functions/src/index.ts
+++ b/firestore-translate-text/functions/src/index.ts
@@ -55,7 +55,7 @@ export const fstranslate = functions.handler.firestore.document.onWrite(
       validators.fieldNameIsTranslationPath(
         inputFieldName,
         outputFieldName,
-        languages
+        Array.from(languages)
       )
     ) {
       logs.inputFieldNameIsOutputPath();
@@ -147,9 +147,10 @@ const translateDocument = async (
 ): Promise<void> => {
   const input: string = extractInput(snapshot);
 
-  logs.translateInputStringToAllLanguages(input, config.languages);
+  const languages = Array.from(config.languages);
+  logs.translateInputStringToAllLanguages(input, languages);
 
-  const tasks = config.languages.map(
+  const tasks = languages.map(
     async (targetLanguage: string): Promise<Translation> => {
       return {
         language: targetLanguage,

--- a/firestore-translate-text/functions/src/index.ts
+++ b/firestore-translate-text/functions/src/index.ts
@@ -55,7 +55,7 @@ export const fstranslate = functions.handler.firestore.document.onWrite(
       validators.fieldNameIsTranslationPath(
         inputFieldName,
         outputFieldName,
-        Array.from(languages)
+        languages
       )
     ) {
       logs.inputFieldNameIsOutputPath();
@@ -147,10 +147,9 @@ const translateDocument = async (
 ): Promise<void> => {
   const input: string = extractInput(snapshot);
 
-  const languages = Array.from(config.languages);
-  logs.translateInputStringToAllLanguages(input, languages);
+  logs.translateInputStringToAllLanguages(input, config.languages);
 
-  const tasks = languages.map(
+  const tasks = config.languages.map(
     async (targetLanguage: string): Promise<Translation> => {
       return {
         language: targetLanguage,


### PR DESCRIPTION
This PR should:
- Change the regex validation of the `languages` field to accept a single language list;
- Use a `Set` so that the extension doesn't translate to the same language more than once;
- Fix #43 