### PR TITLE
chore(*): Initial setup of CODEOWNERS file (automatic review assignments)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# All documentation changes, e.g. changelogs & readmes.
+*.md             @rachelsaunders
+
+# Dependencies, package.json and mono-repo files
+package.json     @Salakar @Ehesp
+*/package.json   @Salakar @Ehesp
+lerna.json       @Salakar @Ehesp
+
+# Tests
+jest.config.js    @Salakar @Ehesp
+*/jest.config.js  @Salakar @Ehesp
+__tests__/*      @Salakar @Ehesp


### PR DESCRIPTION
Small PR to setup an initial GitHub [`CODEOWNERS`](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) file.

Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. Code owners are not automatically requested to review draft pull requests. 

I've added the following rules for now;

 - when any markdown (*.md) file is modified, request review from @rachelsaunders
 - when any `package.json` or `lerna.json` file is modified, request review from myself and @Ehesp 
 - when any of the new testing files/setup are modified, request review from myself and @Ehesp 

Hope these initial ones are ok? I can add more specific to each extension if required - let me know :)

