### PR TITLE
fix(firestore-bigquery-export): add package & update exports

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
@@ -5,7 +5,7 @@
     "url": "github.com/firebase/extensions.git",
     "directory": "firestore-bigquery-export/firestore-bigquery-change-tracker"
   },
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Core change-tracker library for Cloud Firestore Collection BigQuery Exports",
   "main": "./lib/index.js",
   "scripts": {

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/index.ts
@@ -17,6 +17,7 @@
 export {
   FirestoreBigQueryEventHistoryTracker,
   RawChangelogSchema,
+  RawChangelogViewSchema,
 } from "./bigquery";
 export {
   ChangeType,

--- a/firestore-bigquery-export/scripts/gen-schema-view/.gitignore
+++ b/firestore-bigquery-export/scripts/gen-schema-view/.gitignore
@@ -1,1 +1,2 @@
 lib
+test-schema.json

--- a/firestore-bigquery-export/scripts/gen-schema-view/package.json
+++ b/firestore-bigquery-export/scripts/gen-schema-view/package.json
@@ -31,6 +31,7 @@
   "author": "Jan Wyszynski <wyszynski@google.com>",
   "license": "Apache-2.0",
   "dependencies": {
+    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.2",
     "@google-cloud/bigquery": "^2.1.0",
     "commander": "5.0.0",
     "firebase-admin": "^7.1.1",

--- a/firestore-bigquery-export/scripts/gen-schema-view/package.json
+++ b/firestore-bigquery-export/scripts/gen-schema-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebaseextensions/fs-bq-schema-views",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Generate strongly-typed BigQuery Views based on raw JSON",
   "main": "./lib/index.js",
   "repository": {

--- a/firestore-bigquery-export/scripts/gen-schema-view/package.json
+++ b/firestore-bigquery-export/scripts/gen-schema-view/package.json
@@ -31,7 +31,7 @@
   "author": "Jan Wyszynski <wyszynski@google.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.2",
+    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.4",
     "@google-cloud/bigquery": "^2.1.0",
     "commander": "5.0.0",
     "firebase-admin": "^7.1.1",

--- a/firestore-bigquery-export/scripts/gen-schema-view/package.json
+++ b/firestore-bigquery-export/scripts/gen-schema-view/package.json
@@ -31,7 +31,7 @@
   "author": "Jan Wyszynski <wyszynski@google.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.4",
+    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.3",
     "@google-cloud/bigquery": "^2.1.0",
     "commander": "5.0.0",
     "firebase-admin": "^7.1.1",


### PR DESCRIPTION
fixes #250 
- The latest commit for the `gen-schema-view` uses the `firestore-bigquery-change-tracker` package  script which is not specified in the `package.json`.

fixes #196
- The `RawChangelogViewSchema ` was not exported out of the `firestore-bigquery-change-tracker` package. This caused the `fields` property to be `undefined` at this [point](https://github.com/firebase/extensions/blob/d4c56a510094b19c0809d24f335b6c39ecc104de/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts#L193) in the code.

Here's a screenshot of the `gen-schema-view` script working again:
![Screenshot 2020-04-09 at 12 55 13](https://user-images.githubusercontent.com/16018629/78893412-38b5a200-7a63-11ea-8a95-fdae11bcfb72.png)

Please note that the `gen-schema-view` package will still not work until this PR has been merged and the `firestore-bigquery-change-tracker` & `gen-schema-view` packages have been published again.


