### PR TITLE
[storage-resize-images] move "how param works" link to IMG_SIZES parameter

### DIFF
--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -106,7 +106,8 @@ params:
     label: Sizes of resized images
     description: >
       What sizes of images would you like (in pixels)? Enter the sizes as a
-      comma-separated list of WIDTHxHEIGHT values.
+      comma-separated list of WIDTHxHEIGHT values. Learn more about
+      [how this parameter works](https://firebase.google.com/products/extensions/storage-resize-images).
     default: "200x200"
     example: "200x200"
     validationRegex: ^\d+x(\d+,\d+x)*\d+$
@@ -121,8 +122,7 @@ params:
       if you specify a path here of `thumbs` and you upload an image to
       `/images/original.jpg`, then the resized image is stored at
       `/images/thumbs/original_200x200.jpg`. If you prefer to store resized
-      images at the root of your bucket, leave this field empty. Learn more about
-      [how this parameter works](https://firebase.google.com/products/extensions/storage-resize-images).
+      images at the root of your bucket, leave this field empty.
     example: thumbnails
     required: false
 


### PR DESCRIPTION
The parameter RESIZED_IMAGES_PATH does not need this link to the /products page; it should be on the IMG_SIZES param as this is the param that needs more in-depth explanation for proper configuration.