### PR TITLE
[all] clarify label & description of LOCATION param; note for default BigQuery location

### DIFF
--- a/auth-mailchimp-sync/extension.yaml
+++ b/auth-mailchimp-sync/extension.yaml
@@ -69,10 +69,7 @@ params:
     type: select
     label: Cloud Functions location
     description: >-
-      Where do you want to deploy the functions created for this extension? 
-      You usually want a location close to your database. For help selecting a 
-      location, refer to the [location selection 
-      guide](https://firebase.google.com/docs/functions/locations).
+      Where do you want to deploy the functions created for this extension?
     options:
       - label: Iowa (us-central1)
         value: us-central1

--- a/auth-mailchimp-sync/extension.yaml
+++ b/auth-mailchimp-sync/extension.yaml
@@ -67,10 +67,11 @@ resources:
 params:
   - param: LOCATION
     type: select
-    label: Deployment location
+    label: Cloud Functions location
     description: >-
-      Where should the extension be deployed? For help selecting a location,
-      refer to the [location selection
+      Where do you want to deploy the functions created for this extension? 
+      You usually want a location close to your database. For help selecting a 
+      location, refer to the [location selection 
       guide](https://firebase.google.com/docs/functions/locations).
     options:
       - label: Iowa (us-central1)

--- a/delete-user-data/extension.yaml
+++ b/delete-user-data/extension.yaml
@@ -66,11 +66,12 @@ resources:
 params:
   - param: LOCATION
     type: select
-    label: Deployment location
+    label: Cloud Functions location
     description: >-
-      Where should the extension be deployed? You usually want a location close
-      to your database. For help selecting a location, refer to the [location
-      selection guide](https://firebase.google.com/docs/functions/locations).
+      Where do you want to deploy the functions created for this extension? 
+      You usually want a location close to your database. For help selecting a 
+      location, refer to the [location selection 
+      guide](https://firebase.google.com/docs/functions/locations).
     options:
       - label: Iowa (us-central1)
         value: us-central1

--- a/delete-user-data/extension.yaml
+++ b/delete-user-data/extension.yaml
@@ -69,8 +69,8 @@ params:
     label: Cloud Functions location
     description: >-
       Where do you want to deploy the functions created for this extension? 
-      You usually want a location close to your database. For help selecting a 
-      location, refer to the [location selection 
+      You usually want a location close to your database or Storage bucket.
+      For help selecting a location, refer to the [location selection 
       guide](https://firebase.google.com/docs/functions/locations).
     options:
       - label: Iowa (us-central1)

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -58,11 +58,12 @@ resources:
 params:
   - param: LOCATION
     type: select
-    label: Deployment location
+    label: Cloud Functions location
     description: >-
-      Where should the extension be deployed? You usually want a location close to your database.
-      For help selecting a location, refer to the
-      [location selection guide](https://firebase.google.com/docs/functions/locations).
+      Where do you want to deploy the functions created for this extension? 
+      You usually want a location close to your database. For help selecting a 
+      location, refer to the [location selection 
+      guide](https://firebase.google.com/docs/functions/locations).
     options:
       - label: Iowa (us-central1)
         value: us-central1

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -63,7 +63,8 @@ params:
       Where do you want to deploy the functions created for this extension? 
       You usually want a location close to your database. For help selecting a 
       location, refer to the [location selection 
-      guide](https://firebase.google.com/docs/functions/locations).
+      guide](https://firebase.google.com/docs/functions/locations). 
+      Note that this extension locates your BigQuery dataset in `us-central1`.
     options:
       - label: Iowa (us-central1)
         value: us-central1

--- a/firestore-counter/extension.yaml
+++ b/firestore-counter/extension.yaml
@@ -96,11 +96,12 @@ resources:
 params:
   - param: LOCATION
     type: select
-    label: Deployment location
+    label: Cloud Functions location
     description: >-
-      Where should the extension be deployed? You usually want a location close to your database.
-      For help selecting a location, refer to the
-      [location selection guide](https://firebase.google.com/docs/functions/locations).
+      Where do you want to deploy the functions created for this extension? 
+      You usually want a location close to your database. For help selecting a 
+      location, refer to the [location selection 
+      guide](https://firebase.google.com/docs/functions/locations).
     options:
       - label: Iowa (us-central1)
         value: us-central1

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -56,11 +56,12 @@ resources:
 params:
   - param: LOCATION
     type: select
-    label: Deployment location
+    label: Cloud Functions location
     description: >-
-      Where should the extension be deployed? You usually want a location close to your database.
-      For help selecting a location, refer to the
-      [location selection guide](https://firebase.google.com/docs/functions/locations).
+      Where do you want to deploy the functions created for this extension? 
+      You usually want a location close to your database. For help selecting a 
+      location, refer to the [location selection 
+      guide](https://firebase.google.com/docs/functions/locations).
     options:
       - label: Iowa (us-central1)
         value: us-central1

--- a/firestore-shorten-urls-bitly/extension.yaml
+++ b/firestore-shorten-urls-bitly/extension.yaml
@@ -57,11 +57,12 @@ resources:
 params:
   - param: LOCATION
     type: select
-    label: Deployment location
+    label: Cloud Functions location
     description: >-
-      Where should the extension be deployed? You usually want a location close to your database.
-      For help selecting a location, refer to the
-      [location selection guide](https://firebase.google.com/docs/functions/locations).
+      Where do you want to deploy the functions created for this extension? 
+      You usually want a location close to your database. For help selecting a 
+      location, refer to the [location selection 
+      guide](https://firebase.google.com/docs/functions/locations).
     options:
       - label: Iowa (us-central1)
         value: us-central1

--- a/firestore-translate-text/extension.yaml
+++ b/firestore-translate-text/extension.yaml
@@ -59,11 +59,12 @@ resources:
 params:
   - param: LOCATION
     type: select
-    label: Deployment location
+    label: Cloud Functions location
     description: >-
-      Where should the extension be deployed? You usually want a location close to your database.
-      For help selecting a location, refer to the
-      [location selection guide](https://firebase.google.com/docs/functions/locations).
+      Where do you want to deploy the functions created for this extension? 
+      You usually want a location close to your database. For help selecting a 
+      location, refer to the [location selection 
+      guide](https://firebase.google.com/docs/functions/locations).
     options:
       - label: Iowa (us-central1)
         value: us-central1

--- a/rtdb-limit-child-nodes/extension.yaml
+++ b/rtdb-limit-child-nodes/extension.yaml
@@ -58,7 +58,7 @@ params:
     description: >-
       Where do you want to deploy the functions created for this extension? 
       You usually want a location close to your database. Realtime Database 
-      instances are located in us-central1. For help selecting a 
+      instances are located in `us-central1`. For help selecting a 
       location, refer to the [location selection 
       guide](https://firebase.google.com/docs/functions/locations).
     options:

--- a/rtdb-limit-child-nodes/extension.yaml
+++ b/rtdb-limit-child-nodes/extension.yaml
@@ -54,12 +54,13 @@ resources:
 params:
   - param: LOCATION
     type: select
-    label: Deployment location
+    label: Cloud Functions location
     description: >-
-      Where should the extension be deployed? You usually want a location close to your database.
-      Realtime Database instances are located in us-central1.
-      For help selecting a location, refer to the
-      [location selection guide](https://firebase.google.com/docs/functions/locations).
+      Where do you want to deploy the functions created for this extension? 
+      You usually want a location close to your database. Realtime Database 
+      instances are located in us-central1. For help selecting a 
+      location, refer to the [location selection 
+      guide](https://firebase.google.com/docs/functions/locations).
     options:
       - label: Iowa (us-central1)
         value: us-central1

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -65,11 +65,12 @@ resources:
 params:
   - param: LOCATION
     type: select
-    label: Deployment location
+    label: Cloud Functions location
     description: >-
-      Where should the extension be deployed? You usually want a location close to your Storage bucket.
-      For help selecting a location, refer to the
-      [location selection guide](https://firebase.google.com/docs/functions/locations).
+      Where do you want to deploy the functions created for this extension? 
+      You usually want a location close to your Storage bucket. For help selecting a 
+      location, refer to the [location selection 
+      guide](https://firebase.google.com/docs/functions/locations).
     options:
       - label: Iowa (us-central1)
         value: us-central1


### PR DESCRIPTION
Clarifying the parameter LOCATION in _all_ extension.yaml files. For firestore-bigquery-export, also clarified that the default location of the BigQuery dataset is `us-central1`.

Issue #96 