### PR TITLE
feat(storage-resize-images):wildcard in include/exclude paths

### DIFF
--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -172,12 +172,13 @@ params:
   - param: INCLUDE_PATH_LIST
     label: Paths that contain images you want to resize
     description: >
-      A comma-separated list of absolute paths. Restrict image resizes to 
-      the supplied paths. The path only has to match initially for it to be resized.
-      For example, if you supplied this path `/users/pictures`, it will resize images 
-      in  `/users/pictures/image.png` & `/users/pictures/any/sub/directory/image.png`.
-      You may also used wildcard notation for directories in the path e.g `user/*/pictures` 
-      would match `users/profile/pictures/image.png` & `users/profile/pictures/any/sub/directory/image.png` 
+      Restrict storage-resize-images to only resize images in specific locations in your Storage bucket by 
+      supplying a comma-separated list of absolute paths. For example, to only resize the images 
+      stored in the `/users/pictures` and `/restaurants/menuItems` directories, specify the paths `/users/pictures,/restaurants/menuItems`.
+      
+      You may also use wildcard notation for directories in the path. For example, `/users/*/pictures` 
+      would match `/users/profile/pictures/image.png` as well as  `/users/profile/pictures/any/sub/directory/image.png`. 
+      
       If you prefer to resize every image uploaded to the storage bucket, 
       leave this field empty.
     type: string
@@ -190,13 +191,14 @@ params:
   - param: EXCLUDE_PATH_LIST
     label: List of absolute paths not included for resized images
     description: >
-      A comma-separated list of absolute paths. Stop image resizes in 
-      the supplied paths. The path only has to match initially for it to be excluded.
-      For example, if you supplied this path `/users/pictures`, it will exclude image resizes
-      in  `/users/pictures/image.png` & `/users/pictures/any/sub/directory/image.png`.
-      You may also used wildcard notation for directories in the path e.g `user/*/pictures` 
-      would match `users/profile/pictures/image.png` & `users/profile/pictures/any/sub/directory/image.png` 
-      If you prefer to resize every image uploaded to the storage bucket, 
+      Ensure storage-resize-images does *not* resize images in _specific locations_ in your Storage bucket by 
+      supplying a comma-separated list of absolute paths. For example, to *exclude* the images 
+      stored in the `/users/pictures` and `/restaurants/menuItems` directories, specify the paths `/users/pictures,/restaurants/menuItems`.
+      
+      You may also use wildcard notation for directories in the path. For example, `/users/*/pictures` 
+      would exclude `/users/profile/pictures/image.png` as well as `/users/profile/pictures/any/sub/directory/image.png`. 
+      
+      If you prefer to resize every image uploaded to your Storage bucket, 
       leave this field empty.
     type: string
     example: "/users/avatars/thumbs,/design/pictures/thumbs"

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -172,9 +172,12 @@ params:
   - param: INCLUDE_PATH_LIST
     label: Paths that contain images you want to resize
     description: >
-      Restrict storage-resize-images to only resize images in specific locations in your Storage bucket by 
-      supplying a comma-separated list of absolute paths. For example, to only resize the images 
-      stored in `/users/pictures` directory, specify the path `/users/pictures`. 
+      A comma-separated list of absolute paths. Restrict image resizes to 
+      the supplied paths. The path only has to match initially for it to be resized.
+      For example, if you supplied this path `/users/pictures`, it will resize images 
+      in  `/users/pictures/image.png` & `/users/pictures/any/sub/directory/image.png`.
+      You may also used wildcard notation for directories in the path e.g `user/*/pictures` 
+      would match `users/profile/pictures/image.png` & `users/profile/pictures/any/sub/directory/image.png` 
       If you prefer to resize every image uploaded to the storage bucket, 
       leave this field empty.
     type: string
@@ -187,11 +190,14 @@ params:
   - param: EXCLUDE_PATH_LIST
     label: List of absolute paths not included for resized images
     description: >
