### PR TITLE
Migrate to Firestore transactions for writes

### DIFF
--- a/delete-user-data/functions/lib/index.js
+++ b/delete-user-data/functions/lib/index.js
@@ -116,10 +116,13 @@ const clearFirestoreData = (firestorePaths, uid) => __awaiter(this, void 0, void
         try {
             const isRecursive = config_1.default.firestoreDeleteMode === 'recursive';
             if (!isRecursive) {
+                const firestore = admin.firestore();
                 logs.firestorePathDeleting(path, false);
-                yield admin.firestore().runTransaction(((transaction) => __awaiter(this, void 0, void 0, function* () {
-                    return transaction.delete(admin.firestore().doc(path));
-                })));
+                // Wrapping in transaction to allow for automatic retries (#48)
+                yield firestore.runTransaction((transaction => {
+                    transaction.delete(firestore.doc(path));
+                    return Promise.resolve();
+                }));
                 logs.firestorePathDeleted(path, false);
             }
             else {

--- a/delete-user-data/functions/lib/index.js
+++ b/delete-user-data/functions/lib/index.js
@@ -117,10 +117,9 @@ const clearFirestoreData = (firestorePaths, uid) => __awaiter(this, void 0, void
             const isRecursive = config_1.default.firestoreDeleteMode === 'recursive';
             if (!isRecursive) {
                 logs.firestorePathDeleting(path, false);
-                yield admin
-                    .firestore()
-                    .doc(path)
-                    .delete();
+                yield admin.firestore().runTransaction(((transaction) => __awaiter(this, void 0, void 0, function* () {
+                    return transaction.delete(admin.firestore().doc(path));
+                })));
                 logs.firestorePathDeleted(path, false);
             }
             else {

--- a/delete-user-data/functions/src/index.ts
+++ b/delete-user-data/functions/src/index.ts
@@ -121,9 +121,13 @@ const clearFirestoreData = async (firestorePaths: string, uid: string) => {
       const isRecursive = config.firestoreDeleteMode === 'recursive';
 
       if (!isRecursive) {
+        const firestore = admin.firestore();
         logs.firestorePathDeleting(path, false);
-        await admin.firestore().runTransaction((async transaction => {
-          return transaction.delete(admin.firestore().doc(path));
+
+        // Wrapping in transaction to allow for automatic retries (#48)
+        await firestore.runTransaction((transaction => {
+          transaction.delete(firestore.doc(path));
+          return Promise.resolve();
         }));
         logs.firestorePathDeleted(path, false);
       } else {

--- a/delete-user-data/functions/src/index.ts
+++ b/delete-user-data/functions/src/index.ts
@@ -122,10 +122,9 @@ const clearFirestoreData = async (firestorePaths: string, uid: string) => {
 
       if (!isRecursive) {
         logs.firestorePathDeleting(path, false);
-        await admin
-          .firestore()
-          .doc(path)
-          .delete();
+        await admin.firestore().runTransaction((async transaction => {
+          return transaction.delete(admin.firestore().doc(path));
+        }));
         logs.firestorePathDeleted(path, false);
       } else {
         logs.firestorePathDeleting(path, true);

--- a/firestore-shorten-urls-bitly/functions/lib/index.js
+++ b/firestore-shorten-urls-bitly/functions/lib/index.js
@@ -119,6 +119,8 @@ const shortenUrl = (snapshot) => __awaiter(this, void 0, void 0, function* () {
 });
 const updateShortUrl = (snapshot, url) => __awaiter(this, void 0, void 0, function* () {
     logs.updateDocument(snapshot.ref.path);
-    yield snapshot.ref.update(config_1.default.shortUrlFieldName, url);
+    yield admin.firestore().runTransaction(((transaction) => __awaiter(this, void 0, void 0, function* () {
+        return transaction.update(snapshot.ref, config_1.default.shortUrlFieldName, url);
+    })));
     logs.updateDocumentComplete(snapshot.ref.path);
 });

--- a/firestore-shorten-urls-bitly/functions/lib/index.js
+++ b/firestore-shorten-urls-bitly/functions/lib/index.js
@@ -119,8 +119,10 @@ const shortenUrl = (snapshot) => __awaiter(this, void 0, void 0, function* () {
 });
 const updateShortUrl = (snapshot, url) => __awaiter(this, void 0, void 0, function* () {
     logs.updateDocument(snapshot.ref.path);
-    yield admin.firestore().runTransaction(((transaction) => __awaiter(this, void 0, void 0, function* () {
-        return transaction.update(snapshot.ref, config_1.default.shortUrlFieldName, url);
-    })));
+    // Wrapping in transaction to allow for automatic retries (#48)
+    yield admin.firestore().runTransaction((transaction => {
+        transaction.update(snapshot.ref, config_1.default.shortUrlFieldName, url);
+        return Promise.resolve();
+    }));
     logs.updateDocumentComplete(snapshot.ref.path);
 });

--- a/firestore-shorten-urls-bitly/functions/src/index.ts
+++ b/firestore-shorten-urls-bitly/functions/src/index.ts
@@ -139,8 +139,10 @@ const updateShortUrl = async (
 ): Promise<void> => {
   logs.updateDocument(snapshot.ref.path);
 
-  await admin.firestore().runTransaction((async transaction => {
-    return transaction.update(snapshot.ref, config.shortUrlFieldName, url);
+  // Wrapping in transaction to allow for automatic retries (#48)
+  await admin.firestore().runTransaction((transaction => {
+    transaction.update(snapshot.ref, config.shortUrlFieldName, url);
+    return Promise.resolve();
   }));
 
   logs.updateDocumentComplete(snapshot.ref.path);

--- a/firestore-shorten-urls-bitly/functions/src/index.ts
+++ b/firestore-shorten-urls-bitly/functions/src/index.ts
@@ -139,7 +139,9 @@ const updateShortUrl = async (
 ): Promise<void> => {
   logs.updateDocument(snapshot.ref.path);
 
-  await snapshot.ref.update(config.shortUrlFieldName, url);
+  await admin.firestore().runTransaction((async transaction => {
+    return transaction.update(snapshot.ref, config.shortUrlFieldName, url);
+  }));
 
   logs.updateDocumentComplete(snapshot.ref.path);
 };

--- a/firestore-translate-text/functions/lib/index.js
+++ b/firestore-translate-text/functions/lib/index.js
@@ -153,8 +153,10 @@ const translateString = (string, targetLanguage) => __awaiter(this, void 0, void
 });
 const updateTranslations = (snapshot, translations) => __awaiter(this, void 0, void 0, function* () {
     logs.updateDocument(snapshot.ref.path);
-    yield admin.firestore().runTransaction(((transaction) => __awaiter(this, void 0, void 0, function* () {
-        return transaction.update(snapshot.ref, config_1.default.outputFieldName, translations);
-    })));
+    // Wrapping in transaction to allow for automatic retries (#48)
+    yield admin.firestore().runTransaction((transaction) => {
+        transaction.update(snapshot.ref, config_1.default.outputFieldName, translations);
+        return Promise.resolve();
+    });
     logs.updateDocumentComplete(snapshot.ref.path);
 });

--- a/firestore-translate-text/functions/lib/index.js
+++ b/firestore-translate-text/functions/lib/index.js
@@ -153,6 +153,8 @@ const translateString = (string, targetLanguage) => __awaiter(this, void 0, void
 });
 const updateTranslations = (snapshot, translations) => __awaiter(this, void 0, void 0, function* () {
     logs.updateDocument(snapshot.ref.path);
-    yield snapshot.ref.update(config_1.default.outputFieldName, translations);
+    yield admin.firestore().runTransaction(((transaction) => __awaiter(this, void 0, void 0, function* () {
+        return transaction.update(snapshot.ref, config_1.default.outputFieldName, translations);
+    })));
     logs.updateDocumentComplete(snapshot.ref.path);
 });

--- a/firestore-translate-text/functions/src/index.ts
+++ b/firestore-translate-text/functions/src/index.ts
@@ -185,7 +185,10 @@ const translateString = async (
   try {
     logs.translateInputString(string, targetLanguage);
 
-    const [translatedString] = await translate.translate(string, targetLanguage);
+    const [translatedString] = await translate.translate(
+      string,
+      targetLanguage
+    );
 
     logs.translateStringComplete(string, targetLanguage);
 
@@ -202,9 +205,11 @@ const updateTranslations = async (
 ): Promise<void> => {
   logs.updateDocument(snapshot.ref.path);
 
-  await admin.firestore().runTransaction((async transaction => {
-    return transaction.update(snapshot.ref, config.outputFieldName, translations);
-  }));
+  // Wrapping in transaction to allow for automatic retries (#48)
+  await admin.firestore().runTransaction((transaction) => {
+    transaction.update(snapshot.ref, config.outputFieldName, translations);
+    return Promise.resolve();
+  });
 
   logs.updateDocumentComplete(snapshot.ref.path);
 };

--- a/firestore-translate-text/functions/src/index.ts
+++ b/firestore-translate-text/functions/src/index.ts
@@ -202,7 +202,9 @@ const updateTranslations = async (
 ): Promise<void> => {
   logs.updateDocument(snapshot.ref.path);
 
-  await snapshot.ref.update(config.outputFieldName, translations);
+  await admin.firestore().runTransaction((async transaction => {
+    return transaction.update(snapshot.ref, config.outputFieldName, translations);
+  }));
 
   logs.updateDocumentComplete(snapshot.ref.path);
 };


### PR DESCRIPTION
This PR introduces transaction based writes/deletes for extensions using Firestore, as discussed. 

Related PR: https://github.com/firebase/extensions/issues/48