### PR TITLE
feat(firestore-bigquery-export): import script imports document id

### DIFF
--- a/firestore-bigquery-export/scripts/import/src/index.ts
+++ b/firestore-bigquery-export/scripts/import/src/index.ts
@@ -203,6 +203,7 @@ const run = async (): Promise<number> => {
         documentName: `projects/${projectId}/databases/${FIRESTORE_DEFAULT_DATABASE}/documents/${
           snapshot.ref.path
         }`,
+        documentId: snapshot.id,
         eventId: "",
         data: snapshot.data(),
       };


### PR DESCRIPTION

![Screenshot 2020-07-07 at 16 25 19](https://user-images.githubusercontent.com/16018629/86805332-b3488a80-c06f-11ea-88ea-a20a68687ca1.png)

After running `import` script the `document_id` column appears in the view:
- `document_id` column for the `firestore-bigquery-export` `import` script.