### PR TITLE
fix(storage-resize-images): fix bug where name of resized file was missing original name if there was no file extension

### DIFF
--- a/storage-resize-images/__tests__/extractFileNameWithoutExtension.ts
+++ b/storage-resize-images/__tests__/extractFileNameWithoutExtension.ts
@@ -1,0 +1,26 @@
+import { extractFileNameWithoutExtension } from "../functions/src/util";
+describe("extractFileNameWithoutExtension", () => {
+  const filePathWithExtension = "/ref/to/my/image.png";
+  const filePathWithoutExtension = "/ref/to/my/image";
+  const ext = ".png";
+
+  describe("when file path includes file extension", () => {
+    it("extracts the basename without extension", () => {
+      const fileNameWithoutExtension = extractFileNameWithoutExtension(
+        filePathWithExtension,
+        ext
+      );
+      expect(fileNameWithoutExtension).toBe("image");
+    });
+  });
+
+  describe("when file path does not include file extension", () => {
+    it("extracts the basename without extension", () => {
+      const fileNameWithoutExtension = extractFileNameWithoutExtension(
+        filePathWithoutExtension,
+        ext
+      );
+      expect(fileNameWithoutExtension).toBe("image");
+    });
+  });
+});

--- a/storage-resize-images/functions/lib/index.js
+++ b/storage-resize-images/functions/lib/index.js
@@ -33,6 +33,7 @@ const path = require("path");
 const config_1 = require("./config");
 const logs = require("./logs");
 const validators = require("./validators");
+const util_1 = require("./util");
 // Initialize the Firebase Admin SDK
 admin.initializeApp();
 logs.init();
@@ -55,9 +56,8 @@ exports.generateResizedImage = functions.storage.object().onFinalize((object) =>
     const bucket = admin.storage().bucket(object.bucket);
     const filePath = object.name; // File path in the bucket.
     const fileDir = path.dirname(filePath);
-    const fileName = path.basename(filePath);
     const fileExtension = path.extname(filePath);
-    const fileNameWithoutExtension = fileName.slice(0, -fileExtension.length);
+    const fileNameWithoutExtension = util_1.extractFileNameWithoutExtension(filePath, fileExtension);
     const objectMetadata = object;
     let originalFile;
     let remoteFile;

--- a/storage-resize-images/functions/lib/util.js
+++ b/storage-resize-images/functions/lib/util.js
@@ -1,0 +1,6 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const path = require("path");
+exports.extractFileNameWithoutExtension = (filePath, ext) => {
+    return path.basename(filePath, ext);
+};

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -27,6 +27,7 @@ import config from "./config";
 import * as logs from "./logs";
 import * as validators from "./validators";
 import { ObjectMetadata } from "firebase-functions/lib/providers/storage";
+import { extractFileNameWithoutExtension } from "./util";
 
 interface ResizedImageResult {
   size: string;
@@ -61,9 +62,11 @@ export const generateResizedImage = functions.storage.object().onFinalize(
     const bucket = admin.storage().bucket(object.bucket);
     const filePath = object.name; // File path in the bucket.
     const fileDir = path.dirname(filePath);
-    const fileName = path.basename(filePath);
     const fileExtension = path.extname(filePath);
-    const fileNameWithoutExtension = fileName.slice(0, -fileExtension.length);
+    const fileNameWithoutExtension = extractFileNameWithoutExtension(
+      filePath,
+      fileExtension
+    );
     const objectMetadata = object;
 
     let originalFile;

--- a/storage-resize-images/functions/src/util.ts
+++ b/storage-resize-images/functions/src/util.ts
@@ -1,0 +1,8 @@
+import * as path from "path";
+
+export const extractFileNameWithoutExtension = (
+  filePath: string,
+  ext: string
+) => {
+  return path.basename(filePath, ext);
+};


### PR DESCRIPTION
I'm not sure if it is the expected behavior or not, and if so, please disregard this PR.

## Issue
As someone has pointed out in [this comment](https://github.com/firebase/extensions/issues/130#issuecomment-564425978), when a user uploads an image to the storage with a ref name **without** an extension, resized image's name gets to be trimmed like `_200x200`.

Below is a sample code that reproduces this.

```typescript
const storageRef = firebase.storage().ref('RANDOM_PATH')
const folderRef = storageRef.child('my_beautiful_cat')
await folderRef.put(e.target.files[0]) // got this from File API
```

![Screenshot 2019-12-13 02 44 02](https://user-images.githubusercontent.com/14039540/70735884-770bb080-1d52-11ea-93ea-bd16646672ff.png)

## Root Cause

It seems like the problem is happening where it [extracts the file name without extension](https://github.com/firebase/extensions/blob/next/storage-resize-images/functions/src/index.ts#L66). 
The current implementation is based on the premise that the ref would always have an extension, in other words, `fileExtension.length` is never 0. But, as it is not a restriction that firebase SDK enforces, when the file ref does not contain an extension, it should simply use the ref name, I guess.

## Fix

Node.js's `path.basename` can extract filename without extension.

reference: https://nodejs.org/docs/latest-v8.x/api/path.html#path_path_basename_path_ext