### PR TITLE
docs(firestore-bigquery-export): clarify BigQuery billing

### DIFF
--- a/firestore-bigquery-export/PREINSTALL.md
+++ b/firestore-bigquery-export/PREINSTALL.md
@@ -27,7 +27,7 @@ Learn more about using this script to [backfill your existing collection](https:
 This extension uses other Firebase or Google Cloud Platform services which may have associated charges:
 
 +   Cloud Firestore
-+   BigQuery
++   BigQuery (this extension writes to BigQuery with [streaming inserts](https://cloud.google.com/bigquery/pricing#streaming_pricing))
 +   Cloud Functions
 
 When you use Firebase Extensions, you're only charged for the underlying resources that you use. A paid-tier billing plan is only required if the extension uses a service that requires a paid-tier plan, for example calling to a Google Cloud Platform API or making outbound network requests to non-Google services. All Firebase services offer a free tier of usage. [Learn more about Firebase billing.](https://firebase.google.com/pricing)

--- a/firestore-bigquery-export/PREINSTALL.md
+++ b/firestore-bigquery-export/PREINSTALL.md
@@ -26,8 +26,8 @@ Learn more about using this script to [backfill your existing collection](https:
 
 This extension uses other Firebase or Google Cloud Platform services which may have associated charges:
 
-+   Cloud Firestore
 +   BigQuery (this extension writes to BigQuery with [streaming inserts](https://cloud.google.com/bigquery/pricing#streaming_pricing))
++   Cloud Firestore
 +   Cloud Functions
 
 When you use Firebase Extensions, you're only charged for the underlying resources that you use. A paid-tier billing plan is only required if the extension uses a service that requires a paid-tier plan, for example calling to a Google Cloud Platform API or making outbound network requests to non-Google services. All Firebase services offer a free tier of usage. [Learn more about Firebase billing.](https://firebase.google.com/pricing)


### PR DESCRIPTION
[This Stack Overflow post](https://stackoverflow.com/questions/58807763/when-using-firebase-extension-export-to-bigquery-is-the-export-free-or-is-it-c) asked a good clarifying question about BigQuery billing, so I added the information to the preinstall.