### PR TITLE
fix(firestore-shorten-urls-bitly) migrate to v4 api #170

### DIFF
--- a/firestore-shorten-urls-bitly/functions/lib/abstract-shortener.js
+++ b/firestore-shorten-urls-bitly/functions/lib/abstract-shortener.js
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };

--- a/firestore-shorten-urls-bitly/functions/lib/index.js
+++ b/firestore-shorten-urls-bitly/functions/lib/index.js
@@ -15,23 +15,29 @@
  * limitations under the License.
  */
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const functions = require("firebase-functions");
-const bitly_1 = require("bitly");
+const axios_1 = require("axios");
 const abstract_shortener_1 = require("./abstract-shortener");
 const config_1 = require("./config");
 const logs = require("./logs");
 class FirestoreBitlyUrlShortener extends abstract_shortener_1.FirestoreUrlShortener {
     constructor(urlFieldName, shortUrlFieldName, bitlyAccessToken) {
         super(urlFieldName, shortUrlFieldName);
-        this.bitly = new bitly_1.BitlyClient(bitlyAccessToken);
+        this.instance = axios_1.default.create({
+            headers: {
+                Authorization: `Bearer ${bitlyAccessToken}`,
+            },
+            baseURL: "https://api-ssl.bitly.com/v4/",
+        });
         logs.init();
     }
     shortenUrl(snapshot) {
@@ -39,10 +45,12 @@ class FirestoreBitlyUrlShortener extends abstract_shortener_1.FirestoreUrlShorte
             const url = this.extractUrl(snapshot);
             logs.shortenUrl(url);
             try {
-                const response = yield this.bitly.shorten(url);
-                const { url: shortUrl } = response;
-                logs.shortenUrlComplete(shortUrl);
-                yield this.updateShortUrl(snapshot, shortUrl);
+                const response = yield this.instance.post("bitlinks", {
+                    long_url: url,
+                });
+                const { link } = response;
+                logs.shortenUrlComplete(link);
+                yield this.updateShortUrl(snapshot, link);
             }
             catch (err) {
                 logs.error(err);
@@ -51,6 +59,6 @@ class FirestoreBitlyUrlShortener extends abstract_shortener_1.FirestoreUrlShorte
     }
 }
 const urlShortener = new FirestoreBitlyUrlShortener(config_1.default.urlFieldName, config_1.default.shortUrlFieldName, config_1.default.bitlyAccessToken);
-exports.fsurlshortener = functions.handler.firestore.document.onWrite((change) => __awaiter(this, void 0, void 0, function* () {
+exports.fsurlshortener = functions.handler.firestore.document.onWrite((change) => __awaiter(void 0, void 0, void 0, function* () {
     return urlShortener.onDocumentWrite(change);
 }));

--- a/firestore-shorten-urls-bitly/functions/lib/logs.js
+++ b/firestore-shorten-urls-bitly/functions/lib/logs.js
@@ -16,7 +16,7 @@
  */
 Object.defineProperty(exports, "__esModule", { value: true });
 const config_1 = require("./config");
-const obfuscatedConfig = Object.assign({}, config_1.default, { bitlyAccessToken: "********" });
+const obfuscatedConfig = Object.assign(Object.assign({}, config_1.default), { bitlyAccessToken: "********" });
 exports.complete = () => {
     console.log("Completed execution of extension");
 };

--- a/firestore-shorten-urls-bitly/functions/src/index.ts
+++ b/firestore-shorten-urls-bitly/functions/src/index.ts
@@ -16,14 +16,14 @@
 
 import * as admin from "firebase-admin";
 import * as functions from "firebase-functions";
-import { BitlyClient } from "bitly";
+import axios, { AxiosInstance } from "axios";
 
 import { FirestoreUrlShortener } from "./abstract-shortener";
 import config from "./config";
 import * as logs from "./logs";
 
 class FirestoreBitlyUrlShortener extends FirestoreUrlShortener {
-  private bitly: BitlyClient;
+  private instance: AxiosInstance;
 
   constructor(
     urlFieldName: string,
@@ -31,7 +31,12 @@ class FirestoreBitlyUrlShortener extends FirestoreUrlShortener {
     bitlyAccessToken: string
   ) {
     super(urlFieldName, shortUrlFieldName);
-    this.bitly = new BitlyClient(bitlyAccessToken);
+    this.instance = axios.create({
+      headers: {
+        Authorization: `Bearer ${bitlyAccessToken}`,
+      },
+      baseURL: "https://api-ssl.bitly.com/v4/",
+    });
     logs.init();
   }
 
@@ -42,12 +47,15 @@ class FirestoreBitlyUrlShortener extends FirestoreUrlShortener {
     logs.shortenUrl(url);
 
     try {
-      const response: any = await this.bitly.shorten(url);
-      const { url: shortUrl } = response;
+      const response: any = await this.instance.post("bitlinks", {
+        long_url: url,
+      });
 
-      logs.shortenUrlComplete(shortUrl);
+      const { link } = response;
 
-      await this.updateShortUrl(snapshot, shortUrl);
+      logs.shortenUrlComplete(link);
+
+      await this.updateShortUrl(snapshot, link);
     } catch (err) {
       logs.error(err);
     }

--- a/firestore-shorten-urls-bitly/package.json
+++ b/firestore-shorten-urls-bitly/package.json
@@ -11,7 +11,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "bitly": "^6.0.8",
+    "axios": "^0.19.1",
     "firebase-admin": "^8.0.0",
     "firebase-functions": "^2.3.1"
   },


### PR DESCRIPTION
See #170 for more details. This directly connects with the v4 API via a POST request.