### PR TITLE
Lower SHARDS_LIMIT to 100.

### DIFF
--- a/firestore-counter/functions/src/worker.ts
+++ b/firestore-counter/functions/src/worker.ts
@@ -29,7 +29,7 @@ import { Aggregator, NumericUpdate } from "./aggregator";
 import { FieldValue } from "@google-cloud/firestore";
 import * as uuid from "uuid";
 
-const SHARDS_LIMIT = 499;
+const SHARDS_LIMIT = 100;
 const WORKER_TIMEOUT_MS = 45000;
 
 interface WorkerMetadata {


### PR DESCRIPTION
Firestore transactions perform best for up to 100 documents.

Fixes https://github.com/firebase/extensions/issues/64