### PR TITLE
fix(storage-resize-images): capitalised file extensions

### DIFF
--- a/storage-resize-images/functions/lib/resize-image.js
+++ b/storage-resize-images/functions/lib/resize-image.js
@@ -78,7 +78,7 @@ exports.modifyImage = async ({ bucket, originalFile, fileDir, fileNameWithoutExt
         : contentType;
     const modifiedExtensionName = fileExtension && hasImageTypeConfigSet ? `.${imageType}` : fileExtension;
     let modifiedFileName;
-    if (supportedExtensions.includes(fileExtension)) {
+    if (supportedExtensions.includes(fileExtension.toLowerCase())) {
         modifiedFileName = `${fileNameWithoutExtension}_${size}${modifiedExtensionName}`;
     }
     else {

--- a/storage-resize-images/functions/src/resize-image.ts
+++ b/storage-resize-images/functions/src/resize-image.ts
@@ -107,7 +107,7 @@ export const modifyImage = async ({
 
   let modifiedFileName;
 
-  if (supportedExtensions.includes(fileExtension)) {
+  if (supportedExtensions.includes(fileExtension.toLowerCase())) {
     modifiedFileName = `${fileNameWithoutExtension}_${size}${modifiedExtensionName}`;
   } else {
     // Fixes https://github.com/firebase/extensions/issues/476


### PR DESCRIPTION
fixes #544

Logs of image resize:
![Screenshot 2020-12-29 at 10 51 54](https://user-images.githubusercontent.com/16018629/103278669-fa328f80-49c3-11eb-87fe-de5f071c7463.png)


Image as it appears in the storage bucket with extension appended correctly:
![Screenshot 2020-12-29 at 10 52 10](https://user-images.githubusercontent.com/16018629/103278702-0e768c80-49c4-11eb-8312-ab382ce57df8.png)
