### PR TITLE
fix(bitly-shortener): Fix 406 HTTP error code from Bit.ly API due to "Content-Type" not being set. 

### DIFF
--- a/firestore-shorten-urls-bitly/functions/lib/index.js
+++ b/firestore-shorten-urls-bitly/functions/lib/index.js
@@ -34,6 +34,7 @@ class FirestoreBitlyUrlShortener extends abstract_shortener_1.FirestoreUrlShorte
         this.instance = axios_1.default.create({
             headers: {
                 Authorization: `Bearer ${bitlyAccessToken}`,
+                "Content-Type": "application/json",
             },
             baseURL: "https://api-ssl.bitly.com/v4/",
         });
@@ -47,7 +48,7 @@ class FirestoreBitlyUrlShortener extends abstract_shortener_1.FirestoreUrlShorte
                 const response = yield this.instance.post("bitlinks", {
                     long_url: url,
                 });
-                const { link } = response;
+                const { link } = response.data;
                 logs.shortenUrlComplete(link);
                 yield this.updateShortUrl(snapshot, link);
             }

--- a/firestore-shorten-urls-bitly/functions/src/index.ts
+++ b/firestore-shorten-urls-bitly/functions/src/index.ts
@@ -34,12 +34,11 @@ class FirestoreBitlyUrlShortener extends FirestoreUrlShortener {
     this.instance = axios.create({
       headers: {
         Authorization: `Bearer ${bitlyAccessToken}`,
+        "Content-Type": "application/json",
       },
       baseURL: "https://api-ssl.bitly.com/v4/",
     });
     
-    this.instance.defaults.headers["Content-Type"] = "application/json";
-
     logs.init();
   }
 

--- a/firestore-shorten-urls-bitly/functions/src/index.ts
+++ b/firestore-shorten-urls-bitly/functions/src/index.ts
@@ -37,6 +37,9 @@ class FirestoreBitlyUrlShortener extends FirestoreUrlShortener {
       },
       baseURL: "https://api-ssl.bitly.com/v4/",
     });
+    
+    this.instance.defaults.headers["Content-Type"] = "application/json";
+
     logs.init();
   }
 
@@ -51,7 +54,7 @@ class FirestoreBitlyUrlShortener extends FirestoreUrlShortener {
         long_url: url,
       });
 
-      const { link } = response;
+      const { link } = response.data;
 
       logs.shortenUrlComplete(link);
 

--- a/firestore-shorten-urls-bitly/functions/src/index.ts
+++ b/firestore-shorten-urls-bitly/functions/src/index.ts
@@ -38,7 +38,7 @@ class FirestoreBitlyUrlShortener extends FirestoreUrlShortener {
       },
       baseURL: "https://api-ssl.bitly.com/v4/",
     });
-    
+
     logs.init();
   }
 


### PR DESCRIPTION
Bitly requests now appear to require a `Content-Type` to work. If none set, the request fails with a 406 error.

This PR resolves this issue.