### PR TITLE
docs(firestore-bigquery-export): delete query

### DIFF
--- a/firestore-bigquery-export/guides/EXAMPLE_QUERIES.md
+++ b/firestore-bigquery-export/guides/EXAMPLE_QUERIES.md
@@ -111,10 +111,12 @@ WHERE favorite_numbers_index = 0
 
 ### Remove stale data from your changelog table
 
-If you wish to clean up the data from your `changelog` table, use the following `DELETE` query to provide
-a range of time against the `timestamp` column, and delete the requisite rows.
+If you want to clean up data from your `changelog` table, use the following
+`DELETE` query to delete the rows that fall within a range of timestamps.
 
 ```sql
-/* the first WHERE query is the start of the time range, the second WHERE query is the end of the time range. The below deletes every row in a 24 hour time frame on the 4th September, 2020*/
+/* The first WHERE clause is the start of the time range, and the second WHERE
+   clause is the end of the time range. The query below deletes every row in a
+   24-hour time frame on the 4th September, 2020. */
 DELETE FROM `[PROJECT ID].[DATASET ID].[CHANGELOG TABLE ID]` WHERE '2020-09-04 00:00:00' < timestamp AND '2020-09-05 00:00:00' > timestamp
 ```

--- a/firestore-bigquery-export/guides/EXAMPLE_QUERIES.md
+++ b/firestore-bigquery-export/guides/EXAMPLE_QUERIES.md
@@ -55,7 +55,7 @@ schema file:
 
 You can generate a listing of users that have logged in to the app as follows:
 
-```
+```sql
 SELECT name, last_login
 FROM ${param:PROJECT_ID}.${param:DATASET_ID}.${param:TABLE_ID}_schema_${SCHEMA_FILE_NAME}_latest
 ORDER BY last_login DESC
@@ -81,7 +81,7 @@ queries for that data:
 - If you wanted to determine how many favorite numbers each user
   currently has, then you can run the following query:
 
-  ```
+  ```sql
   SELECT document_name, MAX(favorite_numbers_index)
   FROM ${param:PROJECT_ID}.users.users_schema_user_full_schema_latest
   GROUP BY document_name
@@ -91,7 +91,7 @@ queries for that data:
   of the app's users (assuming that number is stored in the first position of
   the `favorite_numbers` array), you can run the following query:
 
-  ```
+  ```sql
   SELECT document_name, favorite_numbers_member
   FROM ${param:PROJECT_ID}.users.users_schema_user_full_schema_latest
   WHERE favorite_numbers_index = 0
@@ -103,8 +103,19 @@ If you had multiple arrays in the schema configuration, you might have to select
 all `DISTINCT` documents to eliminate the redundant rows introduced by the
 cartesian product of `CROSS JOIN`.
 
-```
+```sql
 SELECT DISTINCT document_name, favorite_numbers_member
 FROM ${param:PROJECT_ID}.users.users_schema_user_full_schema_latest
 WHERE favorite_numbers_index = 0
+```
+
+
+### Remove stale data from your changelog table
+
+If you wish to clean up the data from your `changelog` table, use the following `DELETE` query to provide
+a range of time against the `timestamp` column, and delete the requisite rows.
+
+```sql
+/* the first WHERE query is the start of the time range, the second WHERE query is the end of the time range */
+DELETE FROM `[PROJECT ID].[DATASET ID].[CHANGELOG TABLE ID]` WHERE '2020-09-04 00:00:00' < timestamp AND '2020-09-05 00:00:00' > timestamp
 ```

--- a/firestore-bigquery-export/guides/EXAMPLE_QUERIES.md
+++ b/firestore-bigquery-export/guides/EXAMPLE_QUERIES.md
@@ -116,6 +116,6 @@ If you wish to clean up the data from your `changelog` table, use the following 
 a range of time against the `timestamp` column, and delete the requisite rows.
 
 ```sql
-/* the first WHERE query is the start of the time range, the second WHERE query is the end of the time range */
+/* the first WHERE query is the start of the time range, the second WHERE query is the end of the time range. The below deletes every row in a 24 hour time frame on the 4th September, 2020*/
 DELETE FROM `[PROJECT ID].[DATASET ID].[CHANGELOG TABLE ID]` WHERE '2020-09-04 00:00:00' < timestamp AND '2020-09-05 00:00:00' > timestamp
 ```

--- a/firestore-bigquery-export/guides/EXAMPLE_QUERIES.md
+++ b/firestore-bigquery-export/guides/EXAMPLE_QUERIES.md
@@ -109,7 +109,6 @@ FROM ${param:PROJECT_ID}.users.users_schema_user_full_schema_latest
 WHERE favorite_numbers_index = 0
 ```
 
-
 ### Remove stale data from your changelog table
 
 If you wish to clean up the data from your `changelog` table, use the following `DELETE` query to provide


### PR DESCRIPTION
fixes #444 

Provide example of how to delete rows in the changelog table generated by the `firestore-bigquery-export` table