### PR TITLE
chore(*): update release notes URLs

### DIFF
--- a/auth-mailchimp-sync/CHANGELOG.md
+++ b/auth-mailchimp-sync/CHANGELOG.md
@@ -1,0 +1,3 @@
+## Version 0.1.0
+
+Initial release of the *Sync with Mailchimp* extension.

--- a/auth-mailchimp-sync/CHANGELOG.md
+++ b/auth-mailchimp-sync/CHANGELOG.md
@@ -1,3 +1,3 @@
 ## Version 0.1.0
 
-Initial release of the *Sync with Mailchimp* extension.
+Initial release of the _Sync with Mailchimp_ extension.

--- a/auth-mailchimp-sync/extension.yaml
+++ b/auth-mailchimp-sync/extension.yaml
@@ -23,7 +23,7 @@ description:
 license: Apache-2.0
 billingRequired: true
 sourceUrl: https://github.com/firebase/extensions/tree/master/auth-mailchimp-sync
-releaseNotesUrl: hhttps://github.com/firebase/extensions/blob/master/auth-mailchimp-sync/CHANGELOG.md
+releaseNotesUrl: https://github.com/firebase/extensions/blob/master/auth-mailchimp-sync/CHANGELOG.md
 
 author:
   authorName: Firebase

--- a/auth-mailchimp-sync/extension.yaml
+++ b/auth-mailchimp-sync/extension.yaml
@@ -23,7 +23,7 @@ description:
 license: Apache-2.0
 billingRequired: true
 sourceUrl: https://github.com/firebase/extensions/tree/master/auth-mailchimp-sync
-releaseNotesUrl: https://github.com/firebase/extensions/releases
+releaseNotesUrl: hhttps://github.com/firebase/extensions/blob/master/auth-mailchimp-sync/CHANGELOG.md
 
 author:
   authorName: Firebase

