### PR TITLE
fix(firestore-bigquery-export): update "gen-schema-view" script to not hide data rows

### DIFF
--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/arraysNestedInMapsSchema.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/arraysNestedInMapsSchema.txt
@@ -12,5 +12,5 @@ FROM
     FROM
       `test.test_dataset.test_table`
   ) test_table
-  CROSS JOIN UNNEST(test_table.map_array) AS map_array_member WITH OFFSET map_array_index
-  CROSS JOIN UNNEST(test_table.map2_array) AS map2_array_member WITH OFFSET map2_array_index
+  LEFT JOIN UNNEST(test_table.map_array) AS map_array_member WITH OFFSET map_array_index
+  LEFT JOIN UNNEST(test_table.map2_array) AS map2_array_member WITH OFFSET map2_array_index

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/emptySchemaLatestFromView.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/emptySchemaLatestFromView.txt
@@ -21,4 +21,4 @@ FROM
     FROM
       `test.test_dataset.test_table_latest`
   ) test_table_latest
-  CROSS JOIN UNNEST(test_table_latest.favorite_numbers) AS favorite_numbers_member WITH OFFSET favorite_numbers_index
+  LEFT JOIN UNNEST(test_table_latest.favorite_numbers) AS favorite_numbers_member WITH OFFSET favorite_numbers_index

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaChangeLog.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaChangeLog.txt
@@ -21,4 +21,4 @@ FROM
     FROM
       `test.test_dataset.test_table`
   ) test_table
-  CROSS JOIN UNNEST(test_table.favorite_numbers) AS favorite_numbers_member WITH OFFSET favorite_numbers_index
+  LEFT JOIN UNNEST(test_table.favorite_numbers) AS favorite_numbers_member WITH OFFSET favorite_numbers_index

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaLatest.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaLatest.txt
@@ -94,7 +94,7 @@ FROM
     WHERE
       NOT is_deleted
   ) test_table
-  CROSS JOIN UNNEST(test_table.favorite_numbers) AS favorite_numbers_member WITH OFFSET favorite_numbers_index
+  LEFT JOIN UNNEST(test_table.favorite_numbers) AS favorite_numbers_member WITH OFFSET favorite_numbers_index
 GROUP BY
   document_name,
   document_id,

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaLatestFromView.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaLatestFromView.txt
@@ -21,4 +21,4 @@ FROM
     FROM
       `test.test_dataset.test_table_latest`
   ) test_table_latest
-  CROSS JOIN UNNEST(test_table_latest.favorite_numbers) AS favorite_numbers_member WITH OFFSET favorite_numbers_index
+  LEFT JOIN UNNEST(test_table_latest.favorite_numbers) AS favorite_numbers_member WITH OFFSET favorite_numbers_index

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaLatestLatestFromView.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaLatestLatestFromView.txt
@@ -21,4 +21,4 @@ FROM
     FROM
       `test.test_dataset.test_table_latest`
   ) test_table_latest
-  CROSS JOIN UNNEST(test_table_latest.favorite_numbers) AS favorite_numbers_member WITH OFFSET favorite_numbers_index
+  LEFT JOIN UNNEST(test_table_latest.favorite_numbers) AS favorite_numbers_member WITH OFFSET favorite_numbers_index

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaSquared.txt
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaSquared.txt
@@ -32,5 +32,5 @@ FROM
     FROM
       `test.test_dataset.test_table`
   ) test_table
-  CROSS JOIN UNNEST(test_table.schema1_favorite_numbers) AS schema1_favorite_numbers_member WITH OFFSET schema1_favorite_numbers_index
-  CROSS JOIN UNNEST(test_table.schema2_favorite_numbers) AS schema2_favorite_numbers_member WITH OFFSET schema2_favorite_numbers_index
+  LEFT JOIN UNNEST(test_table.schema1_favorite_numbers) AS schema1_favorite_numbers_member WITH OFFSET schema1_favorite_numbers_index
+  LEFT JOIN UNNEST(test_table.schema2_favorite_numbers) AS schema2_favorite_numbers_member WITH OFFSET schema2_favorite_numbers_index

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
@@ -246,7 +246,7 @@ export const buildSchemaViewQuery = (
   `;
   if (schemaHasArrays) {
     /**
-     * If the schema we are generating has arrays, we perform a CROSS JOIN with
+     * If the schema we are generating has arrays, we perform a LEFT JOIN with
      * the result of UNNESTing each array so that each document ends up with N
      * rows, one for each of N members of it's contained array. Each of these
      * rows contains an additional index column and a corresponding member
@@ -258,7 +258,7 @@ export const buildSchemaViewQuery = (
     query = `${subSelectQuery(query)} ${rawTableName} ${fieldArrays
       .map(
         (arrayFieldName) =>
-          `CROSS JOIN UNNEST(${rawTableName}.${arrayFieldName})
+          `LEFT JOIN UNNEST(${rawTableName}.${arrayFieldName})
        AS ${arrayFieldName}_member
        WITH OFFSET ${arrayFieldName}_index`
       )

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
@@ -161,7 +161,7 @@ export const buildLatestSchemaSnapshotViewQuery = (
           .map(
             (
               arrayFieldName
-            ) => `CROSS JOIN UNNEST(${rawTableName}.${arrayFieldName})
+            ) => `LEFT JOIN UNNEST(${rawTableName}.${arrayFieldName})
             AS ${arrayFieldName}_member
             WITH OFFSET ${arrayFieldName}_index`
           )


### PR DESCRIPTION
fixes #298 

- Switched from a `CROSS JOIN` to a `LEFT JOIN` SQL query. 
- This PR only affects the `gen-schema-view` script.

The `LEFT JOIN` will not hide a row if an array in the table is empty:
![Screenshot 2020-09-02 at 11 23 39](https://user-images.githubusercontent.com/16018629/91970092-10c72380-ed0f-11ea-95ac-43889fa8e654.png)

As can be noted below, the rows for `Viva_Parker63@gmail.com` & `Laurence_Heaney65@hotmail.com` rows are missing when using a `CROSS JOIN`:
![Screenshot 2020-09-02 at 11 23 09](https://user-images.githubusercontent.com/16018629/91970255-49ff9380-ed0f-11ea-8cdd-738ef1dcd52d.png)
