### PR TITLE
fix(firestore-bigquery-export): fix bug where timestamp values are not correctly parsed (Issue #324).

### DIFF
--- a/firestore-bigquery-export/scripts/gen-schema-view/package.json
+++ b/firestore-bigquery-export/scripts/gen-schema-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebaseextensions/fs-bq-schema-views",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Generate strongly-typed BigQuery Views based on raw JSON",
   "main": "./lib/index.js",
   "repository": {

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
@@ -469,13 +469,7 @@ const processLeafField = (
         qualifyFieldName(prefix, field.name)
       ] = `${firestoreTimestamp(
         datasetId,
-        jsonExtract(
-          dataFieldName,
-          extractPrefix,
-          field,
-          ``,
-          transformer
-        )
+        jsonExtract(dataFieldName, extractPrefix, field, ``, transformer)
       )} AS ${prefix.concat(field.name).join("_")}`;
 
       bigQueryFields.push({
@@ -536,13 +530,7 @@ const processLeafField = (
         qualifyFieldName(prefix, field.name)
       ] = `${firestoreGeopoint(
         datasetId,
-        jsonExtract(
-          dataFieldName,
-          extractPrefix,
-          field,
-          ``,
-          transformer
-        )
+        jsonExtract(dataFieldName, extractPrefix, field, ``, transformer)
       )} AS ${prefix.concat(field.name).join("_")}`;
 
       bigQueryFields.push({

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/udf.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/udf.ts
@@ -136,7 +136,9 @@ function firestoreGeopointFunction(datasetId: string): any {
 
 function firestoreGeopointDefinition(datasetId: string): string {
   return sqlFormatter.format(`
-    CREATE FUNCTION IF NOT EXISTS \`${process.env.PROJECT_ID}.${datasetId}.firestoreGeopoint\`(json STRING)
+    CREATE FUNCTION IF NOT EXISTS \`${
+      process.env.PROJECT_ID
+    }.${datasetId}.firestoreGeopoint\`(json STRING)
     RETURNS GEOGRAPHY AS
     (ST_GEOGPOINT(SAFE_CAST(JSON_EXTRACT(json, '$._longitude') AS NUMERIC), SAFE_CAST(JSON_EXTRACT(json, '$._latitude') AS NUMERIC)));`);
 }

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/udf.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/udf.ts
@@ -136,9 +136,7 @@ function firestoreGeopointFunction(datasetId: string): any {
 
 function firestoreGeopointDefinition(datasetId: string): string {
   return sqlFormatter.format(`
-    CREATE FUNCTION IF NOT EXISTS \`${
-      process.env.PROJECT_ID
-    }.${datasetId}.firestoreGeopoint\`(json STRING)
+    CREATE FUNCTION IF NOT EXISTS \`${process.env.PROJECT_ID}.${datasetId}.firestoreGeopoint\`(json STRING)
     RETURNS GEOGRAPHY AS
-    (ST_GEOGPOINT(SAFE_CAST(JSON_EXTRACT(json, '$._latitude') AS NUMERIC), SAFE_CAST(JSON_EXTRACT(json, '$._longitude') AS NUMERIC)));`);
+    (ST_GEOGPOINT(SAFE_CAST(JSON_EXTRACT(json, '$._longitude') AS NUMERIC), SAFE_CAST(JSON_EXTRACT(json, '$._latitude') AS NUMERIC)));`);
 }


### PR DESCRIPTION
fixes #318, fixes #324.

- The timestamp and geopoint objects require a `JSON_EXTRACT` as pointed out by @caesarivs.
- The geopoint longitude & latitude extracts are switched as per the [documentation](https://cloud.google.com/bigquery/docs/reference/standard-sql/geography_functions#st_geogpoint) provided by @vpetlu. 

This shows the timestamp and the geopoint correctly extracted in the changelog view.
![Screenshot 2020-06-01 at 16 49 21](https://user-images.githubusercontent.com/16018629/83427832-449d5f00-a429-11ea-95c0-0db449a20764.png)
