### PR TITLE
fix(storage-resize-images) relax bucket naming rules

### DIFF
--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -97,7 +97,7 @@ params:
       Resized images will be stored in this bucket. Depending on your extension configuration,
       original images are either kept or deleted.
     default: ${STORAGE_BUCKET}
-    validationRegex: ^([0-9a-zA-Z_.-]*)$
+    validationRegex: ^([0-9a-z_.-]*)$
     validationErrorMessage: Invalid storage bucket
     example: my-project-12345.appspot.com
     required: true

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -97,7 +97,7 @@ params:
       Resized images will be stored in this bucket. Depending on your extension configuration,
       original images are either kept or deleted.
     default: ${STORAGE_BUCKET}
-    validationRegex: (.)+\.(.)+\.(.)+
+    validationRegex: ^([0-9a-zA-Z_.-]*)$
     validationErrorMessage: Invalid storage bucket
     example: my-project-12345.appspot.com
     required: true


### PR DESCRIPTION
Handles #27 & allows for #18

Currently the rules assume the bucket name is always `x.x.x`, whereas it can actually be anything with letters, numbers, dashes, dots, underscores.

This only checks for characters, it doesn't validate the storage bucket actually exists.