### PR TITLE
fix(storage-resize-images): generate fresh token for resized image (Issue #323).

### DIFF
--- a/storage-resize-images/POSTINSTALL.md
+++ b/storage-resize-images/POSTINSTALL.md
@@ -27,7 +27,9 @@ The extension also copies the following [metadata](https://cloud.google.com/stor
 - `Content-Encoding`
 - `Content-Language`
 - `Content-Type`
-- [user-provided metadata](https://cloud.google.com/storage/docs/metadata#custom-metadata) (except Firebase storage download tokens)
+- [user-provided metadata](https://cloud.google.com/storage/docs/metadata#custom-metadata)
+ - If the original image contains a download token (publically accessible via a unique download URL), a new download token is generated for the resized image(s). 
+ - If the orginal image does not contain a download token, resized image(s) will not be created with unique tokens. To make a resized image publically accessible, call the [`getDownloadURL`](https://firebase.google.com/docs/reference/js/firebase.storage.Reference#getdownloadurl) method.
 
 Be aware of the following when using this extension:
 

--- a/storage-resize-images/PREINSTALL.md
+++ b/storage-resize-images/PREINSTALL.md
@@ -8,7 +8,7 @@ When you upload an image file to your specified Cloud Storage bucket, this exten
 
 You can even configure the extension to create resized images of different dimensions for each original image upload. For example, you might want images that are 200x200, 400x400, and 680x680 - this extension can create these three resized images then store them in your bucket.
 
-The extension automatically copies the following metadata, if present, from the original image to the resized image(s): `Cache-Control`, `Content-Disposition`, `Content-Encoding`, `Content-Language`, `Content-Type`, and user-provided metadata (except Firebase storage download tokens). Note that you can optionally configure the extension to overwrite the [`Cache-Control`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control) value for the resized image(s).
+The extension automatically copies the following metadata, if present, from the original image to the resized image(s): `Cache-Control`, `Content-Disposition`, `Content-Encoding`, `Content-Language`, `Content-Type`, and user-provided metadata (a new Firebase storage download token will be generated on the resized image(s) if the original metadata contains a token). Note that you can optionally configure the extension to overwrite the [`Cache-Control`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control) value for the resized image(s).
 
 #### Detailed configuration information
 

--- a/storage-resize-images/README.md
+++ b/storage-resize-images/README.md
@@ -14,7 +14,7 @@ When you upload an image file to your specified Cloud Storage bucket, this exten
 
 You can even configure the extension to create resized images of different dimensions for each original image upload. For example, you might want images that are 200x200, 400x400, and 680x680 - this extension can create these three resized images then store them in your bucket.
 
-The extension automatically copies the following metadata, if present, from the original image to the resized image(s): `Cache-Control`, `Content-Disposition`, `Content-Encoding`, `Content-Language`, `Content-Type`, and user-provided metadata (except Firebase storage download tokens). Note that you can optionally configure the extension to overwrite the [`Cache-Control`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control) value for the resized image(s).
+The extension automatically copies the following metadata, if present, from the original image to the resized image(s): `Cache-Control`, `Content-Disposition`, `Content-Encoding`, `Content-Language`, `Content-Type`, and user-provided metadata (a new Firebase storage download token will be generated on the resized image(s) if the original metadata contains a token). Note that you can optionally configure the extension to overwrite the [`Cache-Control`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control) value for the resized image(s).
 
 #### Detailed configuration information
 

--- a/storage-resize-images/functions/lib/index.js
+++ b/storage-resize-images/functions/lib/index.js
@@ -15,11 +15,10 @@
  * limitations under the License.
  */
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -31,6 +30,7 @@ const mkdirp = require("mkdirp");
 const os = require("os");
 const path = require("path");
 const sharp = require("sharp");
+const uuidv4_1 = require("uuidv4");
 const config_1 = require("./config");
 const logs = require("./logs");
 const util_1 = require("./util");
@@ -51,7 +51,7 @@ const supportedContentTypes = [
  * When an image is uploaded in the Storage bucket, we generate a resized image automatically using
  * the Sharp image converting library.
  */
-exports.generateResizedImage = functions.storage.object().onFinalize((object) => __awaiter(void 0, void 0, void 0, function* () {
+exports.generateResizedImage = functions.storage.object().onFinalize((object) => __awaiter(this, void 0, void 0, function* () {
     logs.start();
     const { contentType } = object; // This is the image MIME type
     if (!contentType) {
@@ -156,7 +156,7 @@ function resize(originalFile, resizedFile, size) {
     })
         .toFile(resizedFile);
 }
-const resizeImage = ({ bucket, originalFile, fileDir, fileNameWithoutExtension, fileExtension, contentType, size, objectMetadata, }) => __awaiter(void 0, void 0, void 0, function* () {
+const resizeImage = ({ bucket, originalFile, fileDir, fileNameWithoutExtension, fileExtension, contentType, size, objectMetadata, }) => __awaiter(this, void 0, void 0, function* () {
     const resizedFileName = `${fileNameWithoutExtension}_${size}${fileExtension}`;
     // Path where resized image will be uploaded to in Storage.
     const resizedFilePath = path.normalize(config_1.default.resizedImagesPath
@@ -179,6 +179,11 @@ const resizeImage = ({ bucket, originalFile, fileDir, fileNameWithoutExtension, 
         }
         else {
             metadata.cacheControl = objectMetadata.cacheControl;
+        }
+        // If the original image has a download token, add a 
+        // new token to the image being resized #323
+        if (metadata.metadata.firebaseStorageDownloadTokens) {
+            metadata.metadata.firebaseStorageDownloadTokens = uuidv4_1.uuid();
         }
         // Generate a resized image using Sharp.
         logs.imageResizing(resizedFile, size);

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -22,7 +22,7 @@ import * as mkdirp from "mkdirp";
 import * as os from "os";
 import * as path from "path";
 import * as sharp from "sharp";
-import { uuid } from 'uuidv4';
+import { uuid } from "uuidv4";
 
 import config from "./config";
 import * as logs from "./logs";
@@ -222,7 +222,7 @@ const resizeImage = async ({
       metadata.cacheControl = objectMetadata.cacheControl;
     }
 
-    // If the original image has a download token, add a 
+    // If the original image has a download token, add a
     // new token to the image being resized #323
     if (metadata.metadata.firebaseStorageDownloadTokens) {
       metadata.metadata.firebaseStorageDownloadTokens = uuid();

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -22,6 +22,7 @@ import * as mkdirp from "mkdirp";
 import * as os from "os";
 import * as path from "path";
 import * as sharp from "sharp";
+import { uuid } from 'uuidv4';
 
 import config from "./config";
 import * as logs from "./logs";
@@ -201,13 +202,13 @@ const resizeImage = async ({
       ? path.join(fileDir, config.resizedImagesPath, resizedFileName)
       : path.join(fileDir, resizedFileName)
   );
-  let resizedFile;
+  let resizedFile: string;
 
   try {
     resizedFile = path.join(os.tmpdir(), resizedFileName);
 
     // Cloud Storage files.
-    const metadata: any = {
+    const metadata: { [key: string]: any } = {
       contentDisposition: objectMetadata.contentDisposition,
       contentEncoding: objectMetadata.contentEncoding,
       contentLanguage: objectMetadata.contentLanguage,
@@ -219,6 +220,12 @@ const resizeImage = async ({
       metadata.cacheControl = config.cacheControlHeader;
     } else {
       metadata.cacheControl = objectMetadata.cacheControl;
+    }
+
+    // If the original image has a download token, add a 
+    // new token to the image being resized #323
+    if (metadata.metadata.firebaseStorageDownloadTokens) {
+      metadata.metadata.firebaseStorageDownloadTokens = uuid();
     }
 
     // Generate a resized image using Sharp.

--- a/storage-resize-images/package.json
+++ b/storage-resize-images/package.json
@@ -15,9 +15,12 @@
     "firebase-admin": "^8.0.0",
     "firebase-functions": "^3.3.0",
     "mkdirp": "^1.0.4",
-    "sharp": "0.23.4"
+    "sharp": "0.23.4",
+    "uuidv4": "^6.1.0"
   },
   "devDependencies": {
+    "@types/mkdirp": "^1.0.1",
+    "@types/sharp": "^0.25.0",
     "rimraf": "^2.6.3",
     "typescript": "^3.5.2"
   },


### PR DESCRIPTION
As discussed in https://github.com/firebase/extensions/issues/323, image download tokens are being copied which is problematic. This PR updates the flow to check if a download token exists on the original image, and if so, generates a fresh token on the image being resized.

- [x] Peer testing
- [x] Documentation updates (https://github.com/firebase/extensions/pull/322 impacted)