### PR TITLE
fix(firestore-bigquery-export) Fix file name issue in import script for Windows

### DIFF
--- a/firestore-bigquery-export/scripts/import/src/index.ts
+++ b/firestore-bigquery-export/scripts/import/src/index.ts
@@ -163,7 +163,7 @@ const run = async (): Promise<number> => {
 
   let cursorPositionFile =
     __dirname +
-    `/from-${sourceCollectionPath}-to-${projectId}\:${datasetId}\:${rawChangeLogName}`;
+    `/from-${sourceCollectionPath}-to-${projectId}_${datasetId}_${rawChangeLogName}`;
   if (await exists(cursorPositionFile)) {
     let cursorDocumentId = (await read(cursorPositionFile)).toString();
     cursor = await firebase


### PR DESCRIPTION
changing colon to underscore in the cursor position file name - for supporting windows environment execution

Error when trying to import from windows CMD:

Importing data from Cloud Firestore Collection: users, to BigQuery Dataset: firestore_export, Table: users_raw_changelogBigQuery dataset already exists: firestore_export
BigQuery table with name users_raw_changelog already exists in dataset firestore_export!
View with id users_raw_latest already exists in dataset firestore_export.
Inserting 300 row(s) of data into BigQuery
Inserted 300 row(s) of data into BigQuery
Error importing Collection to BigQuery: Error: ENOENT: no such file or directory, open 'C:\Users\Chen\AppData\Roaming\npm-cache\_npx\3232\node_modules\@firebaseextensions\fs-bq-import-collection\lib\from-users-to-<project_name>:firestore_export:users_raw_changelog'