### PR TITLE
feat(firestore-bigquery-export): big query partitioned tables

### DIFF
--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -231,7 +231,7 @@ params:
         value: MONTH 
       - label: year
         value: YEAR
-      - label: no table partitioning
+      - label: none
         value: false
     default: false
     required: true

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -232,6 +232,6 @@ params:
       - label: year
         value: YEAR
       - label: none
-        value: false
-    default: false
+        value: NONE
+    default: NONE
     required: true

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -213,3 +213,25 @@ params:
       more than 1024 characters.
     default: posts
     required: true
+
+  - param: TABLE_PARTITIONING
+    label: BigQuery SQL table partitioning option
+    description: >-
+      This parameter will allow you to partition the BigQuery table and BigQuery view 
+      created by the extension based on data ingestion time. You may select the granularity of
+      partitioning based upon one of: HOUR, DAY, MONTH, YEAR. This will
+      generate one partition per day, hour, month or year, respectively. 
+    type: select
+    options:
+      - label: hour
+        value: HOUR
+      - label: day
+        value: DAY
+      - label: month
+        value: MONTH 
+      - label: year
+        value: YEAR
+      - label: no table partitioning
+        value: false
+    default: false
+    required: true

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/snapshot.test.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/snapshot.test.ts
@@ -40,6 +40,7 @@ const trackerInstance = new FirestoreBigQueryEventHistoryTracker({
   datasetId: "id",
   datasetLocation: undefined,
   tableId: "id",
+  tablePartitioning: null
 });
 
 async function readFormattedSQL(file: string): Promise<string> {

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/snapshot.test.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/snapshot.test.ts
@@ -40,7 +40,7 @@ const trackerInstance = new FirestoreBigQueryEventHistoryTracker({
   datasetId: "id",
   datasetLocation: undefined,
   tableId: "id",
-  tablePartitioning: null
+  tablePartitioning: null,
 });
 
 async function readFormattedSQL(file: string): Promise<string> {

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -30,7 +30,10 @@ import {
   FirestoreDocumentChangeEvent,
 } from "../tracker";
 import * as logs from "../logs";
-import { InsertRowsOptions } from "@google-cloud/bigquery/build/src/table";
+import {
+  InsertRowsOptions,
+  TableMetadata,
+} from "@google-cloud/bigquery/build/src/table";
 
 export { RawChangelogSchema, RawChangelogViewSchema } from "./schema";
 
@@ -38,6 +41,7 @@ export interface FirestoreBigQueryEventHistoryTrackerConfig {
   datasetId: string;
   tableId: string;
   datasetLocation: string | undefined;
+  tablePartitioning: string;
 }
 
 /**
@@ -237,11 +241,17 @@ export class FirestoreBigQueryEventHistoryTracker
       }
     } else {
       logs.bigQueryTableCreating(changelogName);
-      const options = {
-        // `friendlyName` needs to be here to satisfy TypeScript
+      const options: TableMetadata = {
         friendlyName: changelogName,
         schema: RawChangelogSchema,
       };
+
+      if (this.config.tablePartitioning) {
+        options.timePartitioning = {
+          type: this.config.tablePartitioning,
+        };
+      }
+
       await table.create(options);
       logs.bigQueryTableCreated(changelogName);
     }
@@ -281,10 +291,16 @@ export class FirestoreBigQueryEventHistoryTracker
         this.rawChangeLogTableName()
       );
       logs.bigQueryViewCreating(this.rawLatestView(), latestSnapshot.query);
-      const options = {
+      const options: TableMetadata = {
         friendlyName: this.rawLatestView(),
         view: latestSnapshot,
       };
+
+      if (this.config.tablePartitioning) {
+        options.timePartitioning = {
+          type: this.config.tablePartitioning,
+        };
+      }
       await view.create(options);
       await view.setMetadata({ schema: RawChangelogViewSchema });
       logs.bigQueryViewCreated(this.rawLatestView());

--- a/firestore-bigquery-export/functions/__tests__/__snapshots__/config.test.ts.snap
+++ b/firestore-bigquery-export/functions/__tests__/__snapshots__/config.test.ts.snap
@@ -8,6 +8,7 @@ Object {
   "initialized": false,
   "location": "us-central1",
   "tableId": "my_table",
+  "tablePartitioning": null,
 }
 `;
 

--- a/firestore-bigquery-export/functions/lib/config.js
+++ b/firestore-bigquery-export/functions/lib/config.js
@@ -15,6 +15,15 @@
  * limitations under the License.
  */
 Object.defineProperty(exports, "__esModule", { value: true });
+function tablePartitioning(type) {
+    if (type === "HOUR" ||
+        type === "DAY" ||
+        type === "MONTH" ||
+        type === "YEAR") {
+        return type;
+    }
+    return null;
+}
 exports.default = {
     collectionPath: process.env.COLLECTION_PATH,
     datasetId: process.env.DATASET_ID,
@@ -22,4 +31,5 @@ exports.default = {
     location: process.env.LOCATION,
     initialized: false,
     datasetLocation: process.env.DATASET_LOCATION,
+    tablePartitioning: tablePartitioning(process.env.TABLE_PARTITIONING),
 };

--- a/firestore-bigquery-export/functions/lib/index.js
+++ b/firestore-bigquery-export/functions/lib/index.js
@@ -24,7 +24,7 @@ const eventTracker = new firestore_bigquery_change_tracker_1.FirestoreBigQueryEv
     tableId: config_1.default.tableId,
     datasetId: config_1.default.datasetId,
     datasetLocation: config_1.default.datasetLocation,
-    tablePartitioning: config_1.default.tablePartitioning
+    tablePartitioning: config_1.default.tablePartitioning,
 });
 logs.init();
 exports.fsexportbigquery = functions.handler.firestore.document.onWrite(async (change, context) => {

--- a/firestore-bigquery-export/functions/lib/index.js
+++ b/firestore-bigquery-export/functions/lib/index.js
@@ -24,6 +24,7 @@ const eventTracker = new firestore_bigquery_change_tracker_1.FirestoreBigQueryEv
     tableId: config_1.default.tableId,
     datasetId: config_1.default.datasetId,
     datasetLocation: config_1.default.datasetLocation,
+    tablePartitioning: config_1.default.tablePartitioning
 });
 logs.init();
 exports.fsexportbigquery = functions.handler.firestore.document.onWrite(async (change, context) => {

--- a/firestore-bigquery-export/functions/src/config.ts
+++ b/firestore-bigquery-export/functions/src/config.ts
@@ -14,6 +14,19 @@
  * limitations under the License.
  */
 
+function tablePartitioning(type) {
+  if (
+    type === "HOUR" ||
+    type === "DAY" ||
+    type === "MONTH" ||
+    type === "YEAR"
+  ) {
+    return type;
+  }
+
+  return null;
+}
+
 export default {
   collectionPath: process.env.COLLECTION_PATH,
   datasetId: process.env.DATASET_ID,
@@ -21,4 +34,5 @@ export default {
   location: process.env.LOCATION,
   initialized: false,
   datasetLocation: process.env.DATASET_LOCATION,
+  tablePartitioning: tablePartitioning(process.env.TABLE_PARTITIONING),
 };

--- a/firestore-bigquery-export/functions/src/index.ts
+++ b/firestore-bigquery-export/functions/src/index.ts
@@ -29,7 +29,7 @@ const eventTracker: FirestoreEventHistoryTracker = new FirestoreBigQueryEventHis
     tableId: config.tableId,
     datasetId: config.datasetId,
     datasetLocation: config.datasetLocation,
-    tablePartitioning: config.tablePartitioning
+    tablePartitioning: config.tablePartitioning,
   }
 );
 

--- a/firestore-bigquery-export/functions/src/index.ts
+++ b/firestore-bigquery-export/functions/src/index.ts
@@ -29,6 +29,7 @@ const eventTracker: FirestoreEventHistoryTracker = new FirestoreBigQueryEventHis
     tableId: config.tableId,
     datasetId: config.datasetId,
     datasetLocation: config.datasetLocation,
+    tablePartitioning: config.tablePartitioning
   }
 );
 


### PR DESCRIPTION
Fixes https://github.com/firebase/extensions/issues/316

1. Tested creating fresh time partitioned BigQuery tables without a problem
2. Tested "updating" the extension whilst pointing to existing non-partitioned BigQuery tables. 

The feature is backwards compatible. The BigQuery tracker package always checks if the table exists before setting the `timePartitioning` metadata for the raw changelog table and the latest view table. This also means the import script will not be affected as long as the table has already been created by the extension (which is the recommended way).

In future, we may also wish to update the `gen-schema-view` script to also allow time partitioning, but I suggest we wait for this to land and raise a separate PR.


