### PR TITLE
fix(storage-resize-images): fix bug where resized image did not keep orientation of original image (Issue #290)

### DIFF
--- a/storage-resize-images/functions/lib/index.js
+++ b/storage-resize-images/functions/lib/index.js
@@ -138,6 +138,7 @@ function resize(originalFile, resizedFile, size) {
         throw new Error("height and width are not delimited by a ',' or a 'x'");
     }
     return sharp(originalFile)
+        .rotate()
         .resize(parseInt(width, 10), parseInt(height, 10), { fit: "inside" })
         .toFile(resizedFile);
 }

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -153,6 +153,7 @@ function resize(originalFile, resizedFile, size) {
   }
 
   return sharp(originalFile)
+    .rotate()
     .resize(parseInt(width, 10), parseInt(height, 10), { fit: "inside" })
     .toFile(resizedFile);
 }


### PR DESCRIPTION
fixes #290

Shows the image being displayed correctly using the image's EXIF orientation property in the Mac's image viewer:
<img width="247" alt="Screenshot 2020-05-11 at 13 20 24" src="https://user-images.githubusercontent.com/16018629/81560893-327c5380-938a-11ea-8e4d-e56054dbda47.png">

Shows the same image displayed in VScode which does not use the EXIF data orientation property:
![Screenshot 2020-05-11 at 13 10 38](https://user-images.githubusercontent.com/16018629/81560325-175d1400-9389-11ea-9d22-d62d637d9ad8.png)

This shows how the resized image is displayed in the firebase console (The resized image loses EXIF data) without this PR change:
![Screenshot 2020-05-11 at 13 09 42](https://user-images.githubusercontent.com/16018629/81560317-14faba00-9389-11ea-9fc7-ee1c21e1e1c0.png)

This shows the resized image being displayed correctly. It doesn't have the EXIF data, but it was rotated at the time of resizing using the EXIF data orientation property:
![Screenshot 2020-05-11 at 13 10 01](https://user-images.githubusercontent.com/16018629/81560321-162be700-9389-11ea-8823-95573876d4de.png)

