### PR TITLE
feat(firestore-bigquery-export): Add validation regex for collection path parameter.

### DIFF
--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -98,7 +98,7 @@ params:
     type: string
     example: posts
     validationRegex: "^[^/]+(/[^/]+/[^/]+)*$"
-    validationErrorMessage: Must be a valid Cloud Firestore Collection.
+    validationErrorMessage: Firestore collection paths must be an odd number of segments separated by slashes, e.g. "path/to/collection".
     default: posts
     required: true
 

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -98,7 +98,7 @@ params:
     type: string
     example: posts
     validationRegex: "^[^/]+(/[^/]+/[^/]+)*$"
-    validationErrorMessage: Must be a valid Cloud Firestore Collection
+    validationErrorMessage: Must be a valid Cloud Firestore Collection.
     default: posts
     required: true
 

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -97,6 +97,8 @@ params:
       collection (for example: `chatrooms/{chatid}/posts`).
     type: string
     example: posts
+    validationRegex: "^[^/]+(/[^/]+/[^/]+)*$"
+    validationErrorMessage: Must be a valid Cloud Firestore Collection
     default: posts
     required: true
 


### PR DESCRIPTION
fixes https://github.com/firebase/extensions/issues/410

- `firestore-bigquery-export` was the only extension without a regex for its Firestore collection path param.

Attempts at odd number of path segments:
![Screenshot 2020-08-10 at 14 24 32](https://user-images.githubusercontent.com/16018629/89787717-dc988280-db15-11ea-9d95-b856e2fc7d69.png)
