### PR TITLE
feat(storage-resize-images): added multiple image formats to res…

### DIFF
--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -211,21 +211,13 @@ params:
     required: false
 
   - param: IMAGE_TYPE
-    label: Convert image to preferred type
+    label: Convert image to preferred types
     description: >
-      The image type you'd like your source image to convert to. The default for this option will 
+      The image types you'd like your source image to convert to. The default for this option will 
       be to keep the original file type.
-    type: select
-    options:
-      - label: jpg
-        value: jpg
-      - label: png
-        value: png
-      - label: webp
-        value: webp
-      - label: tiff
-        value: tiff
-      - label: Do not convert
-        value: false
-    default: false
-    required: false
+    example: "jpeg,webp,gif,tiff,avif,heif"
+    validationRegex: ^\b(jpeg|webp|gif|tiff|avif|heif|original)\b(,\b(jpeg|webp|gif|tiff|avif|heif|original)\b)*$
+    validationErrorMessage:
+      Invalid image type(s), must be a comma-separated list containing at least one of jpeg,webp,gif,tiff,avif,heif,original.
+    default: original
+    required: true

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -210,7 +210,7 @@ params:
     example: max-age=86400
     required: false
 
-  - param: IMAGE_TYPES
+  - param: IMAGE_TYPE
     label: Convert image to preferred types
     description: >
       The image types you'd like your source image to convert to. The default for this option will 
@@ -225,7 +225,7 @@ params:
         value: png
       - label: tiff
         value: tiff
-      - label: raw
-        value: raw
-    default: raw
-    required: true
+      - label: original
+        value: original
+    default: original
+    required: false

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -210,14 +210,22 @@ params:
     example: max-age=86400
     required: false
 
-  - param: IMAGE_TYPE
+  - param: IMAGE_TYPES
     label: Convert image to preferred types
     description: >
       The image types you'd like your source image to convert to. The default for this option will 
       be to keep the original file type.
-    example: "jpeg,webp,gif,tiff,avif,heif"
-    validationRegex: ^\b(jpeg|webp|gif|tiff|avif|heif|original)\b(,\b(jpeg|webp|gif|tiff|avif|heif|original)\b)*$
-    validationErrorMessage:
-      Invalid image type(s), must be a comma-separated list containing at least one of jpeg,webp,gif,tiff,avif,heif,original.
-    default: original
+    type: multiSelect
+    options:
+      - label: jpeg
+        value: jpeg
+      - label: webp
+        value: webp
+      - label: png
+        value: png
+      - label: tiff
+        value: tiff
+      - label: raw
+        value: raw
+    default: raw
     required: true

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -226,6 +226,6 @@ params:
       - label: tiff
         value: tiff
       - label: original
-        value: original
-    default: original
-    required: false
+        value: false
+    default: false
+    required: true

--- a/storage-resize-images/functions/__tests__/__snapshots__/config.test.ts.snap
+++ b/storage-resize-images/functions/__tests__/__snapshots__/config.test.ts.snap
@@ -9,7 +9,7 @@ Object {
   "imageSizes": Array [
     "200x200",
   ],
-  "imageType": undefined,
+  "imageTypes": undefined,
   "includePathList": undefined,
   "resizedImagesPath": undefined,
 }

