### PR TITLE
docs(firestore-counter): change "Counter SDK" to "Client Sample"

### DIFF
--- a/firestore-counter/POSTINSTALL.md
+++ b/firestore-counter/POSTINSTALL.md
@@ -35,11 +35,11 @@ gcloud --project=${param:PROJECT_ID} scheduler jobs create pubsub ${param:EXT_IN
 ```
 
 
-#### Specify a document path and increment value in your app
+#### Specify a document path and increment value in your web app
 
-1.  Download and copy the [Counter SDK](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/dist/sharded-counter.js) into your application project.
+1.  Download and copy the [compiled client sample](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/dist/sharded-counter.js) into your application project.
 
-1.  Use the Counter SDK library in your code to increment counters. The code snippet below shows an example of how to use the library. For more comprehensive API documentation, refer to the [source code](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/src/index.ts).
+1.  Use the client sample in your code to increment counters. The code snippet below shows an example of how to use it. To see the full reference implementation, refer to the sample's TypeScript [source code](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/src/index.ts).
 
   ```html
   <html>
@@ -81,7 +81,7 @@ After you complete the post-installation configuration above, the process runs a
 
 1. Your extension creates subcollections in all the documents that your app uses as counters.
 
-1. The client SDK writes to these subcollections to distribute the write load.
+1. The client sample writes to these subcollections to distribute the write load.
 
 1. The controllerCore function sums the subcollections' values into the single `visits` field (or whichever field you configured in your master document).
 

--- a/firestore-counter/PREINSTALL.md
+++ b/firestore-counter/PREINSTALL.md
@@ -8,7 +8,7 @@ Here are some features of this extension:
 - Supports an arbitrary number of counters in your app.
 - Works offline and provides latency compensation for the main counter.
 
-Note that this extension requires client-side logic to work. A TypeScript client sample implementationt [is provided in Github](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/src/index.ts) and is compiled to minified JavaScript [here](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/dist/sharded-counter.js). You can use this extension on other platforms if you'd like to develop your own client code based on the provided client sample.
+Note that this extension requires client-side logic to work. We provide a [TypeScript client sample implementation](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/src/index.ts) and its [compiled minified JavaScript](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/dist/sharded-counter.js). You can use this extension on other platforms if you'd like to develop your own client code based on the provided client sample.
 
 
 #### Additional setup

--- a/firestore-counter/PREINSTALL.md
+++ b/firestore-counter/PREINSTALL.md
@@ -8,7 +8,7 @@ Here are some features of this extension:
 - Supports an arbitrary number of counters in your app.
 - Works offline and provides latency compensation for the main counter.
 
-Note that this extension is currently fully resourced for use with JavaScript apps (we provide the required [JS SDK](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/src/index.ts)). You can, however, use this extension on other platforms if you'd like to develop your own API based on the provided JS SDK.
+Note that this extension requires client-side logic to work. A TypeScript client sample implementationt [is provided in Github](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/src/index.ts) and is compiled to minified JavaScript [here](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/dist/sharded-counter.js). You can use this extension on other platforms if you'd like to develop your own client code based on the provided client sample.
 
 
 #### Additional setup
@@ -19,7 +19,7 @@ After installing this extension, you'll need to:
 
 - Update your [database security rules](https://firebase.google.com/docs/rules).
 - Set up a [Cloud Scheduler job](https://cloud.google.com/scheduler/docs/quickstart) to regularly call the controllerCore function, which is created by this extension. It works by either aggregating shards itself or scheduling and monitoring workers to aggregate shards.
-- Install the provided [Counter SDK](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/src/index.ts) in your app. You can then use this library in your code to specify your document path and increment values.
+- Use the provided [client sample](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/src/index.ts) or your own client code to specify your document path and increment values.
 
 Detailed information for these post-installation tasks are provided after you install this extension.
 


### PR DESCRIPTION
Treat the [TypeScript client](https://github.com/firebase/extensions/tree/master/firestore-counter/clients/web/src/index.ts) as a canonical sample implementation to be used by anyone looking to implement a client for `firestore-counter`.