### PR TITLE
feat(delete-user-data): allow deleting directories & files

### DIFF
--- a/delete-user-data/extension.yaml
+++ b/delete-user-data/extension.yaml
@@ -144,14 +144,14 @@ params:
       Where in Google Cloud Storage do you store user data? Leave empty if you
       don't use Cloud Storage.
 
-      Enter the full paths to a file or directory, separated by commas. You can
-      represent the User ID of the deleted user with `{UID}`. You can use
-      `{DEFAULT}` to represent your default bucket.
+      Enter the full paths to files or directories in your Storage buckets,
+      separated by commas. Use `{UID}` to represent the User ID of the deleted
+      user, and use `{DEFAULT}` to represent your default Storage bucket.
 
-      For example, if you are using your default bucket, and the bucket has
-      files with the naming scheme `{UID}-pic.png`, then you can enter
-      `{DEFAULT}/{UID}-pic.png`. If you also have files in another bucket called
-      `my-awesome-app-logs`, and that bucket has files with the naming scheme
-      `{UID}-logs.txt`, then you can enter
-      `{DEFAULT}/{UID}-pic.png,my-awesome-app-logs/{UID}-logs.txt`. You can
-      delete a directory by proving the full path, for example `{DEFAULT}/media/{UID}`.
+      Here's a series of examples. To delete all the files in your default
+      bucket with the file naming scheme `{UID}-pic.png`, enter
+      `{DEFAULT}/{UID}-pic.png`. To also delete all the files in another bucket
+      called my-app-logs with the file naming scheme `{UID}-logs.txt`, enter
+      `{DEFAULT}/{UID}-pic.png,my-app-logs/{UID}-logs.txt`. To *also* delete a User
+      ID-labeled directory and all its files (like `media/{UID}`), enter
+      `{DEFAULT}/{UID}-pic.png,my-app-logs/{UID}-logs.txt,{DEFAULT}/media/{UID}`.

--- a/delete-user-data/extension.yaml
+++ b/delete-user-data/extension.yaml
@@ -18,8 +18,8 @@ specVersion: v1beta
 version: 0.1.2
 
 description:
-  Deletes data keyed on a userId from Cloud Firestore, Realtime
-  Database, and/or Cloud Storage when a user deletes their account.
+  Deletes data keyed on a userId from Cloud Firestore, Realtime Database, and/or
+  Cloud Storage when a user deletes their account.
 
 license: Apache-2.0
 billingRequired: false
@@ -52,9 +52,10 @@ resources:
   - name: clearData
     type: firebaseextensions.v1beta.function
     description:
