### PR TITLE
Bump firestore-bigquery-export version

### DIFF
--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-bigquery-export
-version: 0.1.6
+version: 0.1.7
 specVersion: v1beta
 
 displayName: Export Collections to BigQuery

--- a/firestore-bigquery-export/package.json
+++ b/firestore-bigquery-export/package.json
@@ -13,7 +13,7 @@
   "author": "Jan Wyszynski <wyszynski@google.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.6",
+    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.10",
     "@google-cloud/bigquery": "^2.1.0",
     "@types/chai": "^4.1.6",
     "chai": "^4.2.0",


### PR DESCRIPTION
firestore-bigquery-export needs to be version-bumped, so that consumers who have installed instances can be notified via Console UI to update.