### PR TITLE
chore(firestore-bigquery-export): revert firebase-admin dependency back to v8

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/logs.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/logs.ts
@@ -137,7 +137,7 @@ export const dataInserted = (rowCount: number) => {
 
 export const dataInsertRetried = (rowCount: number) => {
   logger.log(
-    `Retried to insert ${rowCount} row(s) of data into BigQuery (ignoring uknown columns)`
+    `Retried to insert ${rowCount} row(s) of data into BigQuery (ignoring unknown columns)`
   );
 };
 

--- a/firestore-bigquery-export/functions/package.json
+++ b/firestore-bigquery-export/functions/package.json
@@ -17,7 +17,7 @@
     "@google-cloud/bigquery": "^2.1.0",
     "@types/chai": "^4.1.6",
     "chai": "^4.2.0",
-    "firebase-admin": "^9.1.0",
+    "firebase-admin": "^8.1.0",
     "firebase-functions": "^3.9.0",
     "firebase-functions-test": "^0.2.2",
     "generate-schema": "^2.6.0",


### PR DESCRIPTION
Downgrade `firebase-admin` in `firestore-bigquery-export` extension to stop it from breaking the tests. Some types have changed and may need to be updated, or the big query test script for inserting data will have to be changed, and the `not-in` query removed.