### PR TITLE
feat(firestore-send-email): update "Default FROM address" param to allow name to be added

### DIFF
--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -109,7 +109,7 @@ params:
     required: true
     description: >-
       The email address to use as the sender's address (if it's not specified in the added email document).
-    example: foobar <foobar@example.com>  
+    example: Friendly Firebaser <foobar@example.com>  
 
   - param: DEFAULT_REPLY_TO
     type: string

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -105,7 +105,7 @@ params:
     type: string
     label: Default FROM address
     validationRegex: ^(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$|^.*<(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})>$
-    validationErrorMessage: Must be a valid email address
+    validationErrorMessage: Must be a valid email address or valid name plus email address
     required: true
     description: >-
       The email address to use as the sender's address (if it's not specified in the added email document). 

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -104,7 +104,7 @@ params:
   - param: DEFAULT_FROM
     type: string
     label: Default FROM address
-    validationRegex: ^\S+@\S+\.\S+$
+    validationRegex: ^(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$|^.*<(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})>$
     validationErrorMessage: Must be a valid email address
     required: true
     description: >-

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -109,6 +109,7 @@ params:
     required: true
     description: >-
       The email address to use as the sender's address (if it's not specified in the added email document).
+    example: foobar <foobar@example.com>  
 
   - param: DEFAULT_REPLY_TO
     type: string

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -108,8 +108,9 @@ params:
     validationErrorMessage: Must be a valid email address
     required: true
     description: >-
-      The email address to use as the sender's address (if it's not specified in the added email document).
-    example: Friendly Firebaser <foobar@example.com>  
+      The email address to use as the sender's address (if it's not specified in the added email document). 
+      You can optionally include a name with the email address (Friendly Firebaser <foobar@example.com>).
+    example: foobar@example.com  
 
   - param: DEFAULT_REPLY_TO
     type: string


### PR DESCRIPTION
This PR resolves this feature request #167.