### PR TITLE
[fs-bq-export] omit test files from npm package contents

### DIFF
--- a/firestore-bigquery-export/scripts/gen-schema-view/package.json
+++ b/firestore-bigquery-export/scripts/gen-schema-view/package.json
@@ -18,7 +18,12 @@
     "test": "npm run mocha"
   },
   "files": [
-    "lib"
+    "lib/index.js",
+    "lib/logs.js",
+    "lib/snapshot.js",
+    "lib/schema-loader-utils.js",
+    "lib/schema.js",
+    "lib/udf.js"
   ],
   "bin": {
     "fs-bq-schema-views": "./lib/index.js"


### PR DESCRIPTION
Right now the contents of the package `@firebaseextensions/fs-bq-schema-views` includes everything in `lib/`. We should only include things that aren't in `lib/test`.
