### PR TITLE
5/7/2020 Release: bump patch version rather than minor version

### DIFF
--- a/firestore-bigquery-export/CHANGELOG.md
+++ b/firestore-bigquery-export/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Version 0.2.0
+## Version 0.1.5
 
 fixed - TypeError: Cannot read property 'constructor' of null. (Issue #284)
 fixed - Filtered out blob (buffer) data types from being stored as strings in BigQuery.

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-bigquery-export
-version: 0.2.0
+version: 0.1.5
 specVersion: v1beta
 
 displayName: Export Collections to BigQuery

--- a/storage-resize-images/CHANGELOG.md
+++ b/storage-resize-images/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Version 0.2.0
+## Version 0.1.7
 
 fixed - Resized images now render in the Firebase console. (Issue #140)
 fixed - The Sharp cache is now cleared so that the latest image with a given

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: storage-resize-images
-version: 0.2.0
+version: 0.1.7
 specVersion: v1beta
 
 displayName: Resize Images


### PR DESCRIPTION
For storage-resize-images and firestore-bigquery-export.