### PR TITLE
chore(firestore-bigquery-export): use firebase-functions logger

### DIFF
--- a/firestore-bigquery-export/functions/__tests__/__mocks__/console.ts
+++ b/firestore-bigquery-export/functions/__tests__/__mocks__/console.ts
@@ -1,5 +1,7 @@
-export const mockConsoleLog = jest.spyOn(console, "log").mockImplementation();
+import { logger } from "firebase-functions";
+
+export const mockConsoleLog = jest.spyOn(logger, "log").mockImplementation();
 
 export const mockConsoleError = jest
-  .spyOn(console, "error")
+  .spyOn(logger, "error")
   .mockImplementation();

--- a/firestore-bigquery-export/functions/__tests__/functions.test.ts
+++ b/firestore-bigquery-export/functions/__tests__/functions.test.ts
@@ -1,3 +1,4 @@
+import { logger } from "firebase-functions";
 import * as functionsTestInit from "../node_modules/firebase-functions-test";
 import mockedEnv from "../node_modules/mocked-env";
 
@@ -20,11 +21,11 @@ jest.mock("@firebaseextensions/firestore-bigquery-change-tracker", () => ({
 
 jest.mock("../src/logs", () => ({
   start: jest.fn(() =>
-    console.log("Started execution of extension with configuration", config)
+    logger.log("Started execution of extension with configuration", config)
   ),
   init: jest.fn(() => {}),
   error: jest.fn(() => {}),
-  complete: jest.fn(() => console.log("Completed execution of extension")),
+  complete: jest.fn(() => logger.log("Completed execution of extension")),
 }));
 
 const defaultEnvironment = {

--- a/firestore-bigquery-export/functions/lib/logs.js
+++ b/firestore-bigquery-export/functions/lib/logs.js
@@ -1,4 +1,6 @@
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.timestampMissingValue = exports.start = exports.init = exports.error = exports.dataTypeInvalid = exports.dataInserting = exports.dataInserted = exports.complete = exports.bigQueryViewValidating = exports.bigQueryViewValidated = exports.bigQueryViewUpToDate = exports.bigQueryViewUpdating = exports.bigQueryViewUpdated = exports.bigQueryViewAlreadyExists = exports.bigQueryViewCreating = exports.bigQueryViewCreated = exports.bigQueryUserDefinedFunctionCreated = exports.bigQueryUserDefinedFunctionCreating = exports.bigQueryTableValidating = exports.bigQueryTableValidated = exports.bigQueryTableUpToDate = exports.bigQueryTableUpdating = exports.bigQueryTableUpdated = exports.bigQueryTableCreating = exports.bigQueryTableCreated = exports.bigQueryTableAlreadyExists = exports.bigQueryLatestSnapshotViewQueryCreated = exports.bigQueryErrorRecordingDocumentChange = exports.bigQueryDatasetExists = exports.bigQueryDatasetCreating = exports.bigQueryDatasetCreated = exports.arrayFieldInvalid = void 0;
 /*
  * Copyright 2019 Google LLC
  *
@@ -14,103 +16,102 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.timestampMissingValue = exports.start = exports.init = exports.error = exports.dataTypeInvalid = exports.dataInserting = exports.dataInserted = exports.complete = exports.bigQueryViewValidating = exports.bigQueryViewValidated = exports.bigQueryViewUpToDate = exports.bigQueryViewUpdating = exports.bigQueryViewUpdated = exports.bigQueryViewAlreadyExists = exports.bigQueryViewCreating = exports.bigQueryViewCreated = exports.bigQueryUserDefinedFunctionCreated = exports.bigQueryUserDefinedFunctionCreating = exports.bigQueryTableValidating = exports.bigQueryTableValidated = exports.bigQueryTableUpToDate = exports.bigQueryTableUpdating = exports.bigQueryTableUpdated = exports.bigQueryTableCreating = exports.bigQueryTableCreated = exports.bigQueryTableAlreadyExists = exports.bigQueryLatestSnapshotViewQueryCreated = exports.bigQueryErrorRecordingDocumentChange = exports.bigQueryDatasetExists = exports.bigQueryDatasetCreating = exports.bigQueryDatasetCreated = exports.arrayFieldInvalid = void 0;
+const firebase_functions_1 = require("firebase-functions");
 const config_1 = require("./config");
 exports.arrayFieldInvalid = (fieldName) => {
-    console.warn(`Array field '${fieldName}' does not contain an array, skipping`);
+    firebase_functions_1.logger.warn(`Array field '${fieldName}' does not contain an array, skipping`);
 };
 exports.bigQueryDatasetCreated = (datasetId) => {
-    console.log(`Created BigQuery dataset: ${datasetId}`);
+    firebase_functions_1.logger.log(`Created BigQuery dataset: ${datasetId}`);
 };
 exports.bigQueryDatasetCreating = (datasetId) => {
-    console.log(`Creating BigQuery dataset: ${datasetId}`);
+    firebase_functions_1.logger.log(`Creating BigQuery dataset: ${datasetId}`);
 };
 exports.bigQueryDatasetExists = (datasetId) => {
-    console.log(`BigQuery dataset already exists: ${datasetId}`);
+    firebase_functions_1.logger.log(`BigQuery dataset already exists: ${datasetId}`);
 };
 exports.bigQueryErrorRecordingDocumentChange = (e) => {
-    console.error(`Error recording document changes.`, e);
+    firebase_functions_1.logger.error(`Error recording document changes.`, e);
 };
 exports.bigQueryLatestSnapshotViewQueryCreated = (query) => {
-    console.log(`BigQuery latest snapshot view query:\n${query}`);
+    firebase_functions_1.logger.log(`BigQuery latest snapshot view query:\n${query}`);
 };
 exports.bigQueryTableAlreadyExists = (tableName, datasetName) => {
-    console.log(`BigQuery table with name ${tableName} already ` +
+    firebase_functions_1.logger.log(`BigQuery table with name ${tableName} already ` +
         `exists in dataset ${datasetName}!`);
 };
 exports.bigQueryTableCreated = (tableName) => {
-    console.log(`Created BigQuery table: ${tableName}`);
+    firebase_functions_1.logger.log(`Created BigQuery table: ${tableName}`);
 };
 exports.bigQueryTableCreating = (tableName) => {
-    console.log(`Creating BigQuery table: ${tableName}`);
+    firebase_functions_1.logger.log(`Creating BigQuery table: ${tableName}`);
 };
 exports.bigQueryTableUpdated = (tableName) => {
-    console.log(`Updated existing BigQuery table: ${tableName}`);
+    firebase_functions_1.logger.log(`Updated existing BigQuery table: ${tableName}`);
 };
 exports.bigQueryTableUpdating = (tableName) => {
-    console.log(`Updating existing BigQuery table: ${tableName}`);
+    firebase_functions_1.logger.log(`Updating existing BigQuery table: ${tableName}`);
 };
 exports.bigQueryTableUpToDate = (tableName) => {
-    console.log(`BigQuery table: ${tableName} is up to date`);
+    firebase_functions_1.logger.log(`BigQuery table: ${tableName} is up to date`);
 };
 exports.bigQueryTableValidated = (tableName) => {
-    console.log(`Validated existing BigQuery table: ${tableName}`);
+    firebase_functions_1.logger.log(`Validated existing BigQuery table: ${tableName}`);
 };
 exports.bigQueryTableValidating = (tableName) => {
-    console.log(`Validating existing BigQuery table: ${tableName}`);
+    firebase_functions_1.logger.log(`Validating existing BigQuery table: ${tableName}`);
 };
 exports.bigQueryUserDefinedFunctionCreating = (functionDefinition) => {
-    console.log(`Creating BigQuery User-defined Function:\n${functionDefinition}`);
+    firebase_functions_1.logger.log(`Creating BigQuery User-defined Function:\n${functionDefinition}`);
 };
 exports.bigQueryUserDefinedFunctionCreated = (functionDefinition) => {
-    console.log(`Created BigQuery User-defined Function:\n${functionDefinition}`);
+    firebase_functions_1.logger.log(`Created BigQuery User-defined Function:\n${functionDefinition}`);
 };
 exports.bigQueryViewCreated = (viewName) => {
-    console.log(`Created BigQuery view: ${viewName}`);
+    firebase_functions_1.logger.log(`Created BigQuery view: ${viewName}`);
 };
 exports.bigQueryViewCreating = (viewName) => {
-    console.log(`Creating BigQuery view: ${viewName}`);
+    firebase_functions_1.logger.log(`Creating BigQuery view: ${viewName}`);
 };
 exports.bigQueryViewAlreadyExists = (viewName, datasetName) => {
-    console.log(`View with id ${viewName} already exists in dataset ${datasetName}.`);
+    firebase_functions_1.logger.log(`View with id ${viewName} already exists in dataset ${datasetName}.`);
 };
 exports.bigQueryViewUpdated = (viewName) => {
-    console.log(`Updated existing BigQuery view: ${viewName}`);
+    firebase_functions_1.logger.log(`Updated existing BigQuery view: ${viewName}`);
 };
 exports.bigQueryViewUpdating = (viewName) => {
-    console.log(`Updating existing BigQuery view: ${viewName}`);
+    firebase_functions_1.logger.log(`Updating existing BigQuery view: ${viewName}`);
 };
 exports.bigQueryViewUpToDate = (viewName) => {
-    console.log(`BigQuery view: ${viewName} is up to date`);
+    firebase_functions_1.logger.log(`BigQuery view: ${viewName} is up to date`);
 };
 exports.bigQueryViewValidated = (viewName) => {
-    console.log(`Validated existing BigQuery view: ${viewName}`);
+    firebase_functions_1.logger.log(`Validated existing BigQuery view: ${viewName}`);
 };
 exports.bigQueryViewValidating = (viewName) => {
-    console.log(`Validating existing BigQuery view: ${viewName}`);
+    firebase_functions_1.logger.log(`Validating existing BigQuery view: ${viewName}`);
 };
 exports.complete = () => {
-    console.log("Completed execution of extension");
+    firebase_functions_1.logger.log("Completed execution of extension");
 };
 exports.dataInserted = (rowCount) => {
-    console.log(`Inserted ${rowCount} row(s) of data into BigQuery`);
+    firebase_functions_1.logger.log(`Inserted ${rowCount} row(s) of data into BigQuery`);
 };
 exports.dataInserting = (rowCount) => {
-    console.log(`Inserting ${rowCount} row(s) of data into BigQuery`);
+    firebase_functions_1.logger.log(`Inserting ${rowCount} row(s) of data into BigQuery`);
 };
 exports.dataTypeInvalid = (fieldName, fieldType, dataType) => {
-    console.warn(`Field '${fieldName}' has invalid data. Expected: ${fieldType}, received: ${dataType}`);
+    firebase_functions_1.logger.warn(`Field '${fieldName}' has invalid data. Expected: ${fieldType}, received: ${dataType}`);
 };
 exports.error = (err) => {
-    console.error("Error when mirroring data to BigQuery", err);
+    firebase_functions_1.logger.error("Error when mirroring data to BigQuery", err);
 };
 exports.init = () => {
-    console.log("Initializing extension with configuration", config_1.default);
+    firebase_functions_1.logger.log("Initializing extension with configuration", config_1.default);
 };
 exports.start = () => {
-    console.log("Started execution of extension with configuration", config_1.default);
+    firebase_functions_1.logger.log("Started execution of extension with configuration", config_1.default);
 };
 exports.timestampMissingValue = (fieldName) => {
-    console.warn(`Missing value for timestamp field: ${fieldName}, using default timestamp instead.`);
+    firebase_functions_1.logger.warn(`Missing value for timestamp field: ${fieldName}, using default timestamp instead.`);
 };

--- a/firestore-bigquery-export/functions/src/logs.ts
+++ b/firestore-bigquery-export/functions/src/logs.ts
@@ -13,77 +13,77 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import { logger } from "firebase-functions";
 import config from "./config";
 
 export const arrayFieldInvalid = (fieldName: string) => {
-  console.warn(
+  logger.warn(
     `Array field '${fieldName}' does not contain an array, skipping`
   );
 };
 
 export const bigQueryDatasetCreated = (datasetId: string) => {
-  console.log(`Created BigQuery dataset: ${datasetId}`);
+  logger.log(`Created BigQuery dataset: ${datasetId}`);
 };
 
 export const bigQueryDatasetCreating = (datasetId: string) => {
-  console.log(`Creating BigQuery dataset: ${datasetId}`);
+  logger.log(`Creating BigQuery dataset: ${datasetId}`);
 };
 
 export const bigQueryDatasetExists = (datasetId: string) => {
-  console.log(`BigQuery dataset already exists: ${datasetId}`);
+  logger.log(`BigQuery dataset already exists: ${datasetId}`);
 };
 
 export const bigQueryErrorRecordingDocumentChange = (e: Error) => {
-  console.error(`Error recording document changes.`, e);
+  logger.error(`Error recording document changes.`, e);
 };
 
 export const bigQueryLatestSnapshotViewQueryCreated = (query: string) => {
-  console.log(`BigQuery latest snapshot view query:\n${query}`);
+  logger.log(`BigQuery latest snapshot view query:\n${query}`);
 };
 
 export const bigQueryTableAlreadyExists = (
   tableName: string,
   datasetName: string
 ) => {
-  console.log(
+  logger.log(
     `BigQuery table with name ${tableName} already ` +
       `exists in dataset ${datasetName}!`
   );
 };
 
 export const bigQueryTableCreated = (tableName: string) => {
-  console.log(`Created BigQuery table: ${tableName}`);
+  logger.log(`Created BigQuery table: ${tableName}`);
 };
 
 export const bigQueryTableCreating = (tableName: string) => {
-  console.log(`Creating BigQuery table: ${tableName}`);
+  logger.log(`Creating BigQuery table: ${tableName}`);
 };
 
 export const bigQueryTableUpdated = (tableName: string) => {
-  console.log(`Updated existing BigQuery table: ${tableName}`);
+  logger.log(`Updated existing BigQuery table: ${tableName}`);
 };
 
 export const bigQueryTableUpdating = (tableName: string) => {
-  console.log(`Updating existing BigQuery table: ${tableName}`);
+  logger.log(`Updating existing BigQuery table: ${tableName}`);
 };
 
 export const bigQueryTableUpToDate = (tableName: string) => {
-  console.log(`BigQuery table: ${tableName} is up to date`);
+  logger.log(`BigQuery table: ${tableName} is up to date`);
 };
 
 export const bigQueryTableValidated = (tableName: string) => {
-  console.log(`Validated existing BigQuery table: ${tableName}`);
+  logger.log(`Validated existing BigQuery table: ${tableName}`);
 };
 
 export const bigQueryTableValidating = (tableName: string) => {
-  console.log(`Validating existing BigQuery table: ${tableName}`);
+  logger.log(`Validating existing BigQuery table: ${tableName}`);
 };
 
 export const bigQueryUserDefinedFunctionCreating = (
   functionDefinition: string
 ) => {
-  console.log(
+  logger.log(
     `Creating BigQuery User-defined Function:\n${functionDefinition}`
   );
 };
@@ -91,56 +91,56 @@ export const bigQueryUserDefinedFunctionCreating = (
 export const bigQueryUserDefinedFunctionCreated = (
   functionDefinition: string
 ) => {
-  console.log(`Created BigQuery User-defined Function:\n${functionDefinition}`);
+  logger.log(`Created BigQuery User-defined Function:\n${functionDefinition}`);
 };
 
 export const bigQueryViewCreated = (viewName: string) => {
-  console.log(`Created BigQuery view: ${viewName}`);
+  logger.log(`Created BigQuery view: ${viewName}`);
 };
 
 export const bigQueryViewCreating = (viewName: string) => {
-  console.log(`Creating BigQuery view: ${viewName}`);
+  logger.log(`Creating BigQuery view: ${viewName}`);
 };
 
 export const bigQueryViewAlreadyExists = (
   viewName: string,
   datasetName: string
 ) => {
-  console.log(
+  logger.log(
     `View with id ${viewName} already exists in dataset ${datasetName}.`
   );
 };
 
 export const bigQueryViewUpdated = (viewName: string) => {
-  console.log(`Updated existing BigQuery view: ${viewName}`);
+  logger.log(`Updated existing BigQuery view: ${viewName}`);
 };
 
 export const bigQueryViewUpdating = (viewName: string) => {
-  console.log(`Updating existing BigQuery view: ${viewName}`);
+  logger.log(`Updating existing BigQuery view: ${viewName}`);
 };
 
 export const bigQueryViewUpToDate = (viewName: string) => {
-  console.log(`BigQuery view: ${viewName} is up to date`);
+  logger.log(`BigQuery view: ${viewName} is up to date`);
 };
 
 export const bigQueryViewValidated = (viewName: string) => {
-  console.log(`Validated existing BigQuery view: ${viewName}`);
+  logger.log(`Validated existing BigQuery view: ${viewName}`);
 };
 
 export const bigQueryViewValidating = (viewName: string) => {
-  console.log(`Validating existing BigQuery view: ${viewName}`);
+  logger.log(`Validating existing BigQuery view: ${viewName}`);
 };
 
 export const complete = () => {
-  console.log("Completed execution of extension");
+  logger.log("Completed execution of extension");
 };
 
 export const dataInserted = (rowCount: number) => {
-  console.log(`Inserted ${rowCount} row(s) of data into BigQuery`);
+  logger.log(`Inserted ${rowCount} row(s) of data into BigQuery`);
 };
 
 export const dataInserting = (rowCount: number) => {
-  console.log(`Inserting ${rowCount} row(s) of data into BigQuery`);
+  logger.log(`Inserting ${rowCount} row(s) of data into BigQuery`);
 };
 
 export const dataTypeInvalid = (
@@ -148,25 +148,25 @@ export const dataTypeInvalid = (
   fieldType: string,
   dataType: string
 ) => {
-  console.warn(
+  logger.warn(
     `Field '${fieldName}' has invalid data. Expected: ${fieldType}, received: ${dataType}`
   );
 };
 
 export const error = (err: Error) => {
-  console.error("Error when mirroring data to BigQuery", err);
+  logger.error("Error when mirroring data to BigQuery", err);
 };
 
 export const init = () => {
-  console.log("Initializing extension with configuration", config);
+  logger.log("Initializing extension with configuration", config);
 };
 
 export const start = () => {
-  console.log("Started execution of extension with configuration", config);
+  logger.log("Started execution of extension with configuration", config);
 };
 
 export const timestampMissingValue = (fieldName: string) => {
-  console.warn(
+  logger.warn(
     `Missing value for timestamp field: ${fieldName}, using default timestamp instead.`
   );
 };

--- a/firestore-bigquery-export/functions/src/logs.ts
+++ b/firestore-bigquery-export/functions/src/logs.ts
@@ -17,9 +17,7 @@ import { logger } from "firebase-functions";
 import config from "./config";
 
 export const arrayFieldInvalid = (fieldName: string) => {
-  logger.warn(
-    `Array field '${fieldName}' does not contain an array, skipping`
-  );
+  logger.warn(`Array field '${fieldName}' does not contain an array, skipping`);
 };
 
 export const bigQueryDatasetCreated = (datasetId: string) => {
@@ -83,9 +81,7 @@ export const bigQueryTableValidating = (tableName: string) => {
 export const bigQueryUserDefinedFunctionCreating = (
   functionDefinition: string
 ) => {
-  logger.log(
-    `Creating BigQuery User-defined Function:\n${functionDefinition}`
-  );
+  logger.log(`Creating BigQuery User-defined Function:\n${functionDefinition}`);
 };
 
 export const bigQueryUserDefinedFunctionCreated = (


### PR DESCRIPTION
Updated `firestore-bigquery-export` extension to use `firebase-functions` logger as part of #543.

Hey @jhuleatt,  I haven't updated the `console.logs` in the BigQuery scripts as I wasn't sure it was necessary. Let me know if this is desirable and I will update.