### PR TITLE
feat(firestore-bigquery-export): create document id column when using gen-schema-view script

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/fixtures/sql/latestConsistentSnapshot.txt
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/fixtures/sql/latestConsistentSnapshot.txt
@@ -5,6 +5,7 @@
 --   data: A raw JSON payload of the current state of the document.
 SELECT
   document_name,
+  document_id,
   timestamp,
   event_id,
   operation,
@@ -13,6 +14,7 @@ FROM
   (
     SELECT
       document_name,
+      document_id,
       FIRST_VALUE(timestamp) OVER(
         PARTITION BY document_name
         ORDER BY
@@ -48,6 +50,7 @@ WHERE
   NOT is_deleted
 GROUP BY
   document_name,
+  document_id,
   timestamp,
   event_id,
   operation,

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/fixtures/sql/latestConsistentSnapshotNoGroupBy.txt
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/fixtures/sql/latestConsistentSnapshotNoGroupBy.txt
@@ -9,6 +9,7 @@ FROM
   (
     SELECT
       document_name,
+      document_id,
       FIRST_VALUE(operation) OVER(
         PARTITION BY document_name
         ORDER BY

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/arraysNestedInMapsSchema.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/arraysNestedInMapsSchema.txt
@@ -4,6 +4,7 @@ FROM
   (
     SELECT
       document_name,
+      document_id,
       timestamp,
       operation,
       `test.test_dataset.firestoreArray`(JSON_EXTRACT(data, '$.map.array')) AS map_array,

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/emptyMapSchema.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/emptyMapSchema.txt
@@ -1,5 +1,6 @@
 SELECT
   document_name,
+  document_id,
   timestamp,
   operation
 FROM

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/emptySchemaChangeLog.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/emptySchemaChangeLog.txt
@@ -1,5 +1,6 @@
 SELECT
   document_name,
+  document_id,
   timestamp,
   operation
 FROM

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/emptySchemaLatest.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/emptySchemaLatest.txt
@@ -7,12 +7,14 @@
 --                    corresponding to fields defined in the schema.
 SELECT
   document_name,
+  document_id,
   timestamp,
   operation
 FROM
   (
     SELECT
       document_name,
+      document_id,
       FIRST_VALUE(timestamp) OVER(
         PARTITION BY document_name
         ORDER BY

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/emptySchemaLatest.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/emptySchemaLatest.txt
@@ -37,5 +37,6 @@ WHERE
   NOT is_deleted
 GROUP BY
   document_name,
+  document_id,
   timestamp,
   operation

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/emptySchemaLatestFromView.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/emptySchemaLatestFromView.txt
@@ -4,19 +4,20 @@ FROM
   (
     SELECT
       document_name,
+      document_id,
       timestamp,
       operation,
-      JSON_EXTRACT(data, '$.name') AS name,
+      JSON_EXTRACT_SCALAR(data, '$.name') AS name,
       `test.test_dataset.firestoreArray`(JSON_EXTRACT(data, '$.favorite_numbers')) AS favorite_numbers,
       `test.test_dataset.firestoreTimestamp`(JSON_EXTRACT(data, '$.last_login')) AS last_login,
       `test.test_dataset.firestoreGeopoint`(JSON_EXTRACT(data, '$.last_location')) AS last_location,
       SAFE_CAST(
-        JSON_EXTRACT(data, '$.last_location._latitude') AS NUMERIC
+        JSON_EXTRACT_SCALAR(data, '$.last_location._latitude') AS NUMERIC
       ) AS last_location_latitude,
       SAFE_CAST(
-        JSON_EXTRACT(data, '$.last_location._longitude') AS NUMERIC
+        JSON_EXTRACT_SCALAR(data, '$.last_location._longitude') AS NUMERIC
       ) AS last_location_longitude,
-      JSON_EXTRACT(data, '$.friends.name') AS friends_name
+      JSON_EXTRACT_SCALAR(data, '$.friends.name') AS friends_name
     FROM
       `test.test_dataset.test_table_latest`
   ) test_table_latest

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaChangeLog.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaChangeLog.txt
@@ -4,19 +4,20 @@ FROM
   (
     SELECT
       document_name,
+      document_id,
       timestamp,
       operation,
-      JSON_EXTRACT(data, '$.name') AS name,
+      JSON_EXTRACT_SCALAR(data, '$.name') AS name,
       `test.test_dataset.firestoreArray`(JSON_EXTRACT(data, '$.favorite_numbers')) AS favorite_numbers,
       `test.test_dataset.firestoreTimestamp`(JSON_EXTRACT(data, '$.last_login')) AS last_login,
       `test.test_dataset.firestoreGeopoint`(JSON_EXTRACT(data, '$.last_location')) AS last_location,
       SAFE_CAST(
-        JSON_EXTRACT(data, '$.last_location._latitude') AS NUMERIC
+        JSON_EXTRACT_SCALAR(data, '$.last_location._latitude') AS NUMERIC
       ) AS last_location_latitude,
       SAFE_CAST(
-        JSON_EXTRACT(data, '$.last_location._longitude') AS NUMERIC
+        JSON_EXTRACT_SCALAR(data, '$.last_location._longitude') AS NUMERIC
       ) AS last_location_longitude,
-      JSON_EXTRACT(data, '$.friends.name') AS friends_name
+      JSON_EXTRACT_SCALAR(data, '$.friends.name') AS friends_name
     FROM
       `test.test_dataset.test_table`
   ) test_table

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaLatest.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaLatest.txt
@@ -97,6 +97,7 @@ FROM
   CROSS JOIN UNNEST(test_table.favorite_numbers) AS favorite_numbers_member WITH OFFSET favorite_numbers_index
 GROUP BY
   document_name,
+  document_id,
   timestamp,
   operation,
   name,

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaLatest.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaLatest.txt
@@ -13,6 +13,7 @@ FROM
   (
     SELECT
       document_name,
+      document_id,
       timestamp,
       operation,
       name,
@@ -26,6 +27,7 @@ FROM
       (
         SELECT
           document_name,
+          document_id,
           FIRST_VALUE(timestamp) OVER(
             PARTITION BY document_name
             ORDER BY
@@ -41,7 +43,7 @@ FROM
             ORDER BY
               timestamp DESC
           ) = "DELETE" AS is_deleted,
-          FIRST_VALUE(JSON_EXTRACT(data, '$.name')) OVER(
+          FIRST_VALUE(JSON_EXTRACT_SCALAR(data, '$.name')) OVER(
             PARTITION BY document_name
             ORDER BY
               timestamp DESC
@@ -68,20 +70,20 @@ FROM
             )
           ) AS last_location,
           SAFE_CAST(
-            FIRST_VALUE(JSON_EXTRACT(data, '$.last_location._latitude')) OVER(
+            FIRST_VALUE(JSON_EXTRACT_SCALAR(data, '$.last_location._latitude')) OVER(
               PARTITION BY document_name
               ORDER BY
                 timestamp DESC
             ) AS NUMERIC
           ) AS last_location_latitude,
           SAFE_CAST(
-            FIRST_VALUE(JSON_EXTRACT(data, '$.last_location._longitude')) OVER(
+            FIRST_VALUE(JSON_EXTRACT_SCALAR(data, '$.last_location._longitude')) OVER(
               PARTITION BY document_name
               ORDER BY
                 timestamp DESC
             ) AS NUMERIC
           ) AS last_location_longitude,
-          FIRST_VALUE(JSON_EXTRACT(data, '$.friends.name')) OVER(
+          FIRST_VALUE(JSON_EXTRACT_SCALAR(data, '$.friends.name')) OVER(
             PARTITION BY document_name
             ORDER BY
               timestamp DESC

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaLatestFromView.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaLatestFromView.txt
@@ -4,19 +4,20 @@ FROM
   (
     SELECT
       document_name,
+      document_id,
       timestamp,
       operation,
-      JSON_EXTRACT(data, '$.name') AS name,
+      JSON_EXTRACT_SCALAR(data, '$.name') AS name,
       `test.test_dataset.firestoreArray`(JSON_EXTRACT(data, '$.favorite_numbers')) AS favorite_numbers,
       `test.test_dataset.firestoreTimestamp`(JSON_EXTRACT(data, '$.last_login')) AS last_login,
       `test.test_dataset.firestoreGeopoint`(JSON_EXTRACT(data, '$.last_location')) AS last_location,
       SAFE_CAST(
-        JSON_EXTRACT(data, '$.last_location._latitude') AS NUMERIC
+        JSON_EXTRACT_SCALAR(data, '$.last_location._latitude') AS NUMERIC
       ) AS last_location_latitude,
       SAFE_CAST(
-        JSON_EXTRACT(data, '$.last_location._longitude') AS NUMERIC
+        JSON_EXTRACT_SCALAR(data, '$.last_location._longitude') AS NUMERIC
       ) AS last_location_longitude,
-      JSON_EXTRACT(data, '$.friends.name') AS friends_name
+      JSON_EXTRACT_SCALAR(data, '$.friends.name') AS friends_name
     FROM
       `test.test_dataset.test_table_latest`
   ) test_table_latest

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaLatestLatestFromView.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaLatestLatestFromView.txt
@@ -4,19 +4,20 @@ FROM
   (
     SELECT
       document_name,
+      document_id,
       timestamp,
       operation,
-      JSON_EXTRACT(data, '$.name') AS name,
+      JSON_EXTRACT_SCALAR(data, '$.name') AS name,
       `test.test_dataset.firestoreArray`(JSON_EXTRACT(data, '$.favorite_numbers')) AS favorite_numbers,
       `test.test_dataset.firestoreTimestamp`(JSON_EXTRACT(data, '$.last_login')) AS last_login,
       `test.test_dataset.firestoreGeopoint`(JSON_EXTRACT(data, '$.last_location')) AS last_location,
       SAFE_CAST(
-        JSON_EXTRACT(data, '$.last_location._latitude') AS NUMERIC
+        JSON_EXTRACT_SCALAR(data, '$.last_location._latitude') AS NUMERIC
       ) AS last_location_latitude,
       SAFE_CAST(
-        JSON_EXTRACT(data, '$.last_location._longitude') AS NUMERIC
+        JSON_EXTRACT_SCALAR(data, '$.last_location._longitude') AS NUMERIC
       ) AS last_location_longitude,
-      JSON_EXTRACT(data, '$.friends.name') AS friends_name
+      JSON_EXTRACT_SCALAR(data, '$.friends.name') AS friends_name
     FROM
       `test.test_dataset.test_table_latest`
   ) test_table_latest

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaSquared.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaSquared.txt
@@ -4,30 +4,31 @@ FROM
   (
     SELECT
       document_name,
+      document_id,
       timestamp,
       operation,
-      JSON_EXTRACT(data, '$.schema1.name') AS schema1_name,
+      JSON_EXTRACT_SCALAR(data, '$.schema1.name') AS schema1_name,
       `test.test_dataset.firestoreArray`(JSON_EXTRACT(data, '$.schema1.favorite_numbers')) AS schema1_favorite_numbers,
       `test.test_dataset.firestoreTimestamp`(JSON_EXTRACT(data, '$.schema1.last_login')) AS schema1_last_login,
       `test.test_dataset.firestoreGeopoint`(JSON_EXTRACT(data, '$.schema1.last_location')) AS schema1_last_location,
       SAFE_CAST(
-        JSON_EXTRACT(data, '$.schema1.last_location._latitude') AS NUMERIC
+        JSON_EXTRACT_SCALAR(data, '$.schema1.last_location._latitude') AS NUMERIC
       ) AS schema1_last_location_latitude,
       SAFE_CAST(
-        JSON_EXTRACT(data, '$.schema1.last_location._longitude') AS NUMERIC
+        JSON_EXTRACT_SCALAR(data, '$.schema1.last_location._longitude') AS NUMERIC
       ) AS schema1_last_location_longitude,
-      JSON_EXTRACT(data, '$.schema1.friends.name') AS schema1_friends_name,
-      JSON_EXTRACT(data, '$.schema2.name') AS schema2_name,
+      JSON_EXTRACT_SCALAR(data, '$.schema1.friends.name') AS schema1_friends_name,
+      JSON_EXTRACT_SCALAR(data, '$.schema2.name') AS schema2_name,
       `test.test_dataset.firestoreArray`(JSON_EXTRACT(data, '$.schema2.favorite_numbers')) AS schema2_favorite_numbers,
       `test.test_dataset.firestoreTimestamp`(JSON_EXTRACT(data, '$.schema2.last_login')) AS schema2_last_login,
       `test.test_dataset.firestoreGeopoint`(JSON_EXTRACT(data, '$.schema2.last_location')) AS schema2_last_location,
       SAFE_CAST(
-        JSON_EXTRACT(data, '$.schema2.last_location._latitude') AS NUMERIC
+        JSON_EXTRACT_SCALAR(data, '$.schema2.last_location._latitude') AS NUMERIC
       ) AS schema2_last_location_latitude,
       SAFE_CAST(
-        JSON_EXTRACT(data, '$.schema2.last_location._longitude') AS NUMERIC
+        JSON_EXTRACT_SCALAR(data, '$.schema2.last_location._longitude') AS NUMERIC
       ) AS schema2_last_location_longitude,
-      JSON_EXTRACT(data, '$.schema2.friends.name') AS schema2_friends_name
+      JSON_EXTRACT_SCALAR(data, '$.schema2.friends.name') AS schema2_friends_name
     FROM
       `test.test_dataset.test_table`
   ) test_table

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/latestConsistentSnapshot.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/latestConsistentSnapshot.txt
@@ -49,6 +49,7 @@ WHERE
   NOT is_deleted
 GROUP BY
   document_name,
+  document_id,
   timestamp,
   event_id,
   operation,

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/latestConsistentSnapshot.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/latestConsistentSnapshot.txt
@@ -5,6 +5,7 @@
 --   data: A raw JSON payload of the current state of the document.
 SELECT
   document_name,
+  document_id,
   timestamp,
   event_id,
   operation,

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/latestConsistentSnapshotNoGroupBy.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/latestConsistentSnapshotNoGroupBy.txt
@@ -4,11 +4,13 @@
 --   event_id: The id of the event that triggered the cloud function mirrored the event.
 --   data: A raw JSON payload of the current state of the document.
 SELECT
-  document_name
+  document_name,
+  document_id
 FROM
   (
     SELECT
       document_name,
+      document_id,
       FIRST_VALUE(operation) OVER(
         PARTITION BY document_name
         ORDER BY

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/latestConsistentSnapshotNoGroupBy.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/latestConsistentSnapshotNoGroupBy.txt
@@ -25,4 +25,5 @@ FROM
 WHERE
   NOT is_deleted
 GROUP BY
-  document_name
+  document_name,
+  document_id

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/nestedMapSchemaChangeLog.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/nestedMapSchemaChangeLog.txt
@@ -1,9 +1,10 @@
 SELECT
   document_name,
+  document_id,
   timestamp,
   operation,
   `test.test_dataset.firestoreNumber`(
-    JSON_EXTRACT(data, '$.super.nested.schema.value')
+    JSON_EXTRACT_SCALAR(data, '$.super.nested.schema.value')
   ) AS super_nested_schema_value
 FROM
   `test.test_dataset.test_table`

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/referenceSchema.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/referenceSchema.txt
@@ -1,8 +1,9 @@
 SELECT
   document_name,
+  document_id,
   timestamp,
   operation,
-  JSON_EXTRACT(data, '$.reference') AS reference,
-  JSON_EXTRACT(data, '$.map.reference') AS map_reference
+  JSON_EXTRACT_SCALAR(data, '$.reference') AS reference,
+  JSON_EXTRACT_SCALAR(data, '$.map.reference') AS map_reference
 FROM
   `test.test_dataset.test_table`

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
@@ -237,6 +237,7 @@ export const buildSchemaViewQuery = (
   let query = `
     SELECT
       document_name,
+      document_id,
       timestamp,
       operation${fieldValueSelectorClauses.length > 0 ? `,` : ``}
       ${fieldValueSelectorClauses}
@@ -423,7 +424,7 @@ const processLeafField = (
     case "array":
       selector = firestoreArray(
         datasetId,
-        jsonExtractScalar(dataFieldName, extractPrefix, field, ``, transformer)
+        jsonExtract(dataFieldName, extractPrefix, field, ``, transformer)
       );
       break;
     case "boolean":

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
@@ -113,12 +113,14 @@ export const buildLatestSchemaSnapshotViewQuery = (
   let query = `
       SELECT
         document_name,
+        document_id,
         timestamp,
         operation${fieldNameSelectorClauses.length > 0 ? `,` : ``}
         ${fieldNameSelectorClauses}
       FROM (
         SELECT
           document_name,
+          document_id,
           ${firstValue(`timestamp`)} AS timestamp,
           ${firstValue(`operation`)} AS operation,
           ${firstValue(`operation`)} = "DELETE" AS is_deleted${
@@ -139,6 +141,7 @@ export const buildLatestSchemaSnapshotViewQuery = (
   const groupBy = `
     GROUP BY
       document_name,
+      document_id,
       timestamp,
       operation${groupableExtractors.length > 0 ? `,` : ``}
       ${


### PR DESCRIPTION
- Creates a `document_id` column when using the `gen-schema-view` script.

Created a view with `document_id` column.
![Screenshot 2020-07-07 at 15 20 14](https://user-images.githubusercontent.com/16018629/86798637-e76c7d00-c068-11ea-9b19-aaacae86c53a.png)