--- a/storage-resize-images/functions/__tests__/convert-image.test.ts
+++ b/storage-resize-images/functions/__tests__/convert-image.test.ts
@@ -28,36 +28,31 @@ beforeAll(async () => {
 
 describe("convertType", () => {
   it("converts to png image type", async () => {
-    config.imageType = "png";
-    const buffer = await convertType(bufferJPG);
+    const buffer = await convertType(bufferJPG, "png");
 
     expect(imageType(buffer).mime).toBe("image/png");
   });
 
   it("converts to jpeg image type", async () => {
-    config.imageType = "jpeg";
-    const buffer = await convertType(bufferPNG);
+    const buffer = await convertType(bufferPNG, "jpeg");
 
     expect(imageType(buffer).mime).toBe("image/jpeg");
   });
 
   it("converts to webp image type", async () => {
-    config.imageType = "webp";
-    const buffer = await convertType(bufferPNG);
+    const buffer = await convertType(bufferPNG, "webp");
 
     expect(imageType(buffer).mime).toBe("image/webp");
   });
 
   it("converts to tiff image type", async () => {
-    config.imageType = "tiff";
-    const buffer = await convertType(bufferPNG);
+    const buffer = await convertType(bufferPNG, "tiff");
 
     expect(imageType(buffer).mime).toBe("image/tiff");
   });
 
   it("remains jpeg image type when different image type is not supported", async () => {
-    config.imageType = "raw";
-    const buffer = await convertType(bufferJPG);
+    const buffer = await convertType(bufferJPG, "raw");
 
     expect(imageType(buffer).mime).toBe("image/jpeg");
   });

--- a/storage-resize-images/functions/lib/config.js
+++ b/storage-resize-images/functions/lib/config.js
@@ -43,5 +43,5 @@ exports.default = {
     includePathList: paramToArray(process.env.INCLUDE_PATH_LIST),
     excludePathList: paramToArray(process.env.EXCLUDE_PATH_LIST),
     deleteOriginalFile: deleteOriginalFile(process.env.DELETE_ORIGINAL_FILE),
-    imageTypes: process.env.IMAGE_TYPES,
+    imageTypes: process.env.IMAGE_TYPE,
 };

--- a/storage-resize-images/functions/lib/config.js
+++ b/storage-resize-images/functions/lib/config.js
@@ -43,5 +43,5 @@ exports.default = {
     includePathList: paramToArray(process.env.INCLUDE_PATH_LIST),
     excludePathList: paramToArray(process.env.EXCLUDE_PATH_LIST),
     deleteOriginalFile: deleteOriginalFile(process.env.DELETE_ORIGINAL_FILE),
-    imageType: process.env.IMAGE_TYPE,
+    imageTypes: process.env.IMAGE_TYPES,
 };

--- a/storage-resize-images/functions/lib/config.js
+++ b/storage-resize-images/functions/lib/config.js
@@ -43,5 +43,5 @@ exports.default = {
     includePathList: paramToArray(process.env.INCLUDE_PATH_LIST),
     excludePathList: paramToArray(process.env.EXCLUDE_PATH_LIST),
     deleteOriginalFile: deleteOriginalFile(process.env.DELETE_ORIGINAL_FILE),
-    imageTypes: process.env.IMAGE_TYPE,
+    imageTypes: paramToArray(process.env.IMAGE_TYPE),
 };

--- a/storage-resize-images/functions/lib/index.js
+++ b/storage-resize-images/functions/lib/index.js
@@ -91,18 +91,22 @@ exports.generateResizedImage = functions.storage.object().onFinalize(async (obje
         logs.imageDownloaded(filePath, originalFile);
         // Convert to a set to remove any duplicate sizes
         const imageSizes = new Set(config_1.default.imageSizes);
+        const imageTypes = new Set(config_1.default.imageType.split(","));
         const tasks = [];
-        imageSizes.forEach((size) => {
-            tasks.push(resize_image_1.modifyImage({
-                bucket,
-                originalFile,
-                fileDir,
-                fileNameWithoutExtension,
-                fileExtension,
-                contentType,
-                size,
-                objectMetadata: objectMetadata,
-            }));
+        imageTypes.forEach((format) => {
+            imageSizes.forEach((size) => {
+                tasks.push(resize_image_1.modifyImage({
+                    bucket,
+                    originalFile,
+                    fileDir,
+                    fileNameWithoutExtension,
+                    fileExtension,
+                    contentType,
+                    size,
+                    objectMetadata: objectMetadata,
+                    format,
+                }));
+            });
         });
         const results = await Promise.all(tasks);
         const failed = results.some((result) => result.success === false);

--- a/storage-resize-images/functions/lib/index.js
+++ b/storage-resize-images/functions/lib/index.js
@@ -90,7 +90,7 @@ exports.generateResizedImage = functions.storage.object().onFinalize(async (obje
         await remoteFile.download({ destination: originalFile });
         logs.imageDownloaded(filePath, originalFile);
         // Get a unique list of image types
-        const imageTypes = new Set(config_1.default.imageTypes.split(","));
+        const imageTypes = new Set(config_1.default.imageTypes);
         // Convert to a set to remove any duplicate sizes
         const imageSizes = new Set(config_1.default.imageSizes);
         const tasks = [];

--- a/storage-resize-images/functions/lib/index.js
+++ b/storage-resize-images/functions/lib/index.js
@@ -91,7 +91,7 @@ exports.generateResizedImage = functions.storage.object().onFinalize(async (obje
         logs.imageDownloaded(filePath, originalFile);
         // Convert to a set to remove any duplicate sizes
         const imageSizes = new Set(config_1.default.imageSizes);
-        const imageTypes = new Set(config_1.default.imageType.split(","));
+        const imageTypes = new Set(config_1.default.imageTypes.split(","));
         const tasks = [];
         imageTypes.forEach((format) => {
             imageSizes.forEach((size) => {

--- a/storage-resize-images/functions/lib/index.js
+++ b/storage-resize-images/functions/lib/index.js
@@ -89,9 +89,10 @@ exports.generateResizedImage = functions.storage.object().onFinalize(async (obje
         logs.imageDownloading(filePath);
         await remoteFile.download({ destination: originalFile });
         logs.imageDownloaded(filePath, originalFile);
+        // Get a unique list of image types
+        const imageTypes = new Set(config_1.default.imageTypes.split(","));
         // Convert to a set to remove any duplicate sizes
         const imageSizes = new Set(config_1.default.imageSizes);
-        const imageTypes = new Set(config_1.default.imageTypes.split(","));
         const tasks = [];
         imageTypes.forEach((format) => {
             imageSizes.forEach((size) => {

--- a/storage-resize-images/functions/lib/resize-image.js
+++ b/storage-resize-images/functions/lib/resize-image.js
@@ -28,24 +28,23 @@ function resize(file, size) {
         .toBuffer();
 }
 exports.resize = resize;
-function convertType(buffer) {
-    const { imageType } = config_1.default;
-    if (imageType === "jpg" || imageType === "jpeg") {
+function convertType(buffer, format) {
+    if (format === "jpg" || format === "jpeg") {
         return sharp(buffer)
             .jpeg()
             .toBuffer();
     }
-    else if (imageType === "png") {
+    if (format === "png") {
         return sharp(buffer)
             .png()
             .toBuffer();
     }
-    else if (imageType === "webp") {
+    if (format === "webp") {
         return sharp(buffer)
             .webp()
             .toBuffer();
     }
-    else if (imageType === "tiff") {
+    if (format === "tiff") {
         return sharp(buffer)
             .tiff()
             .toBuffer();
@@ -70,7 +69,7 @@ exports.supportedImageContentTypeMap = {
     webp: "image/webp",
 };
 exports.modifyImage = async ({ bucket, originalFile, fileDir, fileNameWithoutExtension, fileExtension, contentType, size, objectMetadata, format, }) => {
-    const useOriginalFormat = format !== "original";
+    const useOriginalFormat = format !== "raw";
     const imageContentType = useOriginalFormat
         ? exports.supportedImageContentTypeMap[format]
         : contentType;
@@ -109,8 +108,8 @@ exports.modifyImage = async ({ bucket, originalFile, fileDir, fileNameWithoutExt
         logs.imageResized(modifiedFile);
         // Generate a converted image type buffer using Sharp.
         logs.imageConverting(fileExtension, format);
-        modifiedImageBuffer = await convertType(modifiedImageBuffer);
-        logs.imageConverted(config_1.default.imageType);
+        modifiedImageBuffer = await convertType(modifiedImageBuffer, format);
+        logs.imageConverted(format);
         // Generate a image file using Sharp.
         await sharp(modifiedImageBuffer).toFile(modifiedFile);
         // Uploading the modified image.

--- a/storage-resize-images/functions/lib/resize-image.js
+++ b/storage-resize-images/functions/lib/resize-image.js
@@ -68,13 +68,21 @@ exports.supportedImageContentTypeMap = {
     tiff: "image/tiff",
     webp: "image/webp",
 };
+const supportedExtensions = Object.keys(exports.supportedImageContentTypeMap).map((type) => `.${type}`);
 exports.modifyImage = async ({ bucket, originalFile, fileDir, fileNameWithoutExtension, fileExtension, contentType, size, objectMetadata, format, }) => {
-    const useOriginalFormat = format !== "raw";
+    const useOriginalFormat = format !== "original";
     const imageContentType = useOriginalFormat
         ? exports.supportedImageContentTypeMap[format]
         : contentType;
     const modifiedExtensionName = fileExtension && useOriginalFormat ? `.${format}` : fileExtension;
-    const modifiedFileName = `${fileNameWithoutExtension}_${size}${modifiedExtensionName}`;
+    let modifiedFileName;
+    if (supportedExtensions.includes(fileExtension)) {
+        modifiedFileName = `${fileNameWithoutExtension}_${size}${modifiedExtensionName}`;
+    }
+    else {
+        // Fixes https://github.com/firebase/extensions/issues/476
+        modifiedFileName = `${fileNameWithoutExtension}${fileExtension}_${size}`;
+    }
     // Path where modified image will be uploaded to in Storage.
     const modifiedFilePath = path.normalize(config_1.default.resizedImagesPath
         ? path.join(fileDir, config_1.default.resizedImagesPath, modifiedFileName)

--- a/storage-resize-images/functions/src/config.ts
+++ b/storage-resize-images/functions/src/config.ts
@@ -43,5 +43,5 @@ export default {
   includePathList: paramToArray(process.env.INCLUDE_PATH_LIST),
   excludePathList: paramToArray(process.env.EXCLUDE_PATH_LIST),
   deleteOriginalFile: deleteOriginalFile(process.env.DELETE_ORIGINAL_FILE),
-  imageTypes: process.env.IMAGE_TYPE,
+  imageTypes: paramToArray(process.env.IMAGE_TYPE),
 };

--- a/storage-resize-images/functions/src/config.ts
+++ b/storage-resize-images/functions/src/config.ts
@@ -43,5 +43,5 @@ export default {
   includePathList: paramToArray(process.env.INCLUDE_PATH_LIST),
   excludePathList: paramToArray(process.env.EXCLUDE_PATH_LIST),
   deleteOriginalFile: deleteOriginalFile(process.env.DELETE_ORIGINAL_FILE),
-  imageType: process.env.IMAGE_TYPE,
+  imageTypes: process.env.IMAGE_TYPES,
 };

--- a/storage-resize-images/functions/src/config.ts
+++ b/storage-resize-images/functions/src/config.ts
@@ -43,5 +43,5 @@ export default {
   includePathList: paramToArray(process.env.INCLUDE_PATH_LIST),
   excludePathList: paramToArray(process.env.EXCLUDE_PATH_LIST),
   deleteOriginalFile: deleteOriginalFile(process.env.DELETE_ORIGINAL_FILE),
-  imageTypes: process.env.IMAGE_TYPES,
+  imageTypes: process.env.IMAGE_TYPE,
 };

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -117,10 +117,12 @@ export const generateResizedImage = functions.storage.object().onFinalize(
       await remoteFile.download({ destination: originalFile });
       logs.imageDownloaded(filePath, originalFile);
 
+      // Get a unique list of image types
+      const imageTypes = new Set(config.imageTypes.split(","));
+
       // Convert to a set to remove any duplicate sizes
       const imageSizes = new Set(config.imageSizes);
 
-      const imageTypes = new Set(config.imageTypes.split(","));
       const tasks: Promise<ResizedImageResult>[] = [];
 
       imageTypes.forEach((format) => {

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -119,20 +119,25 @@ export const generateResizedImage = functions.storage.object().onFinalize(
 
       // Convert to a set to remove any duplicate sizes
       const imageSizes = new Set(config.imageSizes);
+      const imageTypes = new Set(config.imageType.split(","));
       const tasks: Promise<ResizedImageResult>[] = [];
-      imageSizes.forEach((size) => {
-        tasks.push(
-          modifyImage({
-            bucket,
-            originalFile,
-            fileDir,
-            fileNameWithoutExtension,
-            fileExtension,
-            contentType,
-            size,
-            objectMetadata: objectMetadata,
-          })
-        );
+
+      imageTypes.forEach((format) => {
+        imageSizes.forEach((size) => {
+          tasks.push(
+            modifyImage({
+              bucket,
+              originalFile,
+              fileDir,
+              fileNameWithoutExtension,
+              fileExtension,
+              contentType,
+              size,
+              objectMetadata: objectMetadata,
+              format,
+            })
+          );
+        });
       });
 
       const results = await Promise.all(tasks);

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -118,7 +118,7 @@ export const generateResizedImage = functions.storage.object().onFinalize(
       logs.imageDownloaded(filePath, originalFile);
 
       // Get a unique list of image types
-      const imageTypes = new Set(config.imageTypes.split(","));
+      const imageTypes = new Set(config.imageTypes);
 
       // Convert to a set to remove any duplicate sizes
       const imageSizes = new Set(config.imageSizes);

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -119,7 +119,8 @@ export const generateResizedImage = functions.storage.object().onFinalize(
 
       // Convert to a set to remove any duplicate sizes
       const imageSizes = new Set(config.imageSizes);
-      const imageTypes = new Set(config.imageType.split(","));
+
+      const imageTypes = new Set(config.imageTypes.split(","));
       const tasks: Promise<ResizedImageResult>[] = [];
 
       imageTypes.forEach((format) => {

--- a/storage-resize-images/functions/src/resize-image.ts
+++ b/storage-resize-images/functions/src/resize-image.ts
@@ -105,12 +105,12 @@ export const modifyImage = async ({
   objectMetadata: ObjectMetadata;
   format: string;
 }): Promise<ResizedImageResult> => {
-  const useOriginalFormat = format !== "original";
-  const imageContentType = useOriginalFormat
+  const shouldFormatImage = format !== "false";
+  const imageContentType = shouldFormatImage
     ? supportedImageContentTypeMap[format]
     : contentType;
   const modifiedExtensionName =
-    fileExtension && useOriginalFormat ? `.${format}` : fileExtension;
+    fileExtension && shouldFormatImage ? `.${format}` : fileExtension;
 
   let modifiedFileName;
 
@@ -160,9 +160,11 @@ export const modifyImage = async ({
 
     // Generate a converted image type buffer using Sharp.
 
-    logs.imageConverting(fileExtension, format);
-    modifiedImageBuffer = await convertType(modifiedImageBuffer, format);
-    logs.imageConverted(format);
+    if (shouldFormatImage) {
+      logs.imageConverting(fileExtension, format);
+      modifiedImageBuffer = await convertType(modifiedImageBuffer, format);
+      logs.imageConverted(format);
+    }
 
     // Generate a image file using Sharp.
     await sharp(modifiedImageBuffer).toFile(modifiedFile);

--- a/storage-resize-images/functions/src/resize-image.ts
+++ b/storage-resize-images/functions/src/resize-image.ts
@@ -34,25 +34,31 @@ export function resize(file, size) {
     .toBuffer();
 }
 
-export function convertType(buffer) {
-  const { imageType } = config;
-  if (imageType === "jpg" || imageType === "jpeg") {
+export function convertType(buffer, format) {
+  if (format === "jpg" || format === "jpeg") {
     return sharp(buffer)
       .jpeg()
       .toBuffer();
-  } else if (imageType === "png") {
+  }
+
+  if (format === "png") {
     return sharp(buffer)
       .png()
       .toBuffer();
-  } else if (imageType === "webp") {
+  }
+
+  if (format === "webp") {
     return sharp(buffer)
       .webp()
       .toBuffer();
-  } else if (imageType === "tiff") {
+  }
+
+  if (format === "tiff") {
     return sharp(buffer)
       .tiff()
       .toBuffer();
   }
+
   return buffer;
 }
 
@@ -95,7 +101,7 @@ export const modifyImage = async ({
   objectMetadata: ObjectMetadata;
   format: string;
 }): Promise<ResizedImageResult> => {
-  const useOriginalFormat = format !== "original";
+  const useOriginalFormat = format !== "raw";
   const imageContentType = useOriginalFormat
     ? supportedImageContentTypeMap[format]
     : contentType;
@@ -142,8 +148,8 @@ export const modifyImage = async ({
     // Generate a converted image type buffer using Sharp.
 
     logs.imageConverting(fileExtension, format);
-    modifiedImageBuffer = await convertType(modifiedImageBuffer);
-    logs.imageConverted(config.imageType);
+    modifiedImageBuffer = await convertType(modifiedImageBuffer, format);
+    logs.imageConverted(format);
 
     // Generate a image file using Sharp.
     await sharp(modifiedImageBuffer).toFile(modifiedFile);


### PR DESCRIPTION
The current behaviour allows you to convert to a single different type.

This PR allows you to select multiple file types for image type conversion (i.e. `tiff`, `jpeg`).

The original file type can also be selected alongside other types which is not possible currently.

fixes #575