### PR TITLE
fix(storage-resize-images): clear cache so that image names can be reused (Issue #286)

### DIFF
--- a/storage-resize-images/functions/lib/index.js
+++ b/storage-resize-images/functions/lib/index.js
@@ -35,6 +35,7 @@ const config_1 = require("./config");
 const logs = require("./logs");
 const validators = require("./validators");
 const util_1 = require("./util");
+sharp.cache(false);
 // Initialize the Firebase Admin SDK
 admin.initializeApp();
 logs.init();

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -34,6 +34,8 @@ interface ResizedImageResult {
   success: boolean;
 }
 
+sharp.cache(false);
+
 // Initialize the Firebase Admin SDK
 admin.initializeApp();
 


### PR DESCRIPTION
fixes #286

Sharp persists images. If the same name & extension are used, it will use the image persisted in cache. 

This PR clears cache to ensure that the latest image retrieved from the bucket is resized.

correct images being resized to 300x300 pixels.
<img width="292" alt="Screenshot 2020-05-01 at 11 59 06" src="https://user-images.githubusercontent.com/16018629/80801274-b886e600-8ba3-11ea-90f5-0192db6b19f6.png">
<img width="281" alt="Screenshot 2020-05-01 at 11 59 29" src="https://user-images.githubusercontent.com/16018629/80801280-bae94000-8ba3-11ea-990f-0ec6a12911f3.png">
<img width="298" alt="Screenshot 2020-05-01 at 12 00 04" src="https://user-images.githubusercontent.com/16018629/80801282-bb81d680-8ba3-11ea-9259-ac9016514dc0.png">
