### PR TITLE
fix(storage-resize-images): ensure content type is always available

### DIFF
--- a/storage-resize-images/POSTINSTALL.md
+++ b/storage-resize-images/POSTINSTALL.md
@@ -33,7 +33,7 @@ Be aware of the following when using this extension:
 
 - Each original image must have a valid [image MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#Image_types) specified in its [`Content-Type` metadata](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Type) (for example, `image/png`).
 
-- If you configured the `Cache-Control header for resized images` param, the specified value will overwrite the value copied from the original image. Learn more about image metadata in the [Cloud Storage documentation](https://firebase.google.com/docs/storage/).
+- If you configured the `Cache-Control header for resized images` parameter, your specified value will overwrite the value copied from the original image. Learn more about image metadata in the [Cloud Storage documentation](https://firebase.google.com/docs/storage/).
 
 ### Monitoring
 

--- a/storage-resize-images/POSTINSTALL.md
+++ b/storage-resize-images/POSTINSTALL.md
@@ -4,7 +4,7 @@ You can test out this extension right away:
 
 1.  Go to your [Storage dashboard](https://console.firebase.google.com/project/${param:PROJECT_ID}/storage).
 
-1.  Upload an image file to the bucket: `${param:IMG_BUCKET}`. The file must have a valid [image MIME Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#Image_types), for example `image/png`.
+1.  Upload an image file to the bucket: `${param:IMG_BUCKET}`
 
 1.  In a few seconds, the resized image(s) appear in the same bucket.
 
@@ -29,7 +29,11 @@ The extension also copies the following metadata, if present, from the original 
 - [`Content-Type`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Type)
 - [user-provided metadata](https://cloud.google.com/storage/docs/metadata#custom-metadata) (except Firebase storage download tokens)
 
-Note that if you configured the `Cache-Control header for resized images` param, the specified value will overwrite the value copied from the original image. Learn more about image metadata in the [Cloud Storage documentation](https://firebase.google.com/docs/storage/).
+Be aware of the following when using this extension:
+
+- Each original image must have a valid [image MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#Image_types) specified in its [`Content-Type` metadata](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Type) (for example, `image/png`).
+
+- If you configured the `Cache-Control header for resized images` param, the specified value will overwrite the value copied from the original image. Learn more about image metadata in the [Cloud Storage documentation](https://firebase.google.com/docs/storage/).
 
 ### Monitoring
 

--- a/storage-resize-images/POSTINSTALL.md
+++ b/storage-resize-images/POSTINSTALL.md
@@ -4,7 +4,7 @@ You can test out this extension right away:
 
 1.  Go to your [Storage dashboard](https://console.firebase.google.com/project/${param:PROJECT_ID}/storage).
 
-1.  Upload an image file to the bucket: `${param:IMG_BUCKET}`
+1.  Upload an image file to the bucket: `${param:IMG_BUCKET}`. The file must have a valid [image MIME Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#Image_types), for example `image/png`.
 
 1.  In a few seconds, the resized image(s) appear in the same bucket.
 

--- a/storage-resize-images/functions/lib/index.js
+++ b/storage-resize-images/functions/lib/index.js
@@ -44,6 +44,10 @@ logs.init();
 exports.generateResizedImage = functions.storage.object().onFinalize((object) => __awaiter(this, void 0, void 0, function* () {
     logs.start();
     const { contentType } = object; // This is the image MIME type
+    if (!contentType) {
+        logs.noContentType();
+        return;
+    }
     const isImage = validators.isImage(contentType);
     if (!isImage) {
         logs.contentTypeInvalid(contentType);

--- a/storage-resize-images/functions/lib/logs.js
+++ b/storage-resize-images/functions/lib/logs.js
@@ -19,6 +19,9 @@ const config_1 = require("./config");
 exports.complete = () => {
     console.log("Completed execution of extension");
 };
+exports.noContentType = () => {
+    console.log(`File has no Content-Type, no processing is required`);
+};
 exports.contentTypeInvalid = (contentType) => {
     console.log(`File of type '${contentType}' is not an image, no processing is required`);
 };

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -48,6 +48,11 @@ export const generateResizedImage = functions.storage.object().onFinalize(
     logs.start();
     const { contentType } = object; // This is the image MIME type
 
+    if (!contentType) {
+      logs.noContentType();
+      return;
+    }
+
     const isImage = validators.isImage(contentType);
     if (!isImage) {
       logs.contentTypeInvalid(contentType);

--- a/storage-resize-images/functions/src/logs.ts
+++ b/storage-resize-images/functions/src/logs.ts
@@ -20,6 +20,10 @@ export const complete = () => {
   console.log("Completed execution of extension");
 };
 
+export const noContentType = () => {
+  console.log(`File has no Content-Type, no processing is required`);
+};
+
 export const contentTypeInvalid = (contentType: string) => {
   console.log(
     `File of type '${contentType}' is not an image, no processing is required`


### PR DESCRIPTION
- Fix: Files are not always uploaded with a default content type (e.g. gsutils).
- Docs: File validation is unknown to the user. Added a note which indicates a file must have a content type, and one which starts with the `image/` prefix.

Fixes https://github.com/firebase/extensions/issues/175