### PR TITLE
docs(firestore-send-email): Backtick around angled brackets within extension.yaml

### DIFF
--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -110,7 +110,8 @@ params:
     validationErrorMessage: Must be a valid email address or valid name plus email address
     required: true
     description: >-
-      The email address to use as the sender's address (if it's not specified in the added email document).
+      The email address to use as the sender's address (if it's not specified in the added email document). 
+      You can optionally include a name with the email address (`Friendly Firebaser <foobar@example.com>`).
     example: foobar@example.com
 
   - param: DEFAULT_REPLY_TO


### PR DESCRIPTION
As discussed via email, I've placed backticks around the email address which negates the console from removing the angled brackets in the documentation.
<img width="662" alt="Screenshot 2020-03-20 at 10 20 34" src="https://user-images.githubusercontent.com/16018629/77154875-7347a280-6a94-11ea-9bb1-e3f74635739b.png">