-      Listens for user accounts to be deleted from your project's authenticated users,
-      then removes any associated user data (based on Firebase Authentication's User ID) from
-      Realtime Database, Cloud Firestore, and/or Cloud Storage.
+      Listens for user accounts to be deleted from your project's authenticated
+      users, then removes any associated user data (based on Firebase
+      Authentication's User ID) from Realtime Database, Cloud Firestore, and/or
+      Cloud Storage.
     properties:
       sourceDirectory: .
       location: ${LOCATION}
@@ -67,9 +68,9 @@ params:
     type: select
     label: Deployment location
     description: >-
-      Where should the extension be deployed? You usually want a location close to your database.
-      For help selecting a location, refer to the
-      [location selection guide](https://firebase.google.com/docs/functions/locations).
+      Where should the extension be deployed? You usually want a location close
+      to your database. For help selecting a location, refer to the [location
+      selection guide](https://firebase.google.com/docs/functions/locations).
     options:
       - label: Iowa (us-central1)
         value: us-central1
@@ -95,21 +96,23 @@ params:
     example: users/{UID},admins/{UID}
     required: false
     description: >-
-      Which paths in your Cloud Firestore instance contain user data? Leave empty if
-      you don't use Cloud Firestore.
+      Which paths in your Cloud Firestore instance contain user data? Leave
+      empty if you don't use Cloud Firestore.
 
-      Enter the full paths, separated by commas. You can represent the User ID of the deleted user with `{UID}`.
+      Enter the full paths, separated by commas. You can represent the User ID
+      of the deleted user with `{UID}`.
 
-      For example, if you have the collections `users` and `admins`, and each collection
-      has documents with User ID as document IDs, then you can enter `users/{UID},admins/{UID}`.
+      For example, if you have the collections `users` and `admins`, and each
+      collection has documents with User ID as document IDs, then you can enter
+      `users/{UID},admins/{UID}`.
 
   - param: FIRESTORE_DELETE_MODE
     type: select
     label: Cloud Firestore delete mode
     description: >-
-      (Only applicable if you use the `Cloud Firestore paths` parameter.) How do you want
-      to delete Cloud Firestore documents? To also delete documents in subcollections,
-      set this parameter to `recursive`.
+      (Only applicable if you use the `Cloud Firestore paths` parameter.) How do
+      you want to delete Cloud Firestore documents? To also delete documents in
+      subcollections, set this parameter to `recursive`.
     options:
       - label: Recursive
         value: recursive
@@ -124,10 +127,11 @@ params:
     example: users/{UID},admins/{UID}
     required: false
     description: >-
-      Which paths in your Realtime Database instance contain user data? Leave empty if you
-      don't use Realtime Database.
+      Which paths in your Realtime Database instance contain user data? Leave
+      empty if you don't use Realtime Database.
 
-      Enter the full paths, separated by commas. You can represent the User ID of the deleted user with `{UID}`.
+      Enter the full paths, separated by commas. You can represent the User ID
+      of the deleted user with `{UID}`.
 
       For example: `users/{UID},admins/{UID}`.
 
@@ -140,12 +144,14 @@ params:
       Where in Google Cloud Storage do you store user data? Leave empty if you
       don't use Cloud Storage.
 
-      Enter the full paths, separated by commas. You can represent the User ID of the deleted user with `{UID}`.
-      You can use `{DEFAULT}` to represent your default bucket.
+      Enter the full paths to a file or directory, separated by commas. You can
+      represent the User ID of the deleted user with `{UID}`. You can use
+      `{DEFAULT}` to represent your default bucket.
 
-      For example, if you are using your default bucket,
-      and the bucket has files with the naming scheme `{UID}-pic.png`,
-      then you can enter `{DEFAULT}/{UID}-pic.png`.
-      If you also have files in another bucket called `my-awesome-app-logs`,
-      and that bucket has files with the naming scheme `{UID}-logs.txt`,
-      then you can enter `{DEFAULT}/{UID}-pic.png,my-awesome-app-logs/{UID}-logs.txt`.
+      For example, if you are using your default bucket, and the bucket has
+      files with the naming scheme `{UID}-pic.png`, then you can enter
+      `{DEFAULT}/{UID}-pic.png`. If you also have files in another bucket called
+      `my-awesome-app-logs`, and that bucket has files with the naming scheme
+      `{UID}-logs.txt`, then you can enter
+      `{DEFAULT}/{UID}-pic.png,my-awesome-app-logs/{UID}-logs.txt`. You can
+      delete a directory by proving the full path, for example `{DEFAULT}/media/{UID}`.

--- a/delete-user-data/functions/lib/index.js
+++ b/delete-user-data/functions/lib/index.js
@@ -15,11 +15,10 @@
  * limitations under the License.
  */
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -37,7 +36,7 @@ logs.init();
  * Storage, and Firestore. It waits for all deletions to complete, and then
  * returns a success message.
  */
-exports.clearData = functions.auth.user().onDelete((user) => __awaiter(void 0, void 0, void 0, function* () {
+exports.clearData = functions.auth.user().onDelete((user) => __awaiter(this, void 0, void 0, function* () {
     logs.start();
     const { firestorePaths, rtdbPaths, storagePaths } = config_1.default;
     const { uid } = user;
@@ -63,10 +62,10 @@ exports.clearData = functions.auth.user().onDelete((user) => __awaiter(void 0, v
     yield Promise.all(promises);
     logs.complete(uid);
 }));
-const clearDatabaseData = (databasePaths, uid) => __awaiter(void 0, void 0, void 0, function* () {
+const clearDatabaseData = (databasePaths, uid) => __awaiter(this, void 0, void 0, function* () {
     logs.rtdbDeleting();
     const paths = extractUserPaths(databasePaths, uid);
-    const promises = paths.map((path) => __awaiter(void 0, void 0, void 0, function* () {
+    const promises = paths.map((path) => __awaiter(this, void 0, void 0, function* () {
         try {
             logs.rtdbPathDeleting(path);
             yield admin
@@ -82,38 +81,39 @@ const clearDatabaseData = (databasePaths, uid) => __awaiter(void 0, void 0, void
     yield Promise.all(promises);
     logs.rtdbDeleted();
 });
-const clearStorageData = (storagePaths, uid) => __awaiter(void 0, void 0, void 0, function* () {
+const clearStorageData = (storagePaths, uid) => __awaiter(this, void 0, void 0, function* () {
     logs.storageDeleting();
     const paths = extractUserPaths(storagePaths, uid);
-    const promises = paths.map((path) => __awaiter(void 0, void 0, void 0, function* () {
+    const promises = paths.map((path) => __awaiter(this, void 0, void 0, function* () {
         const parts = path.split("/");
         const bucketName = parts[0];
         const bucket = bucketName === "{DEFAULT}"
             ? admin.storage().bucket()
             : admin.storage().bucket(bucketName);
-        const file = bucket.file(parts.slice(1).join("/"));
-        const bucketFilePath = `${bucket.name}/${file.name}`;
+        const prefix = parts.slice(1).join("/");
         try {
-            logs.storagePathDeleting(bucketFilePath);
-            yield file.delete();
-            logs.storagePathDeleted(bucketFilePath);
+            logs.storagePathDeleting(prefix);
+            yield bucket.deleteFiles({
+                prefix,
+            });
+            logs.storagePathDeleted(prefix);
         }
         catch (err) {
             if (err.code === 404) {
-                logs.storagePath404(bucketFilePath);
+                logs.storagePath404(prefix);
             }
             else {
-                logs.storagePathError(bucketFilePath, err);
+                logs.storagePathError(prefix, err);
             }
         }
     }));
     yield Promise.all(promises);
     logs.storageDeleted();
 });
-const clearFirestoreData = (firestorePaths, uid) => __awaiter(void 0, void 0, void 0, function* () {
+const clearFirestoreData = (firestorePaths, uid) => __awaiter(this, void 0, void 0, function* () {
     logs.firestoreDeleting();
     const paths = extractUserPaths(firestorePaths, uid);
-    const promises = paths.map((path) => __awaiter(void 0, void 0, void 0, function* () {
+    const promises = paths.map((path) => __awaiter(this, void 0, void 0, function* () {
         try {
             const isRecursive = config_1.default.firestoreDeleteMode === "recursive";
             if (!isRecursive) {

--- a/delete-user-data/functions/src/index.ts
+++ b/delete-user-data/functions/src/index.ts
@@ -92,17 +92,18 @@ const clearStorageData = async (storagePaths: string, uid: string) => {
       bucketName === "{DEFAULT}"
         ? admin.storage().bucket()
         : admin.storage().bucket(bucketName);
-    const file = bucket.file(parts.slice(1).join("/"));
-    const bucketFilePath = `${bucket.name}/${file.name}`;
+    const prefix = parts.slice(1).join("/");
     try {
-      logs.storagePathDeleting(bucketFilePath);
-      await file.delete();
-      logs.storagePathDeleted(bucketFilePath);
+      logs.storagePathDeleting(prefix);
+      await bucket.deleteFiles({
+        prefix,
+      });
+      logs.storagePathDeleted(prefix);
     } catch (err) {
       if (err.code === 404) {
-        logs.storagePath404(bucketFilePath);
+        logs.storagePath404(prefix);
       } else {
-        logs.storagePathError(bucketFilePath, err);
+        logs.storagePathError(prefix, err);
       }
     }
   });


### PR DESCRIPTION
Implements #148

`bucket.file(x)` only allows deleting specific files, not directories. This change uses `deleteFiles` with a prefix arg to delete both files and directories.

```
-- my-bucket
  -- 123
    -- foo.jpg
    -- bar.jpg
  -- 567.png
```

Given the structure above, the user could enter the following into the setup args to delete both `foo.jpg` & `bar.jpg` files:

`my-bucket/{UID}` (UID = 123)

To delete a single file, they'd do the usual:

`my-bucket/{UID}.png` (UID = 567)