### PR TITLE
chore(firestore-send-email): use firebase-functions logger

### DIFF
--- a/firestore-send-email/functions/lib/logs.js
+++ b/firestore-send-email/functions/lib/logs.js
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.missingUids = exports.missingDeliveryField = exports.deliveryError = exports.delivered = exports.attemptingDelivery = exports.complete = exports.error = exports.start = exports.init = exports.obfuscatedConfig = void 0;
+exports.templateLoaded = exports.partialRegistered = exports.missingUids = exports.missingDeliveryField = exports.deliveryError = exports.delivered = exports.attemptingDelivery = exports.complete = exports.error = exports.start = exports.init = exports.obfuscatedConfig = void 0;
 const config_1 = require("./config");
 const firebase_functions_1 = require("firebase-functions");
 exports.obfuscatedConfig = Object.assign({}, config_1.default, {
@@ -57,3 +57,11 @@ function missingUids(uids) {
     firebase_functions_1.logger.log(`The following uids were provided, however a document does not exist or has no 'email' field: ${uids.join(",")}`);
 }
 exports.missingUids = missingUids;
+function partialRegistered(name) {
+    firebase_functions_1.logger.log(`registered partial '${name}'`);
+}
+exports.partialRegistered = partialRegistered;
+function templateLoaded(name) {
+    firebase_functions_1.logger.log(`loaded template '${name}'`);
+}
+exports.templateLoaded = templateLoaded;

--- a/firestore-send-email/functions/lib/templates.js
+++ b/firestore-send-email/functions/lib/templates.js
@@ -20,7 +20,7 @@ const subjHandlebars = handlebars_1.create();
 const htmlHandlebars = handlebars_1.create();
 const textHandlebars = handlebars_1.create();
 const ampHandlebars = handlebars_1.create();
-const firebase_functions_1 = require("firebase-functions");
+const logs_1 = require("./logs");
 class Templates {
     constructor(collection) {
         this.collection = collection;
@@ -54,7 +54,7 @@ class Templates {
             if (p.amp) {
                 ampHandlebars.registerPartial(p.name, p.amp);
             }
-            console.log(`registered partial '${p.name}'`);
+            logs_1.partialRegistered(p.name);
         });
         templates.forEach((t) => {
             const tgroup = {};
@@ -71,7 +71,7 @@ class Templates {
                 tgroup.amp = ampHandlebars.compile(t.amp);
             }
             this.templateMap[t.name] = tgroup;
-            firebase_functions_1.logger.log(`loaded template '${t.name}'`);
+            logs_1.templateLoaded(t.name);
         });
         this.ready = true;
         this.waits.forEach((wait) => wait());

--- a/firestore-send-email/functions/src/logs.ts
+++ b/firestore-send-email/functions/src/logs.ts
@@ -80,3 +80,11 @@ export function missingUids(uids: string[]) {
     )}`
   );
 }
+
+export function partialRegistered(name) {
+  logger.log(`registered partial '${name}'`);
+}
+
+export function templateLoaded(name) {
+  logger.log(`loaded template '${name}'`);
+}

--- a/firestore-send-email/functions/src/templates.ts
+++ b/firestore-send-email/functions/src/templates.ts
@@ -23,6 +23,8 @@ const ampHandlebars = create();
 
 import { logger } from "firebase-functions";
 
+import { partialRegistered, templateLoaded } from "./logs";
+
 interface TemplateGroup {
   subject?: HandlebarsTemplateDelegate;
   html?: HandlebarsTemplateDelegate;
@@ -83,7 +85,7 @@ export default class Templates {
       if (p.amp) {
         ampHandlebars.registerPartial(p.name, p.amp);
       }
-      console.log(`registered partial '${p.name}'`);
+      partialRegistered(p.name);
     });
 
     templates.forEach((t) => {
@@ -101,7 +103,8 @@ export default class Templates {
         tgroup.amp = ampHandlebars.compile(t.amp);
       }
       this.templateMap[t.name] = tgroup;
-      logger.log(`loaded template '${t.name}'`);
+
+      templateLoaded(t.name);
     });
     this.ready = true;
     this.waits.forEach((wait) => wait());


### PR DESCRIPTION
Updated `firestore-send-email` extension to use `firebase-functions` logger as part of #543.

Log of email successfully sent (I also received as expected):
![Screenshot 2021-01-05 at 12 16 57](https://user-images.githubusercontent.com/16018629/103645519-02547700-4f50-11eb-8e97-619baf34a413.png)
