### PR TITLE
fix(storage-resize-images): stop images from getting enlarged if they were smaller than max width and height (Issue #337).

### DIFF
--- a/storage-resize-images/functions/lib/index.js
+++ b/storage-resize-images/functions/lib/index.js
@@ -140,7 +140,7 @@ function resize(originalFile, resizedFile, size) {
     }
     return sharp(originalFile)
         .rotate()
-        .resize(parseInt(width, 10), parseInt(height, 10), { fit: "inside" })
+        .resize(parseInt(width, 10), parseInt(height, 10), { fit: "inside", withoutEnlargement: true })
         .toFile(resizedFile);
 }
 const resizeImage = ({ bucket, originalFile, fileDir, fileNameWithoutExtension, fileExtension, contentType, size, objectMetadata, }) => __awaiter(void 0, void 0, void 0, function* () {

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -154,11 +154,10 @@ function resize(originalFile, resizedFile, size) {
 
   return sharp(originalFile)
     .rotate()
-    .resize(
-      parseInt(width, 10),
-      parseInt(height, 10),
-      { fit: "inside", withoutEnlargement: true },
-    )
+    .resize(parseInt(width, 10), parseInt(height, 10), {
+      fit: "inside",
+      withoutEnlargement: true,
+    })
     .toFile(resizedFile);
 }
 

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -154,7 +154,11 @@ function resize(originalFile, resizedFile, size) {
 
   return sharp(originalFile)
     .rotate()
-    .resize(parseInt(width, 10), parseInt(height, 10), { fit: "inside" })
+    .resize(
+      parseInt(width, 10),
+      parseInt(height, 10),
+      { fit: "inside", withoutEnlargement: true },
+    )
     .toFile(resizedFile);
 }
 


### PR DESCRIPTION
Fix #337

From the [sharp docs](https://sharp.pixelplumbing.com/api-resize#parameters):

`options.withoutEnlargement` do not enlarge if the width or height are already less than the specified dimensions, equivalent to GraphicsMagick's `>` geometry option. (optional, default `false`)