### PR TITLE
[firestore-bigquery-export] fix import script document name format

### DIFF
--- a/firestore-bigquery-export/scripts/import/package.json
+++ b/firestore-bigquery-export/scripts/import/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebaseextensions/fs-bq-import-collection",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Import a Firestore Collection into a BigQuery ChangeLog Table",
   "main": "./lib/index.js",
   "repository": {

--- a/firestore-bigquery-export/scripts/import/src/index.ts
+++ b/firestore-bigquery-export/scripts/import/src/index.ts
@@ -40,6 +40,8 @@ const FIRESTORE_VALID_CHARACTERS = /^[^\/]+$/;
 const FIRESTORE_COLLECTION_NAME_MAX_CHARS = 6144;
 const BIGQUERY_RESOURCE_NAME_MAX_CHARS = 1024;
 
+const FIRESTORE_DEFAULT_DATABASE = "(default)";
+
 const validateInput = (value: string, name: string, regex: RegExp, sizeLimit: number) => {
   if (!value || value === "" || value.trim() === "") {
     return `Please supply a ${name}`;
@@ -172,7 +174,7 @@ const run = async (): Promise<number> => {
         return {
           timestamp: new Date(0).toISOString(), // epoch
           operation: ChangeType.IMPORT,
-          documentName: snapshot.ref.path,
+          documentName: `projects/${projectId}/databases/${FIRESTORE_DEFAULT_DATABASE}/documents/${snapshot.ref.path}`,
           eventId: "",
           data: snapshot.data(),
         };


### PR DESCRIPTION
This change addresses https://github.com/firebase/extensions/issues/33. 