### PR TITLE
fix(gen-schema-view): double quotes around strings & return timestamp type

### DIFF
--- a/firestore-bigquery-export/scripts/gen-schema-view/package.json
+++ b/firestore-bigquery-export/scripts/gen-schema-view/package.json
@@ -32,7 +32,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.5",
-    "@google-cloud/bigquery": "^2.1.0",
+    "@google-cloud/bigquery": "^4.7.0",
     "commander": "5.0.0",
     "firebase-admin": "^7.1.1",
     "firebase-functions": "^2.2.1",

--- a/firestore-bigquery-export/scripts/gen-schema-view/package.json
+++ b/firestore-bigquery-export/scripts/gen-schema-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebaseextensions/fs-bq-schema-views",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Generate strongly-typed BigQuery Views based on raw JSON",
   "main": "./lib/index.js",
   "repository": {

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/index.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/index.ts
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-import * as bigquery from "@google-cloud/bigquery";
 import * as program from "commander";
 import * as firebase from "firebase-admin";
 import * as inquirer from "inquirer";

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
@@ -140,7 +140,11 @@ export class FirestoreBigQuerySchemaViewFactory {
       view: result.viewInfo,
     };
     if (!changeLogSchemaViewExists) {
-      logs.bigQuerySchemaViewCreating(changeLogSchemaViewName, firestoreSchema, result.viewInfo.query);
+      logs.bigQuerySchemaViewCreating(
+        changeLogSchemaViewName,
+        firestoreSchema,
+        result.viewInfo.query
+      );
       await changeLogSchemaView.create(changelogOptions);
       logs.bigQuerySchemaViewCreated(changeLogSchemaViewName);
     }
@@ -163,7 +167,11 @@ export class FirestoreBigQuerySchemaViewFactory {
       view: result.viewInfo,
     };
     if (!latestSchemaViewExists) {
-      logs.bigQuerySchemaViewCreating(latestSchemaViewName, firestoreSchema, result.viewInfo.query);
+      logs.bigQuerySchemaViewCreating(
+        latestSchemaViewName,
+        firestoreSchema,
+        result.viewInfo.query
+      );
       await latestSchemaView.create(latestOptions);
       logs.bigQueryViewCreated(latestSchemaViewName);
     }
@@ -431,43 +439,66 @@ const processLeafField = (
       );
       break;
     case "timestamp":
-        const seconds = jsonExtract(dataFieldName, extractPrefix, field, `._seconds`, transformer);
-        const nanoseconds = jsonExtract(dataFieldName, extractPrefix, field, `._nanoseconds`, transformer);
-        /*
-         * We return directly from this branch because it's the only one that
-         * generates multiple selector clauses.
-         */
-        fieldNameToSelector[qualifyFieldName(prefix, field.name)] = `${firestoreTimestamp(datasetId, jsonExtract(dataFieldName, extractPrefix, field, ``, transformer))} AS ${prefix
-          .concat(field.name)
-          .join("_")}`;
+      const seconds = jsonExtract(
+        dataFieldName,
+        extractPrefix,
+        field,
+        `._seconds`,
+        transformer
+      );
+      const nanoseconds = jsonExtract(
+        dataFieldName,
+        extractPrefix,
+        field,
+        `._nanoseconds`,
+        transformer
+      );
+      /*
+       * We return directly from this branch because it's the only one that
+       * generates multiple selector clauses.
+       */
+      fieldNameToSelector[
+        qualifyFieldName(prefix, field.name)
+      ] = `${firestoreTimestamp(
+        datasetId,
+        jsonExtract(dataFieldName, extractPrefix, field, ``, transformer)
+      )} AS ${prefix.concat(field.name).join("_")}`;
 
-        bigQueryFields.push({
-          name: qualifyFieldName(prefix, field.name),
-          mode: "NULLABLE",
-          type: firestoreToBigQueryFieldType[field.type],
-          description: field.description,
-        });
+      bigQueryFields.push({
+        name: qualifyFieldName(prefix, field.name),
+        mode: "NULLABLE",
+        type: firestoreToBigQueryFieldType[field.type],
+        description: field.description,
+      });
 
-        fieldNameToSelector[qualifyFieldName(prefix, `${field.name}_seconds`)] = `SAFE_CAST(${seconds} AS NUMERIC) AS ${qualifyFieldName(prefix, `${field.name}_seconds`)}`;
+      fieldNameToSelector[
+        qualifyFieldName(prefix, `${field.name}_seconds`)
+      ] = `SAFE_CAST(${seconds} AS NUMERIC) AS ${qualifyFieldName(
+        prefix,
+        `${field.name}_seconds`
+      )}`;
 
-        bigQueryFields.push({
-          name: qualifyFieldName(prefix, `${field.name}_seconds`),
-          mode: "NULLABLE",
-          type: "NUMERIC",
-          description: `Numeric seconds component of ${field.name}.`,
-        });
+      bigQueryFields.push({
+        name: qualifyFieldName(prefix, `${field.name}_seconds`),
+        mode: "NULLABLE",
+        type: "NUMERIC",
+        description: `Numeric seconds component of ${field.name}.`,
+      });
 
-        fieldNameToSelector[qualifyFieldName(prefix, `${field.name}_nanoseconds`)] = `SAFE_CAST(${nanoseconds} AS NUMERIC) AS ${qualifyFieldName(prefix, `${field.name}_nanoseconds`)}`;
+      fieldNameToSelector[
+        qualifyFieldName(prefix, `${field.name}_nanoseconds`)
+      ] = `SAFE_CAST(${nanoseconds} AS NUMERIC) AS ${qualifyFieldName(
+        prefix,
+        `${field.name}_nanoseconds`
+      )}`;
 
-        bigQueryFields.push({
-          name: qualifyFieldName(prefix, `${field.name}_nanoseconds`),
-          mode: "NULLABLE",
-          type: "NUMERIC",
-          description: `Numeric nanoseconds component of ${
-            field.name
-          }.`,
-        });
-        return fieldNameToSelector;
+      bigQueryFields.push({
+        name: qualifyFieldName(prefix, `${field.name}_nanoseconds`),
+        mode: "NULLABLE",
+        type: "NUMERIC",
+        description: `Numeric nanoseconds component of ${field.name}.`,
+      });
+      return fieldNameToSelector;
     case "geopoint":
       const latitude = jsonExtract(
         dataFieldName,

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
@@ -19,7 +19,14 @@ import * as bigquery from "@google-cloud/bigquery";
 import * as sqlFormatter from "sql-formatter";
 import * as logs from "./logs";
 import { latestConsistentSnapshotSchemaView } from "./snapshot";
-import { firestoreArray, firestoreBoolean, firestoreGeopoint, firestoreNumber, firestoreTimestamp, udfs } from "./udf";
+import {
+  firestoreArray,
+  firestoreBoolean,
+  firestoreGeopoint,
+  firestoreNumber,
+  firestoreTimestamp,
+  udfs,
+} from "./udf";
 
 export type FirestoreFieldType =
   | "boolean"
@@ -313,7 +320,7 @@ export function processFirestoreSchema(
     extractors,
     transformer,
     bigQueryFields,
-    timestamps,
+    timestamps
   );
   return {
     queryInfo: [extractors, arrays, geopoints, timestamps],
@@ -344,7 +351,7 @@ function processFirestoreSchemaHelper(
   extractors: { [fieldName: string]: string },
   transformer: (selector: string) => string,
   bigQueryFields: { [property: string]: string }[],
-  timestamps: string[],
+  timestamps: string[]
 ) {
   const { fields } = schema;
   return fields.map((field) => {
@@ -360,7 +367,7 @@ function processFirestoreSchemaHelper(
         extractors,
         transformer,
         bigQueryFields,
-        timestamps,
+        timestamps
       );
       return;
     }
@@ -381,11 +388,11 @@ function processFirestoreSchemaHelper(
     if (field.type === "array") {
       arrays.push(qualifyFieldName(prefix, field.name));
     }
-    if (field.type === "geopoint" ) {
+    if (field.type === "geopoint") {
       geopoints.push(qualifyFieldName(prefix, field.name));
     }
-    
-    if (field.type === 'timestamp') {
+
+    if (field.type === "timestamp") {
       timestamps.push(qualifyFieldName(prefix, field.name));
     }
   });

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
@@ -16,14 +16,10 @@
 
 import * as sqlFormatter from "sql-formatter";
 
-import { RawChangelogSchema } from "@firebaseextensions/firestore-bigquery-change-tracker";
-
 import {
   buildSchemaViewQuery,
   latest,
   FirestoreSchema,
-  FirestoreFieldType,
-  FirestoreField,
   processFirestoreSchema,
   subSelectQuery,
 } from "./schema";


### PR DESCRIPTION
fixes #295

fix: Changing JSON SQL function to `JSON_EXTRACT_SCALAR` as per [docs](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions).

Notes
- fixed `timestamp` type to extract `seconds` & `nanoseconds` from dataset tables. It currently returns `null`.
- Made variable names slightly more semantic.
- `initializeSchemaViewResources ` returns `void` as no return value is expected.
- bumped `@google-cloud/bigquery` to "^4.7.0". Currently two major versions out of sync.
- bumped `gen-schema-view` script to version `0.1.8`

This is the schema file I used to test the script:
![Screenshot 2020-05-12 at 14 42 20](https://user-images.githubusercontent.com/16018629/81713786-371a3800-946e-11ea-9787-301db077f8bc.png)
This shows the `stringType` returning a single set of double quotes around a string property. It also shows the `timestamp` type returning the `seconds` &  `nanoseconds` properties like the Firestore [Timestamp](https://firebase.google.com/docs/reference/node/firebase.firestore.Timestamp#nanoseconds)
![Screenshot 2020-05-12 at 16 29 18](https://user-images.githubusercontent.com/16018629/81714032-85c7d200-946e-11ea-8fe0-a9461bdbf27d.png)

