### PR TITLE
[firestore-counter] add clarification that subcollections aren't retained (POSTINSTALL)

### DIFF
--- a/firestore-counter/POSTINSTALL.md
+++ b/firestore-counter/POSTINSTALL.md
@@ -71,7 +71,15 @@ gcloud scheduler jobs create http firestore-sharded-counter-controller --schedul
 
 ### Using the extension
 
-After you complete the post-installation configuration above, your extension will create subcollections in all the documents that your app uses as counters. The client SDK will write to these subcollections to distribute the write load, and the scheduled function you deployed will sum the subcollections' values into the single `visits` field (or whichever field you configured).
+After you complete the post-installation configuration above, the process runs as follows:
+
+1. Your extension creates subcollections in all the documents that your app uses as counters.
+
+1. The client SDK writes to these subcollections to distribute the write load.
+
+1. The scheduled function that you deployed sums the subcollections' values into the single `visits` field (or whichever field you configured in your master document).
+
+1. After each summation, the extension deletes the subcollections, leaving only the count in the master document. This is the document field to which you should listen for the count.
 
 ### Monitoring
 


### PR DESCRIPTION
Issue #21 

To POSTINSTALL file:
- Added clarification that subcollections aren't retained after summation
- Broke section out into steps of the process