-      A comma-separated list of absolute paths to not take into account for 
-      images to be resized. For example, to not resize the images 
-      stored in `/users/pictures/avatars` directory, specify the path 
-      `/users/pictures/avatars`. If you prefer to resize every image uploaded 
-      to the storage bucket, leave this field empty.
+      A comma-separated list of absolute paths. Stop image resizes in 
+      the supplied paths. The path only has to match initially for it to be excluded.
+      For example, if you supplied this path `/users/pictures`, it will exclude image resizes
+      in  `/users/pictures/image.png` & `/users/pictures/any/sub/directory/image.png`.
+      You may also used wildcard notation for directories in the path e.g `user/*/pictures` 
+      would match `users/profile/pictures/image.png` & `users/profile/pictures/any/sub/directory/image.png` 
+      If you prefer to resize every image uploaded to the storage bucket, 
+      leave this field empty.
     type: string
     example: "/users/avatars/thumbs,/design/pictures/thumbs"
     validationRegex: ^(\/[^\s\/\,]+)+(\,(\/[^\s\/\,]+)+)*$

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -179,7 +179,7 @@ params:
       You may also use wildcard notation for directories in the path. For example, `/users/*/pictures` 
       would match `/users/profile/pictures/image.png` as well as  `/users/profile/pictures/any/sub/directory/image.png`. 
       
-      If you prefer to resize every image uploaded to the storage bucket, 
+      If you prefer to resize every image uploaded to your Storage bucket, 
       leave this field empty.
     type: string
     example: "/users/avatars,/design/pictures"

--- a/storage-resize-images/functions/__tests__/util.test.ts
+++ b/storage-resize-images/functions/__tests__/util.test.ts
@@ -36,6 +36,20 @@ describe("extractFileNameWithoutExtension", () => {
         expect(allowResize).toBe(true);
       });
     });
+
+    it.only("can handle globbed paths", () => {
+      const imagePaths = ["/test/picture", "/test/*/picture"];
+      const allowed = [
+        "/test/picture",
+        "/test/something/picture",
+        "/test/folder1/folder2/picture",
+      ];
+
+      allowed.forEach((path) => {
+        let allowResize = startsWithArray(imagePaths, path);
+        expect(allowResize).toBe(true);
+      });
+    });
   });
   it("blocked paths", () => {
     const notAllowed = [

--- a/storage-resize-images/functions/__tests__/util.test.ts
+++ b/storage-resize-images/functions/__tests__/util.test.ts
@@ -37,7 +37,21 @@ describe("extractFileNameWithoutExtension", () => {
       });
     });
 
-    it("can handle globbed paths", () => {
+    it("blocked paths", () => {
+      const notAllowed = [
+        "/test",
+        "/test/pict",
+        "/test/pictures",
+        "/test/picturesssssss",
+      ];
+
+      notAllowed.forEach((path) => {
+        let allowResize = startsWithArray(imagePath, path);
+        expect(allowResize).toBe(false);
+      });
+    });
+
+    it("can handle allowed globbed paths", () => {
       const imagePaths = ["/test/picture", "/test/*/picture"];
       const allowed = [
         "/test/picture",
@@ -50,18 +64,15 @@ describe("extractFileNameWithoutExtension", () => {
         expect(allowResize).toBe(true);
       });
     });
-  });
-  it("blocked paths", () => {
-    const notAllowed = [
-      "/test",
-      "/test/pict",
-      "/test/pictures",
-      "/test/picturesssssss",
-    ];
 
-    notAllowed.forEach((path) => {
-      let allowResize = startsWithArray(imagePath, path);
-      expect(allowResize).toBe(false);
+    it("can handle not allowed globbed paths", () => {
+      const imagePaths = ["/test/picture", "/test/*/picture"];
+      const notAllowed = ["/test/*/pictures", "/test/*/folder2/pictures"];
+
+      notAllowed.forEach((path) => {
+        let allowResize = startsWithArray(imagePaths, path);
+        expect(allowResize).toBe(false);
+      });
     });
   });
 });

--- a/storage-resize-images/functions/__tests__/util.test.ts
+++ b/storage-resize-images/functions/__tests__/util.test.ts
@@ -37,7 +37,7 @@ describe("extractFileNameWithoutExtension", () => {
       });
     });
 
