### PR TITLE
refactor(firestore-translate-text): clarify log message

### DIFF
--- a/firestore-translate-text/functions/lib/logs/messages.js
+++ b/firestore-translate-text/functions/lib/logs/messages.js
@@ -11,7 +11,7 @@ exports.messages = {
     documentUpdatedUnchangedInput: () => "Document was updated, input string has not changed, no processing is required",
     error: (err) => ["Failed execution of extension", err],
     fieldNamesNotDifferent: () => "The `Input` and `Output` field names must be different for this extension to function correctly",
-    init: (config = {}) => ["Initializing extension with configuration", config],
+    init: (config = {}) => ["Initializing extension with the parameter values", config],
     inputFieldNameIsOutputPath: () => "The `Input` field name must not be the same as an `Output` path for this extension to function correctly",
     start: (config = {}) => [
         "Started execution of extension with configuration",

--- a/firestore-translate-text/functions/lib/logs/messages.js
+++ b/firestore-translate-text/functions/lib/logs/messages.js
@@ -11,7 +11,10 @@ exports.messages = {
     documentUpdatedUnchangedInput: () => "Document was updated, input string has not changed, no processing is required",
     error: (err) => ["Failed execution of extension", err],
     fieldNamesNotDifferent: () => "The `Input` and `Output` field names must be different for this extension to function correctly",
-    init: (config = {}) => ["Initializing extension with the parameter values", config],
+    init: (config = {}) => [
+        "Initializing extension with the parameter values",
+        config
+    ],
     inputFieldNameIsOutputPath: () => "The `Input` field name must not be the same as an `Output` path for this extension to function correctly",
     start: (config = {}) => [
         "Started execution of extension with configuration",

--- a/firestore-translate-text/functions/src/logs/messages.ts
+++ b/firestore-translate-text/functions/src/logs/messages.ts
@@ -15,7 +15,10 @@ export const messages = {
   error: (err: Error) => ["Failed execution of extension", err],
   fieldNamesNotDifferent: () =>
     "The `Input` and `Output` field names must be different for this extension to function correctly",
-  init: (config = {}) => ["Initializing extension with the parameter values", config],
+  init: (config = {}) => [
+    "Initializing extension with the parameter values",
+    config
+  ],
   inputFieldNameIsOutputPath: () =>
     "The `Input` field name must not be the same as an `Output` path for this extension to function correctly",
   start: (config = {}) => [

--- a/firestore-translate-text/functions/src/logs/messages.ts
+++ b/firestore-translate-text/functions/src/logs/messages.ts
@@ -17,7 +17,7 @@ export const messages = {
     "The `Input` and `Output` field names must be different for this extension to function correctly",
   init: (config = {}) => [
     "Initializing extension with the parameter values",
-    config
+    config,
   ],
   inputFieldNameIsOutputPath: () =>
     "The `Input` field name must not be the same as an `Output` path for this extension to function correctly",

--- a/firestore-translate-text/functions/src/logs/messages.ts
+++ b/firestore-translate-text/functions/src/logs/messages.ts
@@ -15,7 +15,7 @@ export const messages = {
   error: (err: Error) => ["Failed execution of extension", err],
   fieldNamesNotDifferent: () =>
     "The `Input` and `Output` field names must be different for this extension to function correctly",
-  init: (config = {}) => ["Initializing extension with configuration", config],
+  init: (config = {}) => ["Initializing extension with the parameter values", config],
   inputFieldNameIsOutputPath: () =>
     "The `Input` field name must not be the same as an `Output` path for this extension to function correctly",
   start: (config = {}) => [


### PR DESCRIPTION
From chatting with Rachel, we've realized that the words 'configuration' and 'config' are overloaded in the context of extensions. Since these are actually parameter values, I think this will be slightly clearer.