### PR TITLE
Disable HTML escaping for text and subject fields

### DIFF
--- a/firestore-send-email/functions/src/templates.ts
+++ b/firestore-send-email/functions/src/templates.ts
@@ -52,13 +52,13 @@ export default class Templates {
       const data = doc.data();
       const templates: TemplateGroup = {};
       if (data.subject) {
-        templates.subject = compile(data.subject);
+        templates.subject = compile(data.subject, { noEscape: true });
       }
       if (data.html) {
         templates.html = compile(data.html);
       }
       if (data.text) {
-        templates.text = compile(data.text);
+        templates.text = compile(data.text, { noEscape: true });
       }
       if (data.amp) {
         templates.amp = compile(data.amp);


### PR DESCRIPTION
When using the `templates` option for the send email extension, Handlebars by default will HTML escape all text. This change disables that escaping for plain text fields like `subject` and `text`, so that a symbol like `&` does not render as `&amp;` in a subject line, for example (as is current behavior).