### PR TITLE
Bump version for firestore-bigquery-export

### DIFF
--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-bigquery-export
-version: 0.1.6
+version: 0.1.7
 specVersion: v1beta
 
 displayName: Export Collections to BigQuery


### PR DESCRIPTION
firestore-bigquery-export needs to be version-bumped, so that consumers who have installed instances can be notified via Console UI to update.