### PR TITLE
chore: remove husky commit hook

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,5 +1,0 @@
-{
-  "hooks": {
-    "commit-msg": "npm run pre-commit-lint"
-  }
-}

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "test-watch": "jest --watch",
     "test-coverage": "jest --coverage",
     "postinstall": "lerna bootstrap --no-ci && npm run clean && npm run build",
-    "generate-readmes": "lerna run --parallel --ignore delete-user-data generate-readme",
-    "pre-commit-lint": "commitlint -E HUSKY_GIT_PARAMS"
+    "generate-readmes": "lerna run --parallel --ignore delete-user-data generate-readme"
   },
   "repository": "",
   "author": "Firebase (https://firebase.google.com/)",
@@ -22,10 +21,7 @@
     "url": ""
   },
   "devDependencies": {
-    "@commitlint/cli": "^8.2.0",
-    "@commitlint/config-conventional": "^8.2.0",
     "@types/jest": "^24.0.18",
-    "husky": "^3.0.9",
     "jest": "^24.9.0",
     "lerna": "^3.4.3",
     "prettier": "1.15.3",


### PR DESCRIPTION
Removes the pre-commit hook that lints commit messages - no longer required as we're squashing commits.