### PR TITLE
Update release notes URL and delete versions in package.json

### DIFF
--- a/auth-mailchimp-sync/extension.yaml
+++ b/auth-mailchimp-sync/extension.yaml
@@ -23,7 +23,7 @@ description:
 license: Apache-2.0
 billingRequired: true
 sourceUrl: https://github.com/firebase/extensions/tree/master/auth-mailchimp-sync
-releaseNotesUrl: https://github.com/firebase/extensions/commits/master
+releaseNotesUrl: https://github.com/firebase/extensions/releases
 
 author:
   authorName: Firebase

--- a/auth-mailchimp-sync/package.json
+++ b/auth-mailchimp-sync/package.json
@@ -1,6 +1,5 @@
 {
   "name": "auth-mailchimp-sync",
-  "version": "0.1.0",
   "description": "Add new users to a Mailchimp list, and delete them from the list when they delete their account.",
   "main": "functions/lib/index.js",
   "scripts": {
@@ -19,5 +18,6 @@
   "devDependencies": {
     "rimraf": "^2.6.3",
     "typescript": "^3.2.4"
-  }
+  },
+  "private": true
 }

--- a/delete-user-data/extension.yaml
+++ b/delete-user-data/extension.yaml
@@ -24,7 +24,7 @@ description:
 license: Apache-2.0
 billingRequired: false
 sourceUrl: https://github.com/firebase/extensions/tree/master/delete-user-data
-releaseNotesUrl: https://github.com/firebase/extensions/commits/master
+releaseNotesUrl: https://github.com/firebase/extensions/releases
 
 author:
   authorName: Firebase

--- a/delete-user-data/package.json
+++ b/delete-user-data/package.json
@@ -1,6 +1,5 @@
 {
   "name": "delete-user-data",
-  "version": "0.2.0",
   "description": "Automatically delete a user's data when they delete their account.",
   "main": "functions/lib/index.js",
   "scripts": {
@@ -19,5 +18,6 @@
   "devDependencies": {
     "rimraf": "^2.6.3",
     "typescript": "^3.5.2"
-  }
+  },
+  "private": true
 }

--- a/exts-test-data/package.json
+++ b/exts-test-data/package.json
@@ -1,6 +1,5 @@
 {
   "name": "exts-test-data",
-  "version": "0.1.0",
   "description": "Populate a Firebase project with users and data needed to test extensions",
   "main": "index.js",
   "scripts": {
@@ -15,5 +14,6 @@
     "inquirer": "^6.5.0",
     "ts-node": "^8.3.0",
     "typescript": "^3.5.3"
-  }
+  },
+  "private": true
 }

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -23,7 +23,7 @@ description:
 license: Apache-2.0
 billingRequired: true
 sourceUrl: https://github.com/firebase/extensions/tree/master/firestore-bigquery-export
-releaseNotesUrl: https://github.com/firebase/extensions/commits/master
+releaseNotesUrl: https://github.com/firebase/extensions/releases
 
 author:
   authorName: Firebase

--- a/firestore-bigquery-export/package.json
+++ b/firestore-bigquery-export/package.json
@@ -1,6 +1,5 @@
 {
   "name": "firestore-bigquery-export",
-  "version": "0.1.0",
   "description": "Export a Cloud Firestore collection to BigQuery",
   "main": "functions/lib/index.js",
   "scripts": {
@@ -30,5 +29,6 @@
     "generate-schema": "^2.6.0",
     "rimraf": "^2.6.3",
     "inquirer": "^6.4.0"
-  }
+  },
+  "private": true
 }

--- a/firestore-counter/extension.yaml
+++ b/firestore-counter/extension.yaml
@@ -23,7 +23,7 @@ description:
 license: Apache-2.0
 billingRequired: false
 sourceUrl: https://github.com/firebase/extensions/tree/master/firestore-counter
-releaseNotesUrl: https://github.com/firebase/extensions/commits/master
+releaseNotesUrl: https://github.com/firebase/extensions/releases
 
 author:
   authorName: Firebase

--- a/firestore-counter/package.json
+++ b/firestore-counter/package.json
@@ -1,6 +1,5 @@
 {
   "name": "firestore-counter",
-  "version": "0.1.0",
   "main": "functions/lib/index.js",
   "author": "patryk@google.com",
   "license": "Apache-2.0",
@@ -29,5 +28,6 @@
     "compile": "tsc",
     "format": "prettier --write {,**/}*.{yaml,ts,md}",
     "test": "mocha --require ts-node/register test/**/*.ts"
-  }
+  },
+  "private": true
 }

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -23,7 +23,7 @@ description:
 license: Apache-2.0
 billingRequired: true
 sourceUrl: https://github.com/firebase/extensions/tree/master/firestore-send-email