--- a/delete-user-data/CHANGELOG.md
+++ b/delete-user-data/CHANGELOG.md
@@ -2,3 +2,7 @@
 
 feature - Add a new param for recursively deleting subcollections in Cloud Firestore (issue #14).
 fixed - Fixed "cold start" errors experienced when the extension runs after a period of inactivity (issue #48).
+
+## Version 0.1.0
+
+Initial release of the *Delete User Data* extension.

--- a/delete-user-data/CHANGELOG.md
+++ b/delete-user-data/CHANGELOG.md
@@ -5,4 +5,4 @@ fixed - Fixed "cold start" errors experienced when the extension runs after a pe
 
 ## Version 0.1.1
 
-Initial release of the *Delete User Data* extension.
+Initial release of the _Delete User Data_ extension.

--- a/delete-user-data/CHANGELOG.md
+++ b/delete-user-data/CHANGELOG.md
@@ -3,6 +3,6 @@
 feature - Add a new param for recursively deleting subcollections in Cloud Firestore (issue #14).
 fixed - Fixed "cold start" errors experienced when the extension runs after a period of inactivity (issue #48).
 
-## Version 0.1.0
+## Version 0.1.1
 
 Initial release of the *Delete User Data* extension.

--- a/delete-user-data/extension.yaml
+++ b/delete-user-data/extension.yaml
@@ -24,7 +24,7 @@ description:
 license: Apache-2.0
 billingRequired: false
 sourceUrl: https://github.com/firebase/extensions/tree/master/delete-user-data
-releaseNotesUrl: https://github.com/firebase/extensions/releases
+releaseNotesUrl: https://github.com/firebase/extensions/blob/master/delete-user-data/CHANGELOG.md
 
 author:
   authorName: Firebase

--- a/firestore-bigquery-export/CHANGELOG.md
+++ b/firestore-bigquery-export/CHANGELOG.md
@@ -4,4 +4,4 @@ fixed - Fixed occasional duplicate rows created in the BigQuery backup table (is
 
 ## Version 0.1.0
 
-Initial release of the *Export Collections to BigQuery* extension.
+Initial release of the _Export Collections to BigQuery_ extension.

--- a/firestore-bigquery-export/CHANGELOG.md
+++ b/firestore-bigquery-export/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## Version 0.1.1
 
 fixed - Fixed occasional duplicate rows created in the BigQuery backup table (issue #101).
+
+## Version 0.1.0
+
+Initial release of the *Export Collections to BigQuery* extension.

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -23,7 +23,7 @@ description:
 license: Apache-2.0
 billingRequired: true
 sourceUrl: https://github.com/firebase/extensions/tree/master/firestore-bigquery-export
-releaseNotesUrl: https://github.com/firebase/extensions/releases
+releaseNotesUrl: https://github.com/firebase/extensions/blob/master/firestore-bigquery-export/CHANGELOG.md
 
 author:
   authorName: Firebase

--- a/firestore-counter/CHANGELOG.md
+++ b/firestore-counter/CHANGELOG.md
@@ -6,4 +6,4 @@ We recommend that you edit your existing Cloud Scheduler job to instead send a m
 
 ## Version 0.1.0
 
-Initial release of the *Distributed Counter* extension.
+Initial release of the _Distributed Counter_ extension.

--- a/firestore-counter/CHANGELOG.md
+++ b/firestore-counter/CHANGELOG.md
@@ -3,3 +3,7 @@
 changed - Moves the logic for monitoring the extension's workload from the existing HTTP function to a new Pub/Sub controllerCore function. Now, if called, the HTTP function triggers the new `controllerCore` function instead. This change was made to accommodate a [change in the way Google Cloud Functions handles HTTP functions](https://cloud.google.com/functions/docs/securing/managing-access#allowing_unauthenticated_function_invocation).
 
 We recommend that you edit your existing Cloud Scheduler job to instead send a message to the extension's Pub/Sub topic which triggers the new `controllerCore` function (detailed instructions provided in the [POSTINSTALL file](https://github.com/firebase/extensions/blob/master/firestore-counter/POSTINSTALL.md#set-up-a-cloud-scheduler-job). Although it's not recommended, if you leave your Cloud Scheduler job calling the HTTP function, your extension will continue to run as expected.
+
+## Version 0.1.0
+
+Initial release of the *Distributed Counter* extension.

--- a/firestore-counter/extension.yaml
+++ b/firestore-counter/extension.yaml
@@ -23,7 +23,7 @@ description:
 license: Apache-2.0
 billingRequired: false
 sourceUrl: https://github.com/firebase/extensions/tree/master/firestore-counter
-releaseNotesUrl: https://github.com/firebase/extensions/releases
+releaseNotesUrl: https://github.com/firebase/extensions/blob/master/firestore-counter/CHANGELOG.md
 
 author:
   authorName: Firebase

--- a/firestore-send-email/CHANGELOG.md
+++ b/firestore-send-email/CHANGELOG.md
@@ -5,3 +5,7 @@ feature - Support custom email headers. The extension reads from the `headers` f
 ## Version 0.1.1
 
 fixed - Fixed "cold start" errors experienced when the extension runs after a period of inactivity (issue #48).
+
+## Version 0.1.0
+
+Initial release of the *Trigger Email* extension.

--- a/firestore-send-email/CHANGELOG.md
+++ b/firestore-send-email/CHANGELOG.md
@@ -8,4 +8,4 @@ fixed - Fixed "cold start" errors experienced when the extension runs after a pe
 
 ## Version 0.1.0
 
-Initial release of the *Trigger Email* extension.
+Initial release of the _Trigger Email_ extension.

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -23,7 +23,7 @@ description:
 license: Apache-2.0
 billingRequired: true
 sourceUrl: https://github.com/firebase/extensions/tree/master/firestore-send-email
-releaseNotesUrl: https://github.com/firebase/extensions/releases
+releaseNotesUrl: https://github.com/firebase/extensions/blob/master/firestore-send-email/CHANGELOG.md
 
 author:
   authorName: Firebase

--- a/firestore-shorten-urls-bitly/CHANGELOG.md
+++ b/firestore-shorten-urls-bitly/CHANGELOG.md
@@ -1,3 +1,7 @@
 ## Version 0.1.1
 
 fixed - Fixed "cold start" errors experienced when the extension runs after a period of inactivity (issue #48).
+
+## Version 0.1.0
+
+Initial release of the *Shorten URLs* extension.

--- a/firestore-shorten-urls-bitly/CHANGELOG.md
+++ b/firestore-shorten-urls-bitly/CHANGELOG.md
@@ -4,4 +4,4 @@ fixed - Fixed "cold start" errors experienced when the extension runs after a pe
 
 ## Version 0.1.0
 
-Initial release of the *Shorten URLs* extension.
+Initial release of the _Shorten URLs_ extension.

--- a/firestore-shorten-urls-bitly/extension.yaml
+++ b/firestore-shorten-urls-bitly/extension.yaml
@@ -23,7 +23,7 @@ description:
 license: Apache-2.0
 billingRequired: true
 sourceUrl: https://github.com/firebase/extensions/tree/master/firestore-shorten-urls-bitly
-releaseNotesUrl: https://github.com/firebase/extensions/releases
+releaseNotesUrl: https://github.com/firebase/extensions/blob/master/firestore-shorten-urls-bitly/CHANGELOG.md
 
 author:
   authorName: Firebase

--- a/firestore-translate-text/CHANGELOG.md
+++ b/firestore-translate-text/CHANGELOG.md
@@ -9,4 +9,4 @@ fixed - Fixed "cold start" errors experienced when the extension runs after a pe
 
 ## Version 0.1.0
 
-Initial release of the *Translate Text* extension.
+Initial release of the _Translate Text_ extension.

--- a/firestore-translate-text/CHANGELOG.md
+++ b/firestore-translate-text/CHANGELOG.md
@@ -6,3 +6,7 @@ fixed - Fixed bug where target languages could not be reconfigured.
 
 fixed - Fixed bug where param validation failed when a single language was entered.
 fixed - Fixed "cold start" errors experienced when the extension runs after a period of inactivity (issue #48).
+
+## Version 0.1.0
+
+Initial release of the *Translate Text* extension.

--- a/firestore-translate-text/extension.yaml
+++ b/firestore-translate-text/extension.yaml
@@ -24,7 +24,7 @@ description:
 license: Apache-2.0
 billingRequired: true
 sourceUrl: https://github.com/firebase/extensions/tree/master/firestore-translate-text
-releaseNotesUrl: https://github.com/firebase/extensions/releases
+releaseNotesUrl: https://github.com/firebase/extensions/blob/master/firestore-translate-text/CHANGELOG.md
 
 author:
   authorName: Firebase

--- a/rtdb-limit-child-nodes/CHANGELOG.md
+++ b/rtdb-limit-child-nodes/CHANGELOG.md
@@ -1,3 +1,3 @@
 ## Version 0.1.0
 
-Initial release of the *Limit Child Nodes* extension.
+Initial release of the _Limit Child Nodes_ extension.

--- a/rtdb-limit-child-nodes/CHANGELOG.md
+++ b/rtdb-limit-child-nodes/CHANGELOG.md
@@ -1,0 +1,3 @@
+## Version 0.1.0
+
+Initial release of the *Limit Child Nodes* extension.

--- a/rtdb-limit-child-nodes/extension.yaml
+++ b/rtdb-limit-child-nodes/extension.yaml
@@ -23,7 +23,7 @@ description:
 license: Apache-2.0
 billingRequired: false
 sourceUrl: https://github.com/firebase/extensions/tree/master/rtdb-limit-child-nodes
-releaseNotesUrl: https://github.com/firebase/extensions/releases
+releaseNotesUrl: https://github.com/firebase/extensions/blob/master/rtdb-limit-child-nodes/CHANGELOG.md
 
 author:
   authorName: Firebase

--- a/storage-resize-images/CHANGELOG.md
+++ b/storage-resize-images/CHANGELOG.md
@@ -12,4 +12,4 @@ fixed - Fixed bug where certain edge cases led to already resized image being re
 
 ## Version 0.1.0
 
-Initial release of the *Resize Images* extension.
+Initial release of the _Resize Images_ extension.

--- a/storage-resize-images/CHANGELOG.md
+++ b/storage-resize-images/CHANGELOG.md
@@ -9,3 +9,7 @@ feature - Add new param for deleting the original image.
 ## Version 0.1.1
 
 fixed - Fixed bug where certain edge cases led to already resized image being resized again (issue #7).
+
+## Version 0.1.0
+
+Initial release of the _Resize Images_ extension.

--- a/storage-resize-images/CHANGELOG.md
+++ b/storage-resize-images/CHANGELOG.md
@@ -12,4 +12,4 @@ fixed - Fixed bug where certain edge cases led to already resized image being re
 
 ## Version 0.1.0
 
-Initial release of the _Resize Images_ extension.
+Initial release of the *Resize Images* extension.

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -24,7 +24,7 @@ description:
 
 billingRequired: false
 sourceUrl: https://github.com/firebase/extensions/tree/master/storage-resize-images
-releaseNotesUrl: https://github.com/firebase/extensions/releases
+releaseNotesUrl: https://github.com/firebase/extensions/blob/master/storage-resize-images/CHANGELOG.md
 
 author:
   authorName: Firebase


### PR DESCRIPTION
Changes the release notes URL to point to specific extension changelog files, as discussed.

- auth-mailchimp-sync & rtdb-limit-child-nodes did not have a `CHANGELOG.md`, so I creates a stub so the URL doesn't 404. Is this ok being blank?
- Each link points to `master` - assuming this is ok?