### PR TITLE
fix(storage-resize-image): fix Sharp version to v0.23 to preserve compatibility with Node 8

### DIFF
--- a/storage-resize-images/functions/lib/index.js
+++ b/storage-resize-images/functions/lib/index.js
@@ -38,7 +38,10 @@ const util_1 = require("./util");
 // Initialize the Firebase Admin SDK
 admin.initializeApp();
 logs.init();
-
+/**
+ * When an image is uploaded in the Storage bucket, we generate a resized image automatically using
+ * the Sharp image converting library.
+ */
 exports.generateResizedImage = functions.storage.object().onFinalize((object) => __awaiter(void 0, void 0, void 0, function* () {
     logs.start();
     const { contentType } = object; // This is the image MIME type

--- a/storage-resize-images/package.json
+++ b/storage-resize-images/package.json
@@ -16,7 +16,7 @@
     "firebase-functions": "^3.3.0",
     "mkdirp": "^0.5.1",
     "mkdirp-promise": "^4.0.0",
-    "sharp": "^0.24.1"
+    "sharp": "0.23.4"
   },
   "devDependencies": {
     "rimraf": "^2.6.3",


### PR DESCRIPTION
This is the last `sharp` version to [support](https://sharp.pixelplumbing.com/changelog#v0240---16supthsup-january-2020) Node.js 8. It appears the Cloud Functions switch to using Yarn package manager throws an error when installing `sharp` `v0.24` or higher as it requires Node.js >=10

Here are the logs of an image being resized:
<img width="616" alt="Screenshot 2020-04-22 at 09 10 22" src="https://user-images.githubusercontent.com/16018629/79957227-28e18900-8479-11ea-832d-b9ced03cb2e2.png">

Here are the images resized in the storage bucket:
<img width="969" alt="Screenshot 2020-04-22 at 09 09 25" src="https://user-images.githubusercontent.com/16018629/79957281-3d258600-8479-11ea-8e9e-aee4dfcb0b6c.png">
