### PR TITLE
[storage-resize-images] Remove storage-component.googleapis.com from API list

### DIFF
--- a/storage-resize-images/README.md
+++ b/storage-resize-images/README.md
@@ -64,12 +64,6 @@ When you use Firebase Extensions, you're only charged for the underlying resourc
 
 
 
-**APIs Used**:
-
-* storage-component.googleapis.com (Reason: Needed to use Cloud Storage)
-
-
-
 **Access Required**:
 
 

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -41,8 +41,6 @@ contributors:
     url: https://github.com/salakar
 
 apis:
-  - apiName: storage-component.googleapis.com
-    reason: Needed to use Cloud Storage
 
 roles:
   - role: storage.admin


### PR DESCRIPTION
Rationale: this API is actually auto-enabled for all new projects, so the extension does not need to specifically enable it. 