### PR TITLE
firestore-send-email param description edit

### DIFF
--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -110,9 +110,8 @@ params:
     validationErrorMessage: Must be a valid email address or valid name plus email address
     required: true
     description: >-
-      The email address to use as the sender's address (if it's not specified in the added email document). 
-      You can optionally include a name with the email address (Friendly Firebaser <foobar@example.com>).
-    example: foobar@example.com  
+      The email address to use as the sender's address (if it's not specified in the added email document).
+    example: foobar@example.com
 
   - param: DEFAULT_REPLY_TO
     type: string


### PR DESCRIPTION
Remove Friendly Firebaser <foobar@example.com> example in param description. The carats (`<`, `>`) cause parsing issues.