### PR TITLE
fix(firestore-bigquery-export): fix "TypeError: Cannot read property 'constructor' of null" (Issue #284)

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
@@ -5,7 +5,7 @@
     "url": "github.com/firebase/extensions.git",
     "directory": "firestore-bigquery-export/firestore-bigquery-change-tracker"
   },
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Core change-tracker library for Cloud Firestore Collection BigQuery Exports",
   "main": "./lib/index.js",
   "scripts": {

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -76,6 +76,7 @@ export class FirestoreBigQueryEventHistoryTracker
     }
     const data = traverse(eventData).map((property) => {
       if (
+        property &&
         property.constructor &&
         property.constructor.name === firebase.firestore.DocumentReference.name
       ) {

--- a/firestore-bigquery-export/package.json
+++ b/firestore-bigquery-export/package.json
@@ -13,7 +13,7 @@
   "author": "Jan Wyszynski <wyszynski@google.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.5",
+    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.6",
     "@google-cloud/bigquery": "^2.1.0",
     "@types/chai": "^4.1.6",
     "chai": "^4.2.0",


### PR DESCRIPTION
fixes #284 

Test every type (excluding `Blob` type) and nesting within object & array:
![Screenshot 2020-04-27 at 16 53 20](https://user-images.githubusercontent.com/16018629/80392989-c688ee00-88a7-11ea-9c30-80d9658e6881.png)

Firebase Console logs:
<img width="959" alt="Screenshot 2020-04-27 at 16 55 47" src="https://user-images.githubusercontent.com/16018629/80393139-fd5f0400-88a7-11ea-9f37-aa0962000379.png">

Created Record in BigQuery table:
<img width="1324" alt="Screenshot 2020-04-27 at 16 54 18" src="https://user-images.githubusercontent.com/16018629/80392998-c8eb4800-88a7-11ea-958b-59a09d97bb5d.png">

