### PR TITLE
docs(storage-resize-images): explicit content type

### DIFF
--- a/storage-resize-images/POSTINSTALL.md
+++ b/storage-resize-images/POSTINSTALL.md
@@ -33,7 +33,46 @@ The extension also copies the following [metadata](https://cloud.google.com/stor
 
 Be aware of the following when using this extension:
 
-- Each original image must have a valid [image MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#Image_types) specified in its [`Content-Type` metadata](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Type) (for example, `image/png`).
+- Each original image must have a valid [image MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#Image_types) specified in its [`Content-Type` metadata](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Type) (for example, `image/png`). Below is a list of the content types supported by this extension:
+  * image/jpeg
+  * image/png
+  * image/tiff
+  * image/webp
+
+If you are using raw image data in your application, you need to ensure you set the correct content type when uploading to the Firebase Storage bucket to trigger the extension image resize. Here's an example:
+
+```js
+
+const admin = require("firebase-admin");
+const serviceAccount = require("../path-to-service-account.json");
+
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount),
+});
+
+const storage = admin.storage();
+
+// rawImage param is the binary data read from the file system or downloaded from URL
+function uploadImageToStorage(rawImage){
+  const bucket = storage.bucket("YOUR FIREBASE STORAGE BUCKET URL");
+  const file = bucket.file("filename.jpeg");
+
+  file.save(
+    rawImage,
+    {
+      //Set the content type to ensure the extension triggers the image resize(s)
+      metadata: { contentType: "image/jpeg" },
+    },
+    (error) => {
+      if (error) {
+        throw error;
+      }
+      console.log("Sucessfully uploaded image");
+    }
+  );
+}
+
+```
 
 - If you configured the `Cache-Control header for resized images` parameter, your specified value will overwrite the value copied from the original image. Learn more about image metadata in the [Cloud Storage documentation](https://firebase.google.com/docs/storage/).
 

--- a/storage-resize-images/POSTINSTALL.md
+++ b/storage-resize-images/POSTINSTALL.md
@@ -59,7 +59,7 @@ function uploadImageToStorage(rawImage){
   file.save(
     rawImage,
     {
-      //Set the content type to ensure the extension triggers the image resize(s)
+      // set the content type to ensure the extension triggers the image resize(s)
       metadata: { contentType: "image/jpeg" },
     },
     (error) => {
@@ -70,7 +70,6 @@ function uploadImageToStorage(rawImage){
     }
   );
 }
-
 ```
 
 - If you configured the `Cache-Control header for resized images` parameter, your specified value will overwrite the value copied from the original image. Learn more about image metadata in the [Cloud Storage documentation](https://firebase.google.com/docs/storage/).

--- a/storage-resize-images/POSTINSTALL.md
+++ b/storage-resize-images/POSTINSTALL.md
@@ -39,10 +39,9 @@ Be aware of the following when using this extension:
   * image/tiff
   * image/webp
 
-If you are using raw image data in your application, you need to ensure you set the correct content type when uploading to the Firebase Storage bucket to trigger the extension image resize. Here's an example:
+If you are using raw image data in your application, you need to ensure you set the correct content type when uploading to the Firebase Storage bucket to trigger the extension image resize. Below is an example of how to set the content type:
 
 ```js
-
 const admin = require("firebase-admin");
 const serviceAccount = require("../path-to-service-account.json");
 


### PR DESCRIPTION
fixes #530

documents setting content type explicitly and which content types are supported by `storage-resize-images` extension