### PR TITLE
feat(firestore-bigquery-export): add document id column in changelog table and snapshot view

### DIFF
--- a/firestore-bigquery-export/functions/lib/index.js
+++ b/firestore-bigquery-export/functions/lib/index.js
@@ -38,11 +38,13 @@ exports.fsexportbigquery = functions.handler.firestore.document.onWrite((change,
     logs.start();
     try {
         const changeType = util_1.getChangeType(change);
+        const documentId = util_1.getDocumentId(change);
         yield eventTracker.record([
             {
                 timestamp: context.timestamp,
                 operation: changeType,
                 documentName: context.resource.name,
+                documentId: documentId,
                 eventId: context.eventId,
                 data: changeType === firestore_bigquery_change_tracker_1.ChangeType.DELETE ? undefined : change.after.data(),
             },

--- a/firestore-bigquery-export/functions/lib/util.js
+++ b/firestore-bigquery-export/functions/lib/util.js
@@ -26,3 +26,10 @@ function getChangeType(change) {
     return firestore_bigquery_change_tracker_1.ChangeType.UPDATE;
 }
 exports.getChangeType = getChangeType;
+function getDocumentId(change) {
+    if (change.after.exists) {
+        return change.after.id;
+    }
+    return change.before.id;
+}
+exports.getDocumentId = getDocumentId;

--- a/firestore-bigquery-export/functions/src/index.ts
+++ b/firestore-bigquery-export/functions/src/index.ts
@@ -22,7 +22,7 @@ import {
   FirestoreEventHistoryTracker,
 } from "@firebaseextensions/firestore-bigquery-change-tracker";
 import * as logs from "./logs";
-import { getChangeType } from "./util";
+import { getChangeType, getDocumentId } from "./util";
 
 const eventTracker: FirestoreEventHistoryTracker = new FirestoreBigQueryEventHistoryTracker(
   {
@@ -38,11 +38,13 @@ exports.fsexportbigquery = functions.handler.firestore.document.onWrite(
     logs.start();
     try {
       const changeType = getChangeType(change);
+      const documentId = getDocumentId(change);
       await eventTracker.record([
         {
           timestamp: context.timestamp, // This is a Cloud Firestore commit timestamp with microsecond precision.
           operation: changeType,
           documentName: context.resource.name,
+          documentId: documentId,
           eventId: context.eventId,
           data:
             changeType === ChangeType.DELETE ? undefined : change.after.data(),

--- a/firestore-bigquery-export/functions/src/util.ts
+++ b/firestore-bigquery-export/functions/src/util.ts
@@ -28,3 +28,10 @@ export function getChangeType(change: Change<DocumentSnapshot>): ChangeType {
   }
   return ChangeType.UPDATE;
 }
+
+export function getDocumentId(change: Change<DocumentSnapshot>): string {
+  if (change.after.exists) {
+    return change.after.id;
+  }
+  return change.before.id;
+}


### PR DESCRIPTION
Closed down PR #373 to base of `next` branch.
- updates the changelog table and the snapshot latest view to have a `document_id` column.
- replaces this PR: #346 created by a Firebase Extension's user.

`latest` view with the column at the end containing the document id.

![Screenshot 2020-07-07 at 12 02 08](https://user-images.githubusercontent.com/16018629/86784718-bf295200-c059-11ea-9fcc-00c988dd9a1f.png)

`changelog` table with the column at the end containing the document id.

![Screenshot 2020-07-07 at 13 59 11](https://user-images.githubusercontent.com/16018629/86785006-13343680-c05a-11ea-8c13-e438ef615cb6.png)

