### PR TITLE
fix(firestore-bigquery-export): fix bug where modules were not sharing the same Firestore DocumentReference (issue #265)

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
@@ -5,7 +5,7 @@
     "url": "github.com/firebase/extensions.git",
     "directory": "firestore-bigquery-export/firestore-bigquery-change-tracker"
   },
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Core change-tracker library for Cloud Firestore Collection BigQuery Exports",
   "main": "./lib/index.js",
   "scripts": {

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -74,8 +74,10 @@ export class FirestoreBigQueryEventHistoryTracker
     if (typeof eventData === "undefined") {
       return undefined;
     }
-    const data = traverse(eventData).map((property) => { 
-      if (property.constructor.name === firebase.firestore.DocumentReference.name) {
+    const data = traverse(eventData).map((property) => {
+      if (
+        property.constructor.name === firebase.firestore.DocumentReference.name
+      ) {
         return property.path;
       }
 

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -74,9 +74,8 @@ export class FirestoreBigQueryEventHistoryTracker
     if (typeof eventData === "undefined") {
       return undefined;
     }
-
-    const data = traverse(eventData).map((property) => {
-      if (property instanceof firebase.firestore.DocumentReference) {
+    const data = traverse(eventData).map((property) => { 
+      if (property.constructor.name === firebase.firestore.DocumentReference.name) {
         return property.path;
       }
 

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -76,6 +76,7 @@ export class FirestoreBigQueryEventHistoryTracker
     }
     const data = traverse(eventData).map((property) => {
       if (
+        property.constructor &&
         property.constructor.name === firebase.firestore.DocumentReference.name
       ) {
         return property.path;

--- a/firestore-bigquery-export/package.json
+++ b/firestore-bigquery-export/package.json
@@ -13,7 +13,7 @@
   "author": "Jan Wyszynski <wyszynski@google.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.3",
+    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.5",
     "@google-cloud/bigquery": "^2.1.0",
     "@types/chai": "^4.1.6",
     "chai": "^4.2.0",

--- a/firestore-bigquery-export/scripts/gen-schema-view/package.json
+++ b/firestore-bigquery-export/scripts/gen-schema-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebaseextensions/fs-bq-schema-views",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Generate strongly-typed BigQuery Views based on raw JSON",
   "main": "./lib/index.js",
   "repository": {
@@ -31,7 +31,7 @@
   "author": "Jan Wyszynski <wyszynski@google.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.3",
+    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.5",
     "@google-cloud/bigquery": "^2.1.0",
     "commander": "5.0.0",
     "firebase-admin": "^7.1.1",


### PR DESCRIPTION
Fixes #265

The previous fix stopped functioning after dependancy updates - there are two versions of the `@google/firestore` Node.js module being used due to the BigQuery scripts using an older version of `firebase-admin` vs the version `firebase-functions` uses -  this meant that `instanceof` checks would evaluate to false as there were two instances (or versions) of the class in use

## Tests

Adding document with reference to Firestore:
<img width="604" alt="Screenshot 2020-04-20 at 10 39 54" src="https://user-images.githubusercontent.com/16018629/79738741-13435680-82f5-11ea-9ae0-258a14146f70.png">

BigQuery row in table: 
<img width="708" alt="Screenshot 2020-04-20 at 10 40 17" src="https://user-images.githubusercontent.com/16018629/79738837-3968f680-82f5-11ea-8422-f5eddcef718d.png">
