### PR TITLE
test(rtdb-limit-child-nodes): use emulator for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 node_modules/
 *.env
 firebase-debug.log
+database-debug.log
+ui-debug.log
 .DS_Store
 mods-test-data/key.json
 .gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 install:
   - npm install -g codecov
+  - npm install -g firebase-tools
   - npm install
 
 node_js:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test-watch": "jest --watch",
     "test-coverage": "jest --coverage",
     "postinstall": "lerna bootstrap --no-ci && npm run clean && npm run build",
-    "generate-readmes": "lerna run --parallel --ignore delete-user-data generate-readme"
+    "generate-readmes": "lerna run --parallel --ignore delete-user-data generate-readme",
+    "emulators": "lerna run --parallel emulator"
   },
   "repository": "",
   "author": "Firebase (https://firebase.google.com/)",

--- a/rtdb-limit-child-nodes/extension.yaml
+++ b/rtdb-limit-child-nodes/extension.yaml
@@ -55,7 +55,7 @@ resources:
       runtime: nodejs10
       eventTrigger:
         eventType: providers/google.firebase.database/eventTypes/ref.create
-        resource: projects/_/instances/${param:DATABASE_INSTANCE}/refs/${param:NODE_PATH}/{messageid}
+        resource: projects/_/instances/${DATABASE_INSTANCE}/refs/${NODE_PATH}/{messageid}
 
 params:
   - param: LOCATION

--- a/rtdb-limit-child-nodes/functions/__tests__/__snapshots__/functions.test.ts.snap
+++ b/rtdb-limit-child-nodes/functions/__tests__/__snapshots__/functions.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`extension functions configuration detected from environment variables 1`] = `
+Object {
+  "location": "europe-west2",
+  "maxCount": 2,
+  "nodePath": "test_path",
+}
+`;

--- a/rtdb-limit-child-nodes/functions/__tests__/emulator/.firebaserc
+++ b/rtdb-limit-child-nodes/functions/__tests__/emulator/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "extensions-testing"
+  }
+}

--- a/rtdb-limit-child-nodes/functions/__tests__/emulator/database.rules.json
+++ b/rtdb-limit-child-nodes/functions/__tests__/emulator/database.rules.json
@@ -1,0 +1,8 @@
+{
+  "rules": {
+		"test_path": {
+      ".read": true,
+      ".write": true
+    }
+  }
+}

--- a/rtdb-limit-child-nodes/functions/__tests__/emulator/firebase.json
+++ b/rtdb-limit-child-nodes/functions/__tests__/emulator/firebase.json
@@ -1,0 +1,9 @@
+{
+  "database": {
+    "rules": "database.rules.json"
+  },
+  "functions": {
+    "source": "../..",
+    "predeploy": "npm --prefix \"$RESOURCE_DIR\" run build"
+  }
+}

--- a/rtdb-limit-child-nodes/functions/__tests__/emulator/run-emulator.sh
+++ b/rtdb-limit-child-nodes/functions/__tests__/emulator/run-emulator.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+if ! [ -x "$(command -v firebase)" ]; then
+  echo "❌ Firebase tools CLI is missing."
+  exit 1
+fi
+# TODO check out the firebase CLI, there are options for ext emulators
+# firebase emulators:start &

--- a/rtdb-limit-child-nodes/functions/__tests__/functions.test.ts
+++ b/rtdb-limit-child-nodes/functions/__tests__/functions.test.ts
@@ -1,0 +1,12 @@
+import functionsConfig from "../src/config";
+import * as exportedFunctions from "../src";
+
+describe("extension", () => {
+  test("functions configuration detected from environment variables", async () => {
+    expect(functionsConfig).toMatchSnapshot();
+  });
+
+  test("functions are exported", async () => {
+    expect(exportedFunctions.rtdblimit).toBeInstanceOf(Function);
+  });
+});

--- a/rtdb-limit-child-nodes/functions/jest.config.js
+++ b/rtdb-limit-child-nodes/functions/jest.config.js
@@ -5,4 +5,6 @@ module.exports = {
   displayName: packageJson.name,
   rootDir: "./",
   preset: "ts-jest",
+  globalSetup: "<rootDir>/jest.setup.js",
+  testMatch: ["**/__tests__/*.test.ts"],
 };

--- a/rtdb-limit-child-nodes/functions/jest.setup.js
+++ b/rtdb-limit-child-nodes/functions/jest.setup.js
@@ -1,0 +1,7 @@
+module.exports = async function() {
+  process.env = Object.assign(process.env, {
+    LOCATION: "europe-west2",
+    MAX_COUNT: 2,
+    NODE_PATH: "test_path",
+  });
+};

--- a/rtdb-limit-child-nodes/functions/package.json
+++ b/rtdb-limit-child-nodes/functions/package.json
@@ -6,13 +6,14 @@
     "build": "npm run clean && npm run compile",
     "clean": "rimraf lib",
     "compile": "tsc",
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "generate-readme": "firebase ext:info .. --markdown > ../README.md"
+    "test": "jest",
+    "generate-readme": "firebase ext:info .. --markdown > ../README.md",
+    "emulator": "cd ./__tests__/emulator && ./run-emulator.sh"
   },
   "license": "Apache-2.0",
   "dependencies": {
     "firebase-admin": "^8.0.0",
-    "firebase-functions": "^3.9.0"
+    "firebase-functions": "^3.11.0"
   },
   "devDependencies": {
     "rimraf": "^2.6.3",


### PR DESCRIPTION
**WIP**

### notes
- `path` property on [Reference](https://firebase.google.com/docs/reference/node/firebase.database.Reference#parent) is deprecated so it has been removed.