### PR TITLE
Revert "[storage-resize-images] Remove storage-component.googleapis.com from API list"

### DIFF
--- a/storage-resize-images/README.md
+++ b/storage-resize-images/README.md
@@ -64,6 +64,12 @@ When you use Firebase Extensions, you're only charged for the underlying resourc
 
 
 
+**APIs Used**:
+
+* storage-component.googleapis.com (Reason: Needed to use Cloud Storage)
+
+
+
 **Access Required**:
 
 

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -41,6 +41,8 @@ contributors:
     url: https://github.com/salakar
 
 apis:
+  - apiName: storage-component.googleapis.com
+    reason: Needed to use Cloud Storage
 
 roles:
   - role: storage.admin


### PR DESCRIPTION
Reverts firebase/extensions#95

Reverting this, because as it stands today. The API will actually get disabled during the update of the extension, which is not a desired behavior. There's a backend fix for this that's in progress. After that's done, this can be re-merged. 