### PR TITLE
fix(firestore-bigquery-export): filter out blobs data from being mirrored into BigQuery

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
@@ -23,6 +23,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@google-cloud/bigquery": "^4.7.0",
+    "@types/traverse": "^0.6.32",
     "firebase-admin": "^7.1.1",
     "firebase-functions": "^2.2.1",
     "generate-schema": "^2.6.0",

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
@@ -5,7 +5,7 @@
     "url": "github.com/firebase/extensions.git",
     "directory": "firestore-bigquery-export/firestore-bigquery-change-tracker"
   },
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Core change-tracker library for Cloud Firestore Collection BigQuery Exports",
   "main": "./lib/index.js",
   "scripts": {

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -74,16 +74,22 @@ export class FirestoreBigQueryEventHistoryTracker
     if (typeof eventData === "undefined") {
       return undefined;
     }
-    const data = traverse(eventData).map((property) => {
-      if (
-        property &&
-        property.constructor &&
-        property.constructor.name === firebase.firestore.DocumentReference.name
-      ) {
-        return property.path;
-      }
 
-      return property;
+    const data = traverse<traverse.Traverse<any>>(eventData).map(function(
+      property
+    ) {
+      if (property && property.constructor) {
+        if (property.constructor.name === "Buffer") {
+          this.remove();
+        }
+
+        if (
+          property.constructor.name ===
+          firebase.firestore.DocumentReference.name
+        ) {
+          this.update(property.path);
+        }
+      }
     });
 
     return data;


### PR DESCRIPTION
This PR filters out `Blob` (`Buffer`) data types from being stored as strings in Big Query:
Adding data:

![Screenshot 2020-04-29 at 14 49 05](https://user-images.githubusercontent.com/16018629/80603938-f57a9d80-8a28-11ea-97fb-814f6aec407f.png)
Firebase Console logs:

<img width="962" alt="Screenshot 2020-04-29 at 14 48 42" src="https://user-images.githubusercontent.com/16018629/80603940-f6133400-8a28-11ea-90cb-8924b24ec67c.png">
Row in BigQuery table:

<img width="1332" alt="Screenshot 2020-04-29 at 14 50 57" src="https://user-images.githubusercontent.com/16018629/80603931-f3184380-8a28-11ea-9589-d3b39e9652bc.png">

