### PR TITLE
fix(release): use placeholder changelog entry when changelog file does not exist

### DIFF
--- a/.github/workflows/scripts/release.sh
+++ b/.github/workflows/scripts/release.sh
@@ -167,7 +167,7 @@ for i in $(find . -type f -name 'extension.yaml' -exec dirname {} \; | sort -u);
 
   changelog_contents="No changelog found for this version."
 
-  # Ensure changelog exists exists
+  # Ensure changelog exists
   if [ -f "$i/CHANGELOG.md" ]; then
     # Pluck out change log contents for the latest extension version
     changelog_contents=$(awk -v ver="$extension_version" '/^## Version / { if (p) { exit }; if ($3 == ver) { p=1; next} } p && NF' "$i/CHANGELOG.md")

--- a/.github/workflows/scripts/release.sh
+++ b/.github/workflows/scripts/release.sh
@@ -10,7 +10,7 @@ set -o pipefail
 # -------------------
 #      Functions
 # -------------------
-json_escape () {
+json_escape() {
   printf '%s' "$1" | python -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
 }
 
@@ -19,38 +19,38 @@ json_escape () {
 #     1: Name of the release (becomes the release title on GitHub)
 #     2: Markdown body of the release
 #     3: Release Git tag
-create_github_release(){
+create_github_release() {
   local response=''
   local release_name=$1
   local release_body=$2
   local release_tag=$3
 
-	local body='{
-	  "tag_name": "%s",
-	  "target_commitish": "master",
-	  "name": "%s",
-	  "body": %s,
-	  "draft": false,
-	  "prerelease": false
-	}'
+  local body='{
+    "tag_name": "%s",
+    "target_commitish": "master",
+    "name": "%s",
+    "body": %s,
+    "draft": false,
+    "prerelease": false
+  }'
 
   # shellcheck disable=SC2059
   body=$(printf "$body" "$release_tag" "$release_name" "$release_body")
-	response=$(curl --request POST \
-	  --url https://api.github.com/repos/${GITHUB_REPOSITORY}/releases \
-	  --header "Authorization: Bearer $GITHUB_TOKEN" \
-	  --header 'Content-Type: application/json' \
-	  --data "$body" \
-	  -s)
+  response=$(curl --request POST \
+    --url https://api.github.com/repos/${GITHUB_REPOSITORY}/releases \
+    --header "Authorization: Bearer $GITHUB_TOKEN" \
+    --header 'Content-Type: application/json' \
+    --data "$body" \
+    -s)
 
-	created=$(echo "$response" | python -c "import sys, json; data = json.load(sys.stdin); print(data.get('id', sys.stdin))")
-	if [ "$created" != "$response" ]; then
+  created=$(echo "$response" | python -c "import sys, json; data = json.load(sys.stdin); print(data.get('id', sys.stdin))")
+  if [ "$created" != "$response" ]; then
     printf "release created successfully!\n"
   else
     printf "release failed to create; "
     printf "\n%s\n" "$body"
     printf "\n%s\n" "$response"
-    exit 1;
+    exit 1
   fi
 }
 
@@ -60,14 +60,14 @@ create_github_release(){
 #     2: Markdown body of the release
 #     3: Release Git tag
 #     4: ID of the existing release
-update_github_release(){
+update_github_release() {
   local response=''
   local release_name=$1
   local release_body=$2
   local release_tag=$3
   local release_id=$4
 
-	local body='{
+  local body='{
 	  "tag_name": "%s",
 	  "target_commitish": "master",
 	  "name": "%s",
@@ -78,21 +78,21 @@ update_github_release(){
 
   # shellcheck disable=SC2059
   body=$(printf "$body" "$release_tag" "$release_name" "$release_body")
-	response=$(curl --request PATCH \
-	  --url "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/$release_id" \
-	  --header "Authorization: Bearer $GITHUB_TOKEN" \
-	  --header 'Content-Type: application/json' \
-	  --data "$body" \
-	  -s)
+  response=$(curl --request PATCH \
+    --url "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/$release_id" \
+    --header "Authorization: Bearer $GITHUB_TOKEN" \
+    --header 'Content-Type: application/json' \
+    --data "$body" \
+    -s)
 
-	updated=$(echo "$response" | python -c "import sys, json; data = json.load(sys.stdin); print(data.get('id', sys.stdin))")
-	if [ "$updated" != "$response" ]; then
+  updated=$(echo "$response" | python -c "import sys, json; data = json.load(sys.stdin); print(data.get('id', sys.stdin))")
+  if [ "$updated" != "$response" ]; then
     printf "release updated successfully!\n"
   else
     printf "release failed to update; "
     printf "\n%s\n" "$body"
     printf "\n%s\n" "$response"
-    exit 1;
+    exit 1
   fi
 }
 
@@ -134,7 +134,7 @@ create_or_update_github_release() {
     if [ "$response_message" != "Not Found" ]; then
       echo "Failed to query release '$release_name' -> GitHub API request failed with response: $response_message"
       echo "$response"
-      exit 1;
+      exit 1
     else
       printf "Creating new release '%s' ... " "$release_tag"
       create_github_release "$release_name" "$release_body" "$release_tag"
@@ -180,9 +180,10 @@ for i in $(find . -type f -name 'extension.yaml' -exec dirname {} \; | sort -u);
   extension_version=$(awk '/^version: /' "$i/extension.yaml" | sed "s/version: //")
 
   # TODO(salakar): Remove once this is no longer outputting logs.
-  case "${SKIP_EXTENSION_VERSIONS[@]}" in  *"$extension_name $extension_version"*)
+  case "${SKIP_EXTENSION_VERSIONS[@]}" in *"$extension_name $extension_version"*)
     echo "Skipping $extension_name version $extension_version"
     continue
+    ;;
   esac
 
   # Pluck out change log contents for the latest extension version

--- a/.github/workflows/scripts/release.sh
+++ b/.github/workflows/scripts/release.sh
@@ -165,10 +165,19 @@ for i in $(find . -type f -name 'extension.yaml' -exec dirname {} \; | sort -u);
   # Pluck extension latest version from yaml file
   extension_version=$(awk '/^version: /' "$i/extension.yaml" | sed "s/version: //")
 
-  # Pluck out change log contents for the latest extension version
-  changelog_contents=$(awk -v ver="$extension_version" '/^## Version / { if (p) { exit }; if ($3 == ver) { p=1; next} } p && NF' "$i/CHANGELOG.md")
+  changelog_contents="No changelog found for this version."
+
+  # Ensure changelog exists exists
+  if [ -f "$i/CHANGELOG.md" ]; then
+    # Pluck out change log contents for the latest extension version
+    changelog_contents=$(awk -v ver="$extension_version" '/^## Version / { if (p) { exit }; if ($3 == ver) { p=1; next} } p && NF' "$i/CHANGELOG.md")
+  else
+    echo "WARNING: A changelog could not be found at $i/CHANGELOG.md - a default entry will be used instead."
+  fi
+
   # JSON escape the markdown content for the release body
   changelog_contents=$(json_escape "$changelog_contents")
+
   # Creates a new release if it does not exist
   #   OR
   # Updates an existing release with updated content (allows updating CHANGELOG.md which will update relevant release body)

--- a/.github/workflows/scripts/release.sh
+++ b/.github/workflows/scripts/release.sh
@@ -158,33 +158,12 @@ if [[ -z "$GITHUB_REPOSITORY" ]]; then
   exit 1
 fi
 
-# TODO(salakar): Extensions & Versions to temporarily skip release checks.
-# TODO(salakar): Remove once no more 'skipping' logs on CI.
-SKIP_EXTENSION_VERSIONS=(
-  "auth-mailchimp-sync 0.1.0"
-  "delete-user-data 0.1.4"
-  "firestore-bigquery-export 0.1.5"
-  "firestore-counter 0.1.3"
-  "firestore-send-email 0.1.4"
-  "firestore-shorten-urls-bitly 0.1.3"
-  "firestore-translate-text 0.1.2"
-  "rtdb-limit-child-nodes 0.1.0"
-  "storage-resize-images 0.1.7"
-)
-
 # Find all extensions based on whether a extension.yaml file exists in the directory
 for i in $(find . -type f -name 'extension.yaml' -exec dirname {} \; | sort -u); do
   # Pluck extension name from directory name
   extension_name=$(echo "$i" | sed "s/\.\///")
   # Pluck extension latest version from yaml file
   extension_version=$(awk '/^version: /' "$i/extension.yaml" | sed "s/version: //")
-
-  # TODO(salakar): Remove once this is no longer outputting logs.
-  case "${SKIP_EXTENSION_VERSIONS[@]}" in *"$extension_name $extension_version"*)
-    echo "Skipping $extension_name version $extension_version"
-    continue
-    ;;
-  esac
 
   # Pluck out change log contents for the latest extension version
   changelog_contents=$(awk -v ver="$extension_version" '/^## Version / { if (p) { exit }; if ($3 == ver) { p=1; next} } p && NF' "$i/CHANGELOG.md")


### PR DESCRIPTION
Fixes an issue where if an extension does not have a `CHANGELOG.md` file the script would error and exit ([example](https://github.com/firebase/extensions/runs/1097667905#step:3:12)).

![image](https://user-images.githubusercontent.com/5347038/93208460-82ae5c80-f754-11ea-9293-02a8329af5aa.png)

Additionally made the following changes (see individual commits):

 - formatted the script
 - removed temporary version skipping logic as it's now no longer required as each extension has since had a release.

### Testing

Tested all 3 scenarios (release already exists, changelog could not be found, new release):

![image](https://user-images.githubusercontent.com/5347038/93208785-036d5880-f755-11ea-9865-a7f4fe546d67.png)

Testing releases can be seen here: https://github.com/invertase/extensions-release-testing/releases

![image](https://user-images.githubusercontent.com/5347038/93209000-59da9700-f755-11ea-82ab-f7701807e62a.png)

![image](https://user-images.githubusercontent.com/5347038/93209021-619a3b80-f755-11ea-9766-e60e920afa21.png)
