### PR TITLE
fix(delete-user-data): storage bucket param

### DIFF
--- a/delete-user-data/functions/lib/config.js
+++ b/delete-user-data/functions/lib/config.js
@@ -21,5 +21,6 @@ exports.default = {
     firestoreDeleteMode: process.env.FIRESTORE_DELETE_MODE,
     rtdbPaths: process.env.RTDB_PATHS,
     storagePaths: process.env.STORAGE_PATHS,
+    storageBucketDefault: process.env.STORAGE_BUCKET,
     SELECTED_DATABASE_INSTANCE: process.env.SELECTED_DATABASE_INSTANCE,
 };

--- a/delete-user-data/functions/lib/index.js
+++ b/delete-user-data/functions/lib/index.js
@@ -84,7 +84,7 @@ const clearStorageData = async (storagePaths, uid) => {
         const parts = path.split("/");
         const bucketName = parts[0];
         const bucket = bucketName === "{DEFAULT}"
-            ? admin.storage().bucket()
+            ? admin.storage().bucket(config_1.default.storageBucketDefault)
             : admin.storage().bucket(bucketName);
         const prefix = parts.slice(1).join("/");
         try {

--- a/delete-user-data/functions/src/config.ts
+++ b/delete-user-data/functions/src/config.ts
@@ -20,5 +20,6 @@ export default {
   firestoreDeleteMode: process.env.FIRESTORE_DELETE_MODE,
   rtdbPaths: process.env.RTDB_PATHS,
   storagePaths: process.env.STORAGE_PATHS,
+  storageBucketDefault: process.env.STORAGE_BUCKET,
   SELECTED_DATABASE_INSTANCE: process.env.SELECTED_DATABASE_INSTANCE,
 };

--- a/delete-user-data/functions/src/index.ts
+++ b/delete-user-data/functions/src/index.ts
@@ -93,7 +93,7 @@ const clearStorageData = async (storagePaths: string, uid: string) => {
     const bucketName = parts[0];
     const bucket =
       bucketName === "{DEFAULT}"
-        ? admin.storage().bucket()
+        ? admin.storage().bucket(config.storageBucketDefault)
         : admin.storage().bucket(bucketName);
     const prefix = parts.slice(1).join("/");
     try {


### PR DESCRIPTION
fixes #531 

Here is a log of the `{DEFAULT}/testext/{UID}.jpg` being deleted:
![Screenshot 2020-12-14 at 15 42 53](https://user-images.githubusercontent.com/16018629/102102079-507bcc00-3e23-11eb-8df8-38a80c5d2f61.png)


I also spent some time trying to run the emulator for this extension. The cloud function emulator ran as expected, the auth emulator did not. I'll create an issue on the `firestore-tools` repository. 