-releaseNotesUrl: https://github.com/firebase/extensions/commits/master
+releaseNotesUrl: https://github.com/firebase/extensions/releases
 
 author:
   authorName: Firebase

--- a/firestore-send-email/package.json
+++ b/firestore-send-email/package.json
@@ -1,6 +1,5 @@
 {
   "name": "firestore-send-email",
-  "version": "0.1.0",
   "description": "",
   "main": "functions/lib/index.js",
   "scripts": {
@@ -23,5 +22,6 @@
   "devDependencies": {
     "rimraf": "^2.6.3",
     "typescript": "^3.5.3"
-  }
+  },
+  "private": true
 }

--- a/firestore-shorten-urls-bitly/extension.yaml
+++ b/firestore-shorten-urls-bitly/extension.yaml
@@ -23,7 +23,7 @@ description:
 license: Apache-2.0
 billingRequired: true
 sourceUrl: https://github.com/firebase/extensions/tree/master/firestore-shorten-urls-bitly
-releaseNotesUrl: https://github.com/firebase/extensions/commits/master
+releaseNotesUrl: https://github.com/firebase/extensions/releases
 
 author:
   authorName: Firebase

--- a/firestore-shorten-urls-bitly/package.json
+++ b/firestore-shorten-urls-bitly/package.json
@@ -1,6 +1,5 @@
 {
   "name": "firestore-shorten-urls-bitly",
-  "version": "0.1.0",
   "description": "Automatically shorten url links",
   "author": "Chris Bianca <chris@csfrequency.com>",
   "license": "Apache-2.0",
@@ -19,5 +18,6 @@
   "devDependencies": {
     "rimraf": "^2.6.3",
     "typescript": "^3.2.4"
-  }
+  },
+  "private": true
 }

--- a/firestore-translate-text/extension.yaml
+++ b/firestore-translate-text/extension.yaml
@@ -24,7 +24,7 @@ description:
 license: Apache-2.0
 billingRequired: true
 sourceUrl: https://github.com/firebase/extensions/tree/master/firestore-translate-text
-releaseNotesUrl: https://github.com/firebase/extensions/commits/master
+releaseNotesUrl: https://github.com/firebase/extensions/releases
 
 author:
   authorName: Firebase

--- a/firestore-translate-text/package.json
+++ b/firestore-translate-text/package.json
@@ -1,6 +1,5 @@
 {
   "name": "firestore-translate-text",
-  "version": "0.1.0",
   "description": "Translate messages into multiple languages, provided by user",
   "author": "Chris Bianca <chris@csfrequency.com>",
   "license": "Apache-2.0",
@@ -19,5 +18,6 @@
   "devDependencies": {
     "rimraf": "^2.6.3",
     "typescript": "^3.2.4"
-  }
+  },
+  "private": true
 }

--- a/rtdb-limit-child-nodes/extension.yaml
+++ b/rtdb-limit-child-nodes/extension.yaml
@@ -23,7 +23,7 @@ description:
 license: Apache-2.0
 billingRequired: false
 sourceUrl: https://github.com/firebase/extensions/tree/master/rtdb-limit-child-nodes
-releaseNotesUrl: https://github.com/firebase/extensions/commits/master
+releaseNotesUrl: https://github.com/firebase/extensions/releases
 
 author:
   authorName: Firebase

--- a/rtdb-limit-child-nodes/package.json
+++ b/rtdb-limit-child-nodes/package.json
@@ -1,6 +1,5 @@
 {
   "name": "rtdb-limit-child-nodes",
-  "version": "0.1.0",
   "description": "Limit number of child nodes Firebase Functions sample",
   "main": "functions/lib/index.js",
   "scripts": {
@@ -17,5 +16,6 @@
   "devDependencies": {
     "rimraf": "^2.6.3",
     "typescript": "^3.5.2"
-  }
+  },
+  "private": true
 }

--- a/storage-resize-images/package.json
+++ b/storage-resize-images/package.json
@@ -1,6 +1,5 @@
 {
   "name": "storage-resize-images",
-  "version": "0.1.0",
   "description": "Resized Image Generator for Firebase",
   "author": "Firebase",
   "license": "Apache-2.0",
@@ -21,5 +20,6 @@
   "devDependencies": {
     "rimraf": "^2.6.3",
     "typescript": "^3.5.2"
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
- Revise release note url for all extensions to point to Github releases page
- Remove version number from all package.jsons, since they are not used for anything, and it is a burden to keep them in sync with the versions in extension.yaml
- Add "private:true" to package.json so that npm will not complain about the lack of a version number in package.json