### PR TITLE
fix(firestore-bigquery-export): extract array

### DIFF
--- a/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
@@ -614,7 +614,11 @@ const jsonExtractScalar = (
   subselector: string = "",
   transformer: (selector: string) => string
 ) => {
-  return transformer(`JSON_EXTRACT_SCALAR(${dataFieldName}, \'\$.${prefix.length > 0 ? `${prefix}.` : ``}${field.name}${subselector}\')`);
+  return transformer(
+    `JSON_EXTRACT_SCALAR(${dataFieldName}, \'\$.${
+      prefix.length > 0 ? `${prefix}.` : ``
+    }${field.name}${subselector}\')`
+  );
 };
 
 const jsonExtract = (

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
@@ -431,7 +431,7 @@ const processLeafField = (
     case "array":
       selector = firestoreArray(
         datasetId,
-        jsonExtractScalar(dataFieldName, extractPrefix, field, ``, transformer)
+        jsonExtract(dataFieldName, extractPrefix, field, ``, transformer)
       );
       break;
     case "boolean":
@@ -614,11 +614,7 @@ const jsonExtractScalar = (
   subselector: string = "",
   transformer: (selector: string) => string
 ) => {
-  return transformer(
-    `JSON_EXTRACT_SCALAR(${dataFieldName}, \'\$.${
-      prefix.length > 0 ? `${prefix}.` : ``
-    }${field.name}${subselector}\')`
-  );
+  return transformer(`JSON_EXTRACT_SCALAR(${dataFieldName}, \'\$.${prefix.length > 0 ? `${prefix}.` : ``}${field.name}${subselector}\')`);
 };
 
 const jsonExtract = (


### PR DESCRIPTION
fixes #359
![Screenshot 2020-06-26 at 17 07 39](https://user-images.githubusercontent.com/16018629/85877988-e701f580-b7cf-11ea-9c4f-5498514639f8.png)

- incorrectly extracting array as `JSON_EXTRACT_SCALAR` when it should be `JSON_EXTRACT`.