### PR TITLE
Improve Firestore path validation

### DIFF
--- a/firestore-bigquery-export/scripts/import/src/index.ts
+++ b/firestore-bigquery-export/scripts/import/src/index.ts
@@ -35,7 +35,7 @@ const read = util.promisify(fs.readFile);
 const unlink = util.promisify(fs.unlink);
 
 const BIGQUERY_VALID_CHARACTERS = /^[a-zA-Z0-9_]+$/;
-const FIRESTORE_VALID_CHARACTERS = /^[^\/]+$/;
+const FIRESTORE_VALID_CHARACTERS = /^[^({|})]+$/;
 
 const FIRESTORE_COLLECTION_NAME_MAX_CHARS = 6144;
 const BIGQUERY_RESOURCE_NAME_MAX_CHARS = 1024;


### PR DESCRIPTION
Currently, only top-level collections are allowed for the firestore collection "path", but NO subcollections.
To work around this issue @russellwheatley made a change to allow collection group queries #354.

However, in some cases, collection group queries won't work well, and manually importing specific subcollections might be required.

This PR tries to relax the restriction on the input validation.

---

Before this change, this would be allowed: `collection`
But this wouldn't be allowed: `collection/doc/subcollection` and `collection/{doc}/subcollection`

After this change, this will be allowed: `collection` and `collection/doc/subcollection`
But his wouldn't be allowed: `collection/{doc}/subcollection`