### PR TITLE
docs(firestore-bigquery-export) Investigation into improving Documentation

### DIFF
--- a/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
+++ b/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
@@ -8,6 +8,8 @@ You may pause and resume the import script from the last batch at any point.
 
 #### Important notes
 
+** More information is needed here **
+
 - You must run the import script over the entire collection **_after_** installing the Export Collections to BigQuery extension; otherwise the writes to your database during the import might not be exported to the dataset.
 
 - The import script can take up to _O(collection size)_ time to finish. If your collection is large, you might want to consider [loading data from a Cloud Firestore export into BigQuery](https://cloud.google.com/bigquery/docs/loading-data-cloud-firestore).


### PR DESCRIPTION
Based on current documentation an updated approach is required for assisting users who are initially import large (and complex?) datasets into BigQuery (BQ). f

fixes: https://github.com/firebase/extensions/issues/571.

# Issues

- An initial import is required as Firestore to BQ extension is too limited for large queries and batch processing.
- The import script created to solve this issue has been highlighted as *flaky* and too slow on large amounts of data.
- Documentation requires more information on guidance on the best solution to these problems

# Proposals

 ##  Utilising [Firestore exports to BQ](https://cloud.google.com/bigquery/docs/loading-data-cloud-firestore)

- [x]  Can import small amounts of records (0-10)
- [x] ~Can import large amounts of records (200,000+)~
- [x]  ~Can import large amounts of records (500,000+)~
- [x]  ~Can import huge amounts of records (1,000,000+)~

- [x]  Can import small complex amounts of records (0-10)
- [x]  ~Can import large complex amounts of records (500,000+)~
- [x]  ~Can import huge complex amounts of records (1,000,000+)~

 ## Improving the import script

- [ ]  Can import small amounts of records (0-10)
- [ ]  Can import large amounts of records (500,000+)
- [ ]  Can import huge amounts of records (1,000,000+)

- [ ]  Can import small complex amounts of records (0-10)
- [ ]  Can import large complex amounts of records (500,000+)
- [ ]  Can import huge complex amounts of records (1,000,000+)

 ## Alternatives? 

# Documentation
- Updates required for [import documentation](https://github.com/firebase/extensions/blob/next/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md) on how to perform these actions.

# Testing
- Develop test cases for importing large (and complex) datasets