### PR TITLE
fix(firestore-bigquery-export): fix occasional duplicate entries in BigQuery

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,7 @@ package-lock.json
 # generated files
 README.md
 **/functions/lib/**
+**/lib/**
 **/dist/**
 
 # extension install md files

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
@@ -5,7 +5,7 @@
     "url": "github.com/firebase/extensions.git",
     "directory": "firestore-bigquery-export/firestore-bigquery-change-tracker"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Core change-tracker library for Cloud Firestore Collection BigQuery Exports",
   "main": "./lib/index.js",
   "scripts": {

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -73,11 +73,16 @@ export class FirestoreBigQueryEventHistoryTracker
    * Inserts rows of data into the BigQuery raw change log table.
    */
   private async insertData(rows: bigquery.RowMetadata[], options: object) {
+    const payload = {
+      skipInvalidRows: false,
+      ignoreUnkownValues: false,
+      rows: rows,
+    };
     try {
       const dataset = this.bq.dataset(this.config.datasetId);
       const table = dataset.table(this.rawChangeLogTableName());
       logs.dataInserting(rows.length);
-      await table.insert(rows, options);
+      await table.insert(payload, options);
       logs.dataInserted(rows.length);
     } catch (e) {
       // Reinitializing in case the destintation table is modified.

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -52,7 +52,7 @@ export class FirestoreBigQueryEventHistoryTracker
   async record(events: FirestoreDocumentChangeEvent[]) {
     await this.initialize();
     const options = {
-      raw: true
+      raw: true,
     };
     const rows = events.map((event) => {
       return {

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/tsconfig.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/tsconfig.json
@@ -8,5 +8,6 @@
     "target": "es6"
   },
   "compileOnSave": true,
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/node_modules/@types/jest/**"]
 }

--- a/firestore-bigquery-export/functions/package.json
+++ b/firestore-bigquery-export/functions/package.json
@@ -14,7 +14,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "firebase-admin": "~7.0.0",
-    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.0.0",
+    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.0.1",
     "firebase-functions": "^2.3.0",
     "sql-formatter": "^2.3.3"
   },

--- a/firestore-bigquery-export/scripts/gen-schema-view/tsconfig.json
+++ b/firestore-bigquery-export/scripts/gen-schema-view/tsconfig.json
@@ -9,5 +9,6 @@
     "types": ["node", "mocha", "chai"]
   },
   "compileOnSave": true,
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/node_modules/@types/jest/**"]
 }

--- a/firestore-bigquery-export/scripts/import/package.json
+++ b/firestore-bigquery-export/scripts/import/package.json
@@ -24,7 +24,7 @@
   "author": "Jan Wyszynski <wyszynski@google.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.0.0",
+    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.0.1",
     "@google-cloud/bigquery": "^2.1.0",
     "firebase-admin": "^7.1.1",
     "firebase-functions": "^2.2.1",

--- a/firestore-bigquery-export/scripts/import/tsconfig.json
+++ b/firestore-bigquery-export/scripts/import/tsconfig.json
@@ -8,5 +8,6 @@
     "target": "es6"
   },
   "compileOnSave": true,
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/node_modules/@types/jest/**"]
 }


### PR DESCRIPTION
https://github.com/firebase/extensions/issues/101 identifies the possibility that the raw change log may contain duplicate rows with matching eventIds. This is due to the at-least-once nature of cloud function execution. One potential safeguard against this is to use the function's eventId as a BigQuery streaming insert `insertId`. This will give BigQuery streaming works the chance to deduplicate redundant rows coming from repeated Cloud function executions occurring within a couple of minutes of one another [1]. This should probably cover most instances of this issue. 

I've stress tested mirroring around 500K document changes to a collection and compared the number of rows in the raw changelog to the number of distinct event_ids and found them to be equal. This indicates that the fix should at least mitigate the concern raised in the issue.

[1] https://cloud.google.com/bigquery/streaming-data-into-bigquery#dataconsistency