### PR TITLE
fix(storage-resize-images): Fix "TypeError: Cannot set property 'resizedImage' of undefined" by ensuring metadata is always available

### DIFF
--- a/storage-resize-images/functions/lib/index.js
+++ b/storage-resize-images/functions/lib/index.js
@@ -135,7 +135,7 @@ const resizeImage = ({ bucket, originalFile, fileDir, fileNameWithoutExtension, 
             contentEncoding: objectMetadata.contentEncoding,
             contentLanguage: objectMetadata.contentLanguage,
             contentType: contentType,
-            metadata: objectMetadata.metadata,
+            metadata: objectMetadata.metadata || {},
         };
         metadata.metadata.resizedImage = true;
         if (config_1.default.cacheControlHeader) {

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -170,7 +170,7 @@ const resizeImage = async ({
       contentEncoding: objectMetadata.contentEncoding,
       contentLanguage: objectMetadata.contentLanguage,
       contentType: contentType,
-      metadata: objectMetadata.metadata,
+      metadata: objectMetadata.metadata || {},
     };
     metadata.metadata.resizedImage = true;
     if (config.cacheControlHeader) {


### PR DESCRIPTION
Fixes https://github.com/firebase/extensions/issues/130

When images are uploaded to storage, depending on the tool used (e.g. Console vs gsutils vs SDK), the metadata object is not always created. This quick fix ensures an empty object is always available when resizing.