### PR TITLE
fix(firestore-bigquery-export): clean column names for generating schema views

### DIFF
--- a/firestore-bigquery-export/scripts/gen-schema-view/package.json
+++ b/firestore-bigquery-export/scripts/gen-schema-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebaseextensions/fs-bq-schema-views",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Generate strongly-typed BigQuery Views based on raw JSON",
   "main": "./lib/index.js",
   "repository": {

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
@@ -576,7 +576,10 @@ export function subSelectQuery(query: string, filter?: string[]): string {
 }
 
 function qualifyFieldName(prefix: string[], name: string): string {
-  return prefix.concat(name).join("_");
+  const notAlphaDigitUnderscore = /([^a-zA-Z0-9_])/;
+  const cleanName = name.replace(notAlphaDigitUnderscore, "_");
+
+  return prefix.concat(cleanName).join("_");
 }
 
 export function latest(tableName: string): string {

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
@@ -576,8 +576,8 @@ export function subSelectQuery(query: string, filter?: string[]): string {
 }
 
 function qualifyFieldName(prefix: string[], name: string): string {
-  const notAlphaDigitUnderscore = /([^a-zA-Z0-9_])/;
-  const cleanName = name.replace(notAlphaDigitUnderscore, "_");
+  const notAlphanumericUnderscore = /([^a-zA-Z0-9_])/g;
+  const cleanName = name.replace(notAlphanumericUnderscore, "_");
 
   return prefix.concat(cleanName).join("_");
 }


### PR DESCRIPTION
fixes #247

Screenshot of successfully generating schema view without error
![Screenshot 2020-05-06 at 15 39 42](https://user-images.githubusercontent.com/16018629/81192868-a3022980-8fb2-11ea-98eb-6001b6ec6e0b.png)

Screenshot of view in Big Query updated with column name successfully changed to `colon_colon`.
<img width="184" alt="Screenshot 2020-05-06 at 16 03 32" src="https://user-images.githubusercontent.com/16018629/81193423-481d0200-8fb3-11ea-91ae-385580866bab.png">

