### PR TITLE
docs(firestore-bigquery-export) Capitalize "IMPORT" in example query

### DIFF
--- a/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
+++ b/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
@@ -44,7 +44,7 @@ This import script uses several values from your installation of the extension:
     ```
     SELECT COUNT(*) FROM
       `${PROJECT_ID}.${COLLECTION_PATH}.${COLLECTION_PATH}_raw_changelog`
-      WHERE operation = "import"
+      WHERE operation = "IMPORT"
     ```
 
     The result set will contain the number of documents in your source collection.


### PR DESCRIPTION
Using lowercase "import" will give zero results since the value of the `operation` field is capitalized in rows written by the script.