### PR TITLE
feat(firestore-bigquery-export): record document id of changes tracked by firestore-bigquery-change-tracker package

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
@@ -5,7 +5,7 @@
     "url": "github.com/firebase/extensions.git",
     "directory": "firestore-bigquery-export/firestore-bigquery-change-tracker"
   },
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Core change-tracker library for Cloud Firestore Collection BigQuery Exports",
   "main": "./lib/index.js",
   "scripts": {
@@ -23,7 +23,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@google-cloud/bigquery": "^4.7.0",
-    "@types/traverse": "^0.6.32",
     "firebase-admin": "^7.1.1",
     "firebase-functions": "^2.2.1",
     "generate-schema": "^2.6.0",
@@ -33,6 +32,7 @@
     "traverse": "^0.6.6"
   },
   "devDependencies": {
+    "@types/traverse": "^0.6.32",
     "typescript": "^3.4.5",
     "rimraf": "^2.6.3",
     "nyc": "^14.0.0",

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/snapshot.test.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/snapshot.test.ts
@@ -31,7 +31,6 @@ const testTable = "test_table";
 
 const expect = chai.expect;
 const readFile = util.promisify(fs.readFile);
-const writeFile = util.promisify(fs.writeFile);
 
 process.env.PROJECT_ID = testProjectId;
 
@@ -40,12 +39,8 @@ async function readFormattedSQL(file: string): Promise<string> {
   return sqlFormatter.format(query);
 }
 
-async function readBigQuerySchema(file: string): Promise<any> {
-  return require(file);
-}
-
 describe("latest snapshot view sql generation", () => {
-  it("should generate the epxected sql", async () => {
+  it("should generate the expected sql", async () => {
     const expectedQuery = await readFormattedSQL(
       `${sqlDir}/latestConsistentSnapshot.txt`
     );

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/fixtures/sql/latestConsistentSnapshot.txt
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/fixtures/sql/latestConsistentSnapshot.txt
@@ -3,8 +3,10 @@
 --   operation: One of INSERT, UPDATE, DELETE, IMPORT.
 --   event_id: The id of the event that triggered the cloud function mirrored the event.
 --   data: A raw JSON payload of the current state of the document.
+--   document_id: The document id as defined in the Firestore database
 SELECT
   document_name,
+  document_id,
   timestamp,
   event_id,
   operation,
@@ -13,6 +15,7 @@ FROM
   (
     SELECT
       document_name,
+      document_id,
       FIRST_VALUE(timestamp) OVER(
         PARTITION BY document_name
         ORDER BY
@@ -48,6 +51,7 @@ WHERE
   NOT is_deleted
 GROUP BY
   document_name,
+  document_id,
   timestamp,
   event_id,
   operation,

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/fixtures/sql/latestConsistentSnapshotNoGroupBy.txt
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/fixtures/sql/latestConsistentSnapshotNoGroupBy.txt
@@ -3,12 +3,15 @@
 --   operation: One of INSERT, UPDATE, DELETE, IMPORT.
 --   event_id: The id of the event that triggered the cloud function mirrored the event.
 --   data: A raw JSON payload of the current state of the document.
+--   document_id: The document id as defined in the Firestore database
 SELECT
-  document_name
+  document_name,
+  document_id
 FROM
   (
     SELECT
       document_name,
+      document_id,
       FIRST_VALUE(operation) OVER(
         PARTITION BY document_name
         ORDER BY
@@ -23,4 +26,5 @@ FROM
 WHERE
   NOT is_deleted
 GROUP BY
-  document_name
+  document_name,
+  document_id

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -62,6 +62,7 @@ export class FirestoreBigQueryEventHistoryTracker
           timestamp: event.timestamp,
           event_id: event.eventId,
           document_name: event.documentName,
+          document_id: event.documentId,
           operation: ChangeType[event.operation],
           data: JSON.stringify(this.serializeData(event.data)),
         },

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/schema.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/schema.ts
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-import * as bigquery from "@google-cloud/bigquery";
-import * as errors from "../errors";
-import * as logs from "../logs";
-import * as sqlFormatter from "sql-formatter";
-
 export type BigQueryFieldMode = "NULLABLE" | "REPEATED" | "REQUIRED";
 export type BigQueryFieldType =
   | "BOOLEAN"
@@ -104,6 +99,12 @@ export const RawChangelogViewSchema: any = {
       description:
         "The full JSON representation of the current document state.",
     },
+    {
+      name: "document_id",
+      mode: "NULLABLE",
+      type: "STRING",
+      description: "The document id as defined in the firestore database.",
+    },
   ],
 };
 
@@ -142,6 +143,12 @@ export const RawChangelogSchema: any = {
       type: "STRING",
       description:
         "The full JSON representation of the document state after the indicated operation is applied. This field will be null for DELETE operations.",
+    },
+    {
+      name: "document_id",
+      mode: "NULLABLE",
+      type: "STRING",
+      description: "The document id as defined in the firestore database.",
     },
   ],
 };

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/snapshot.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/snapshot.ts
@@ -16,14 +16,12 @@
 
 import * as sqlFormatter from "sql-formatter";
 
-import * as logs from "../logs";
 import {
-  RawChangelogSchema,
   RawChangelogViewSchema,
   timestampField,
 } from "./schema";
 
-const excludeFields: string[] = ["document_name"];
+const excludeFields: string[] = ["document_name", "document_id"];
 
 export const latestConsistentSnapshotView = (
   datasetId: string,
@@ -60,12 +58,15 @@ export function buildLatestSnapshotViewQuery(
     --   operation: One of INSERT, UPDATE, DELETE, IMPORT.
     --   event_id: The id of the event that triggered the cloud function mirrored the event.
     --   data: A raw JSON payload of the current state of the document.
+    --   document_id: The document id as defined in the Firestore database
     SELECT
-      document_name${groupByColumns.length > 0 ? `,` : ``}
+    document_name,
+    document_id${groupByColumns.length > 0 ? `,` : ``}
       ${groupByColumns.join(",")}
-     FROM (
+    FROM (
       SELECT
         document_name,
+        document_id,
         ${groupByColumns
           .map(
             (columnName) =>
@@ -79,11 +80,11 @@ export function buildLatestSnapshotViewQuery(
           AS is_deleted
       FROM \`${process.env.PROJECT_ID}.${datasetId}.${tableName}\`
       ORDER BY document_name, ${timestampColumnName} DESC
-     )
-     WHERE NOT is_deleted
-     GROUP BY document_name${
-       groupByColumns.length > 0 ? `, ` : ``
-     }${groupByColumns.join(",")}`
+    )
+    WHERE NOT is_deleted
+    GROUP BY document_name, document_id${
+      groupByColumns.length > 0 ? `, ` : ``
+    }${groupByColumns.join(",")}`
   );
   return query;
 }

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/snapshot.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/snapshot.ts
@@ -16,10 +16,7 @@
 
 import * as sqlFormatter from "sql-formatter";
 
-import {
-  RawChangelogViewSchema,
-  timestampField,
-} from "./schema";
+import { RawChangelogViewSchema, timestampField } from "./schema";
 
 const excludeFields: string[] = ["document_name", "document_id"];
 

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/tracker.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/tracker.ts
@@ -32,6 +32,7 @@ export interface FirestoreDocumentChangeEvent {
   operation: ChangeType;
   documentName: string;
   eventId: string;
+  documentId: string;
   data: Object;
 }
 

--- a/firestore-bigquery-export/scripts/import/src/index.ts
+++ b/firestore-bigquery-export/scripts/import/src/index.ts
@@ -203,6 +203,7 @@ const run = async (): Promise<number> => {
         documentName: `projects/${projectId}/databases/${FIRESTORE_DEFAULT_DATABASE}/documents/${
           snapshot.ref.path
         }`,
+        documentId: snapshot.id,
         eventId: "",
         data: snapshot.data(),
       };


### PR DESCRIPTION
-  `document_id` implementation for `firestore-bigquery-change-tracker` which the `firestore-bigquery-export` extension depends upon.