### PR TITLE
docs(firestore-bigquery-export): collectionGroup import script documentation improvement

### DIFF
--- a/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
+++ b/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
@@ -17,13 +17,17 @@ You may pause and resume the import script from the last batch at any point.
   - If document changes occur in the time between installing the extension and running the import script.
   - If you run the import script multiple times over the same collection.
 
+- You cannot use wildcard notation in the collection path (i.e. `/collection/{document}/sub_collection}`). It is possible to perform a [collectionGroup](https://firebase.google.com/docs/firestore/query-data/queries#collection-group-query) query. 
+
+To use a collectionGroup query, provide the collection name value as the `${COLLECTION_PATH}`, and set `${COLLECTION_GROUP_QUERY}` value to `true`. Warning: A collectionGroup will target every collection in your Firestore project with the `${COLLECTION_PATH}` value as its name. For example, if you have 10,000 documents with a sub-collection named: `landmarks`, the import script will import every document in those 10,000 `landmark` collections.
+
 ### Run the script
 
 The import script uses several values from your installation of the extension:
 
 - `${PROJECT_ID}`: the project ID for the Firebase project in which you installed the extension
 - `${COLLECTION_PATH}`: the collection path that you specified during extension installation
-- `${BOOLEAN}`: Confirmation you would like to use a `collectionGroup` query. Reverts to a `collection` query if the value is `false`.
+- `${COLLECTION_GROUP_QUERY}`: Confirmation you would like to use a `collectionGroup` query. Reverts to a `collection` query if the value is `false`.
 - `${DATASET_ID}`: the ID that you specified for your dataset during extension installation
 
 Run the import script using [`npx` (the Node Package Runner)](https://www.npmjs.com/package/npx) via `npm` (the Node Package Manager).

--- a/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
+++ b/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
@@ -18,7 +18,7 @@ You may pause and resume the import script from the last batch at any point.
   - If you run the import script multiple times over the same collection.
 
 - You cannot use wildcard notation in the collection path (i.e. `/collection/{document}/sub_collection}`). Instead, you can use a [collectionGroup](https://firebase.google.com/docs/firestore/query-data/queries#collection-group-query) query. To use a `collectionGroup` query, provide the collection name value as `${COLLECTION_PATH}`, and set `${COLLECTION_GROUP_QUERY}` to `true`.
-  
+
   Warning: A `collectionGroup` query will target every collection in your Firestore project with the provided `${COLLECTION_PATH}`. For example, if you have 10,000 documents with a sub-collection named: `landmarks`, the import script will query every document in 10,000 `landmarks` collections.
 
 ### Run the script

--- a/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
+++ b/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
@@ -17,9 +17,9 @@ You may pause and resume the import script from the last batch at any point.
   - If document changes occur in the time between installing the extension and running the import script.
   - If you run the import script multiple times over the same collection.
 
-- You cannot use wildcard notation in the collection path (i.e. `/collection/{document}/sub_collection}`). It is possible to perform a [collectionGroup](https://firebase.google.com/docs/firestore/query-data/queries#collection-group-query) query.
-
-To use a `collectionGroup` query, provide the collection name value as `${COLLECTION_PATH}`, and set `${COLLECTION_GROUP_QUERY}` value to `true`. Warning: A `collectionGroup` query will target every collection in your Firestore project with the provided `${COLLECTION_PATH}`. For example, if you have 10,000 documents with a sub-collection named: `landmarks`, the import script will query every document in 10,000 `landmarks` collections.
+- You cannot use wildcard notation in the collection path (i.e. `/collection/{document}/sub_collection}`). Instead, you can use a [collectionGroup](https://firebase.google.com/docs/firestore/query-data/queries#collection-group-query) query. To use a `collectionGroup` query, provide the collection name value as `${COLLECTION_PATH}`, and set `${COLLECTION_GROUP_QUERY}` to `true`.
+  
+  Warning: A `collectionGroup` query will target every collection in your Firestore project with the provided `${COLLECTION_PATH}`. For example, if you have 10,000 documents with a sub-collection named: `landmarks`, the import script will query every document in 10,000 `landmarks` collections.
 
 ### Run the script
 

--- a/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
+++ b/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
@@ -19,7 +19,7 @@ You may pause and resume the import script from the last batch at any point.
 
 - You cannot use wildcard notation in the collection path (i.e. `/collection/{document}/sub_collection}`). It is possible to perform a [collectionGroup](https://firebase.google.com/docs/firestore/query-data/queries#collection-group-query) query. 
 
-To use a collectionGroup query, provide the collection name value as the `${COLLECTION_PATH}`, and set `${COLLECTION_GROUP_QUERY}` value to `true`. Warning: A collectionGroup will target every collection in your Firestore project with the `${COLLECTION_PATH}` value as its name. For example, if you have 10,000 documents with a sub-collection named: `landmarks`, the import script will import every document in those 10,000 `landmark` collections.
+To use a `collectionGroup` query, provide the collection name value as the `${COLLECTION_PATH}`, and set `${COLLECTION_GROUP_QUERY}` value to `true`. Warning: A `collectionGroup`  will target every collection in your Firestore project with the provided `${COLLECTION_PATH}` value. For example, if you have 10,000 documents with a sub-collection named: `landmarks`, the import script will query every document in 10,000 `landmark` collections.
 
 ### Run the script
 

--- a/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
+++ b/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
@@ -19,7 +19,7 @@ You may pause and resume the import script from the last batch at any point.
 
 - You cannot use wildcard notation in the collection path (i.e. `/collection/{document}/sub_collection}`). It is possible to perform a [collectionGroup](https://firebase.google.com/docs/firestore/query-data/queries#collection-group-query) query. 
 
-To use a `collectionGroup` query, provide the collection name value as `${COLLECTION_PATH}`, and set `${COLLECTION_GROUP_QUERY}` value to `true`. Warning: A `collectionGroup`  will target every collection in your Firestore project with the provided `${COLLECTION_PATH}` value. For example, if you have 10,000 documents with a sub-collection named: `landmarks`, the import script will query every document in 10,000 `landmark` collections.
+To use a `collectionGroup` query, provide the collection name value as `${COLLECTION_PATH}`, and set `${COLLECTION_GROUP_QUERY}` value to `true`. Warning: A `collectionGroup` query  will target every collection in your Firestore project with the provided `${COLLECTION_PATH}`. For example, if you have 10,000 documents with a sub-collection named: `landmarks`, the import script will query every document in 10,000 `landmark` collections.
 
 ### Run the script
 

--- a/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
+++ b/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
@@ -19,7 +19,7 @@ You may pause and resume the import script from the last batch at any point.
 
 - You cannot use wildcard notation in the collection path (i.e. `/collection/{document}/sub_collection}`). It is possible to perform a [collectionGroup](https://firebase.google.com/docs/firestore/query-data/queries#collection-group-query) query. 
 
-To use a `collectionGroup` query, provide the collection name value as `${COLLECTION_PATH}`, and set `${COLLECTION_GROUP_QUERY}` value to `true`. Warning: A `collectionGroup` query  will target every collection in your Firestore project with the provided `${COLLECTION_PATH}`. For example, if you have 10,000 documents with a sub-collection named: `landmarks`, the import script will query every document in 10,000 `landmark` collections.
+To use a `collectionGroup` query, provide the collection name value as `${COLLECTION_PATH}`, and set `${COLLECTION_GROUP_QUERY}` value to `true`. Warning: A `collectionGroup` query  will target every collection in your Firestore project with the provided `${COLLECTION_PATH}`. For example, if you have 10,000 documents with a sub-collection named: `landmarks`, the import script will query every document in 10,000 `landmarks` collections.
 
 ### Run the script
 

--- a/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
+++ b/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
@@ -19,7 +19,7 @@ You may pause and resume the import script from the last batch at any point.
 
 - You cannot use wildcard notation in the collection path (i.e. `/collection/{document}/sub_collection}`). It is possible to perform a [collectionGroup](https://firebase.google.com/docs/firestore/query-data/queries#collection-group-query) query. 
 
-To use a `collectionGroup` query, provide the collection name value as the `${COLLECTION_PATH}`, and set `${COLLECTION_GROUP_QUERY}` value to `true`. Warning: A `collectionGroup`  will target every collection in your Firestore project with the provided `${COLLECTION_PATH}` value. For example, if you have 10,000 documents with a sub-collection named: `landmarks`, the import script will query every document in 10,000 `landmark` collections.
+To use a `collectionGroup` query, provide the collection name value as `${COLLECTION_PATH}`, and set `${COLLECTION_GROUP_QUERY}` value to `true`. Warning: A `collectionGroup`  will target every collection in your Firestore project with the provided `${COLLECTION_PATH}` value. For example, if you have 10,000 documents with a sub-collection named: `landmarks`, the import script will query every document in 10,000 `landmark` collections.
 
 ### Run the script
 

--- a/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
+++ b/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
@@ -17,9 +17,9 @@ You may pause and resume the import script from the last batch at any point.
   - If document changes occur in the time between installing the extension and running the import script.
   - If you run the import script multiple times over the same collection.
 
-- You cannot use wildcard notation in the collection path (i.e. `/collection/{document}/sub_collection}`). It is possible to perform a [collectionGroup](https://firebase.google.com/docs/firestore/query-data/queries#collection-group-query) query. 
+- You cannot use wildcard notation in the collection path (i.e. `/collection/{document}/sub_collection}`). It is possible to perform a [collectionGroup](https://firebase.google.com/docs/firestore/query-data/queries#collection-group-query) query.
 
-To use a `collectionGroup` query, provide the collection name value as `${COLLECTION_PATH}`, and set `${COLLECTION_GROUP_QUERY}` value to `true`. Warning: A `collectionGroup` query  will target every collection in your Firestore project with the provided `${COLLECTION_PATH}`. For example, if you have 10,000 documents with a sub-collection named: `landmarks`, the import script will query every document in 10,000 `landmarks` collections.
+To use a `collectionGroup` query, provide the collection name value as `${COLLECTION_PATH}`, and set `${COLLECTION_GROUP_QUERY}` value to `true`. Warning: A `collectionGroup` query will target every collection in your Firestore project with the provided `${COLLECTION_PATH}`. For example, if you have 10,000 documents with a sub-collection named: `landmarks`, the import script will query every document in 10,000 `landmarks` collections.
 
 ### Run the script
 

--- a/firestore-counter/POSTINSTALL.md
+++ b/firestore-counter/POSTINSTALL.md
@@ -19,8 +19,9 @@ match /databases/{database}/documents/pages/{page} {
 }
 ```
 
-
 #### Specify a document path and increment value in your web app
+
+##### Web Client
 
 1.  Download and copy the [compiled client sample](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/dist/sharded-counter.js) into your application project.
 
@@ -60,6 +61,54 @@ match /databases/{database}/documents/pages/{page} {
   </html>
   ```
 
+##### Android Client
+
+1. Follow the Firebase android setup [guide](https://firebase.google.com/docs/android/setup) in order to use Firebase in your app.
+
+1. Copy and paste the sample [code](https://github.com/firebase/extensions/blob/next/firestore-counter/clients/android/src/main/java/com/firebase/firestore/counter/FirestoreShardedCounter.java) and create this file  `FirestoreShardedCounter.java` in the relevant directory you wish to use the `FirestoreShardedCounter` instance.
+
+```java
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.EventListener;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.FirebaseFirestoreException;
+import com.google.firebase.firestore.ListenerRegistration;
+
+
+// somewhere in your app code initialize Firestore instance
+FirebaseFirestore db = FirebaseFirestore.getInstance();
+// create reference to the collection and the document you wish to use 
+DocumentReference doc = db.collection("pages").document("hello-world");
+// initialize FirestoreShardedCounter with the document and the property which will hold the counter value
+FirestoreShardedCounter visits = new FirestoreShardedCounter(doc, "visits");
+
+// to increment counter
+visits.incrementBy(1);
+
+// listen for updates
+EventListener<Double> snapshotListener = new EventListener<Double>(){
+  @Override
+  public void onEvent(@Nullable Double value, @Nullable FirebaseFirestoreException error) {
+    // 'value' param is total amount of pages visits
+  }
+};
+ListenerRegistration registration = visits.onSnapshot(snapshotListener);
+// clean up event listeners once finished
+registration.remove();
+
+// make one time call to query total amount of visits
+double totalVisits = visits.get();
+
+// if you don't mind counter delays, you can listen to the document directly.
+db.document("pages/hello-world").addSnapshotListener(new EventListener<DocumentSnapshot>() {
+  @Override
+  public void onEvent(@Nullable DocumentSnapshot value, @Nullable FirebaseFirestoreException error) {
+    // total page visits
+    double pageVisits = (double) value.get("visits");
+  }
+});
+```
 
 #### Upgrading from v0.1.3 and earlier
 

--- a/firestore-counter/POSTINSTALL.md
+++ b/firestore-counter/POSTINSTALL.md
@@ -19,9 +19,8 @@ match /databases/{database}/documents/pages/{page} {
 }
 ```
 
-#### Specify a document path and increment value in your web app
 
-##### Web Client
+#### Specify a document path and increment value in your web app
 
 1.  Download and copy the [compiled client sample](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/dist/sharded-counter.js) into your application project.
 
@@ -61,54 +60,6 @@ match /databases/{database}/documents/pages/{page} {
   </html>
   ```
 
-##### Android Client
-
-1. Follow the Firebase android setup [guide](https://firebase.google.com/docs/android/setup) in order to use Firebase in your app.
-
-1. Copy and paste the sample [code](https://github.com/firebase/extensions/blob/next/firestore-counter/clients/android/src/main/java/com/firebase/firestore/counter/FirestoreShardedCounter.java) and create this file  `FirestoreShardedCounter.java` in the relevant directory you wish to use the `FirestoreShardedCounter` instance.
-
-```java
-import com.google.firebase.firestore.DocumentReference;
-import com.google.firebase.firestore.DocumentSnapshot;
-import com.google.firebase.firestore.EventListener;
-import com.google.firebase.firestore.FirebaseFirestore;
-import com.google.firebase.firestore.FirebaseFirestoreException;
-import com.google.firebase.firestore.ListenerRegistration;
-
-
-// somewhere in your app code initialize Firestore instance
-FirebaseFirestore db = FirebaseFirestore.getInstance();
-// create reference to the collection and the document you wish to use 
-DocumentReference doc = db.collection("pages").document("hello-world");
-// initialize FirestoreShardedCounter with the document and the property which will hold the counter value
-FirestoreShardedCounter visits = new FirestoreShardedCounter(doc, "visits");
-
-// to increment counter
-visits.incrementBy(1);
-
-// listen for updates
-EventListener<Double> snapshotListener = new EventListener<Double>(){
-  @Override
-  public void onEvent(@Nullable Double value, @Nullable FirebaseFirestoreException error) {
-    // 'value' param is total amount of pages visits
-  }
-};
-ListenerRegistration registration = visits.onSnapshot(snapshotListener);
-// clean up event listeners once finished
-registration.remove();
-
-// make one time call to query total amount of visits
-double totalVisits = visits.get();
-
-// if you don't mind counter delays, you can listen to the document directly.
-db.document("pages/hello-world").addSnapshotListener(new EventListener<DocumentSnapshot>() {
-  @Override
-  public void onEvent(@Nullable DocumentSnapshot value, @Nullable FirebaseFirestoreException error) {
-    // total page visits
-    double pageVisits = (double) value.get("visits");
-  }
-});
-```
 
 #### Upgrading from v0.1.3 and earlier
 


### PR DESCRIPTION
fixes #501

Make documentation a bit more explicit about how to use a `collectionGroup` query when backfilling data into your BigQuery table.