### PR TITLE
chore(storage-resize-images): use cloud function logger

### DIFF
--- a/storage-resize-images/functions/lib/logs.js
+++ b/storage-resize-images/functions/lib/logs.js
@@ -22,7 +22,7 @@ exports.complete = () => {
     firebase_functions_1.logger.log("Completed execution of extension");
 };
 exports.noContentType = () => {
-    firebase_functions_1.logger.log(`File has no Content-Type, no processing is required`);
+    firebase_functions_1.logger.log("File has no Content-Type, no processing is required");
 };
 exports.gzipContentEncoding = () => {
     firebase_functions_1.logger.log("Images encoded with 'gzip' are not supported by this extension");
@@ -40,16 +40,16 @@ exports.errorDeleting = (err) => {
     firebase_functions_1.logger.warn("Error when deleting temporary files", err);
 };
 exports.failed = () => {
-    firebase_functions_1.logger.log("Failed execution of extension");
+    firebase_functions_1.logger.error("Failed execution of extension");
 };
 exports.imageAlreadyResized = () => {
     firebase_functions_1.logger.log("File is already a resized image, no processing is required");
 };
 exports.imageOutsideOfPaths = (absolutePaths, imagePath) => {
-    console.log(`Image path '${imagePath}' is not supported, these are the supported absolute paths: ${absolutePaths.join(", ")}`);
+    firebase_functions_1.logger.log(`Image path '${imagePath}' is not supported, these are the supported absolute paths: ${absolutePaths.join(", ")}`);
 };
 exports.imageInsideOfExcludedPaths = (absolutePaths, imagePath) => {
-    console.log(`Image path '${imagePath}' is not supported, these are the not supported absolute paths: ${absolutePaths.join(", ")}`);
+    firebase_functions_1.logger.log(`Image path '${imagePath}' is not supported, these are the not supported absolute paths: ${absolutePaths.join(", ")}`);
 };
 exports.imageDownloaded = (remotePath, localPath) => {
     firebase_functions_1.logger.log(`Downloaded image file: '${remotePath}' to '${localPath}'`);
@@ -58,10 +58,10 @@ exports.imageDownloading = (path) => {
     firebase_functions_1.logger.log(`Downloading image file: '${path}'`);
 };
 exports.imageConverting = (originalImageType, imageType) => {
-    console.log(`Converting image from type, ${originalImageType}, to type ${imageType}.`);
+    firebase_functions_1.logger.log(`Converting image from type, ${originalImageType}, to type ${imageType}.`);
 };
 exports.imageConverted = (imageType) => {
-    console.log(`Converted image to ${imageType}`);
+    firebase_functions_1.logger.log(`Converted image to ${imageType}`);
 };
 exports.imageResized = (path) => {
     firebase_functions_1.logger.log(`Resized image created at '${path}'`);

--- a/storage-resize-images/functions/src/logs.ts
+++ b/storage-resize-images/functions/src/logs.ts
@@ -22,7 +22,7 @@ export const complete = () => {
 };
 
 export const noContentType = () => {
-  logger.log(`File has no Content-Type, no processing is required`);
+  logger.log("File has no Content-Type, no processing is required");
 };
 
 export const gzipContentEncoding = () => {
@@ -55,7 +55,7 @@ export const errorDeleting = (err: Error) => {
 };
 
 export const failed = () => {
-  logger.log("Failed execution of extension");
+  logger.error("Failed execution of extension");
 };
 
 export const imageAlreadyResized = () => {
@@ -66,7 +66,7 @@ export const imageOutsideOfPaths = (
   absolutePaths: string[],
   imagePath: string
 ) => {
-  console.log(
+  logger.log(
     `Image path '${imagePath}' is not supported, these are the supported absolute paths: ${absolutePaths.join(
       ", "
     )}`
@@ -77,7 +77,7 @@ export const imageInsideOfExcludedPaths = (
   absolutePaths: string[],
   imagePath: string
 ) => {
-  console.log(
+  logger.log(
     `Image path '${imagePath}' is not supported, these are the not supported absolute paths: ${absolutePaths.join(
       ", "
     )}`
@@ -96,13 +96,13 @@ export const imageConverting = (
   originalImageType: string,
   imageType: string
 ) => {
-  console.log(
+  logger.log(
     `Converting image from type, ${originalImageType}, to type ${imageType}.`
   );
 };
 
 export const imageConverted = (imageType: string) => {
-  console.log(`Converted image to ${imageType}`);
+  logger.log(`Converted image to ${imageType}`);
 };
 
 export const imageResized = (path: string) => {


### PR DESCRIPTION
`storage-resize-images` audit of cloud function logger. Partial resolution of #543.

Logs of successful resize:
![Screenshot 2021-01-05 at 12 19 27](https://user-images.githubusercontent.com/16018629/103645682-51021100-4f50-11eb-8bd0-51269225875b.png)