-    it.only("can handle globbed paths", () => {
+    it("can handle globbed paths", () => {
       const imagePaths = ["/test/picture", "/test/*/picture"];
       const allowed = [
         "/test/picture",

--- a/storage-resize-images/functions/lib/util.js
+++ b/storage-resize-images/functions/lib/util.js
@@ -7,7 +7,7 @@ exports.extractFileNameWithoutExtension = (filePath, ext) => {
 };
 exports.startsWithArray = (userInputPaths, imagePath) => {
     for (let userPath of userInputPaths) {
-        const trimmedUserPath = userPath.trim();
+        const trimmedUserPath = userPath.trim().replace(/\*/g, ".*");
         const regex = new RegExp("^" + trimmedUserPath + "(?:/.*|$)");
         if (regex.test(imagePath)) {
             return true;

--- a/storage-resize-images/functions/lib/util.js
+++ b/storage-resize-images/functions/lib/util.js
@@ -7,15 +7,11 @@ exports.extractFileNameWithoutExtension = (filePath, ext) => {
 };
 exports.startsWithArray = (userInputPaths, imagePath) => {
     for (let userPath of userInputPaths) {
-        console.warn("starting >>>", userPath, userInputPaths);
         const trimmedUserPath = userPath
             .trim()
-            .replace(/\*/g, "([a-zA-Z0-9_-.\n/]*)");
-        console.warn("Trimmed user path >>>", trimmedUserPath);
+            .replace(/\*/g, "([a-zA-Z0-9_\\-.\\s\\/]*)?");
         const regex = new RegExp("^" + trimmedUserPath + "(?:/.*|$)");
-        console.warn("testing >>>", regex, imagePath);
         if (regex.test(imagePath)) {
-            console.warn("worked >>>", regex);
             return true;
         }
     }

--- a/storage-resize-images/functions/lib/util.js
+++ b/storage-resize-images/functions/lib/util.js
@@ -7,9 +7,15 @@ exports.extractFileNameWithoutExtension = (filePath, ext) => {
 };
 exports.startsWithArray = (userInputPaths, imagePath) => {
     for (let userPath of userInputPaths) {
-        const trimmedUserPath = userPath.trim().replace(/\*/g, ".*");
+        console.warn("starting >>>", userPath, userInputPaths);
+        const trimmedUserPath = userPath
+            .trim()
+            .replace(/\*/g, "([a-zA-Z0-9_-.\n/]*)");
+        console.warn("Trimmed user path >>>", trimmedUserPath);
         const regex = new RegExp("^" + trimmedUserPath + "(?:/.*|$)");
+        console.warn("testing >>>", regex, imagePath);
         if (regex.test(imagePath)) {
+            console.warn("worked >>>", regex);
             return true;
         }
     }

--- a/storage-resize-images/functions/src/util.ts
+++ b/storage-resize-images/functions/src/util.ts
@@ -12,7 +12,10 @@ export const startsWithArray = (
   imagePath: string
 ) => {
   for (let userPath of userInputPaths) {
-    const trimmedUserPath = userPath.trim().replace(/\*/g, ".*");
+    const trimmedUserPath = userPath
+      .trim()
+      .replace(/\*/g, "([a-zA-Z0-9_\\-.\\s\\/]*)?");
+
     const regex = new RegExp("^" + trimmedUserPath + "(?:/.*|$)");
 
     if (regex.test(imagePath)) {

--- a/storage-resize-images/functions/src/util.ts
+++ b/storage-resize-images/functions/src/util.ts
@@ -12,7 +12,7 @@ export const startsWithArray = (
   imagePath: string
 ) => {
   for (let userPath of userInputPaths) {
-    const trimmedUserPath = userPath.trim();
+    const trimmedUserPath = userPath.trim().replace(/\*/g, ".*");
     const regex = new RegExp("^" + trimmedUserPath + "(?:/.*|$)");
 
     if (regex.test(imagePath)) {


### PR DESCRIPTION
fixes #560

Allow wildcard notation for directory names.

Supplied path for images I want to be resized: `/users/*/pictures`

## Include path tests

Unsuccessful upload to `/users/portraits/avatar`:
![Screenshot 2021-01-19 at 16 02 46](https://user-images.githubusercontent.com/16018629/105065299-9dcc0880-5a75-11eb-9095-7045850ce207.png)

Uploaded successfully to `/users/profile`:
![Screenshot 2021-01-19 at 16 00 44](https://user-images.githubusercontent.com/16018629/105065373-b5a38c80-5a75-11eb-845c-f762fb606bc7.png)
/pictures`:

Supplied paths for images I don't want to be resized: `/animals/*/cats,/animals/*/dogs/*/sleepy`

## Exclude path tests

Unsuccessful upload to `/animals/fluffy/dogs/large/sleepy`:
![Screenshot 2021-01-19 at 16 05 16](https://user-images.githubusercontent.com/16018629/105065560-e683c180-5a75-11eb-8c48-6e1c2d17553c.png)

Unsuccessful upload to `/animals/fluffy/cats/large/sleepy`:
![Screenshot 2021-01-19 at 16 12 14](https://user-images.githubusercontent.com/16018629/105065690-0adf9e00-5a76-11eb-94b5-b588f4877428.png)


Uploaded successfully to `/animals/fluffy/dogs/large/fast`:
![Screenshot 2021-01-19 at 16 09 18](https://user-images.githubusercontent.com/16018629/105065789-26e33f80-5a76-11eb-8be3-b99e8c5865d0.png)
