### PR TITLE
fix(firestore-bigquery-export): Updated file naming for bq imports

### DIFF
--- a/firestore-bigquery-export/scripts/import/package.json
+++ b/firestore-bigquery-export/scripts/import/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.2",
     "commander": "5.0.0",
+    "filenamify": "^4.2.0",
     "firebase-admin": "^7.1.1",
     "firebase-functions": "^2.2.1",
     "generate-schema": "^2.6.0",

--- a/firestore-bigquery-export/scripts/import/src/index.ts
+++ b/firestore-bigquery-export/scripts/import/src/index.ts
@@ -261,9 +261,11 @@ const run = async (): Promise<number> => {
   // operations supersede imports when listing the live documents.
   let cursor;
 
+  const formattedPath = sourceCollectionPath.replace(/\//g, "-");
+
   let cursorPositionFile =
     __dirname +
-    `/from-${sourceCollectionPath}-to-${projectId}_${datasetId}_${rawChangeLogName}`;
+    `/from-${formattedPath}-to-${projectId}_${datasetId}_${rawChangeLogName}`;
   if (await exists(cursorPositionFile)) {
     let cursorDocumentId = (await read(cursorPositionFile)).toString();
     cursor = await firebase

--- a/firestore-bigquery-export/scripts/import/src/index.ts
+++ b/firestore-bigquery-export/scripts/import/src/index.ts
@@ -21,6 +21,7 @@ import * as program from "commander";
 import * as fs from "fs";
 import * as inquirer from "inquirer";
 import * as util from "util";
+import * as filenamify from "filenamify";
 
 import {
   ChangeType,
@@ -261,7 +262,7 @@ const run = async (): Promise<number> => {
   // operations supersede imports when listing the live documents.
   let cursor;
 
-  const formattedPath = sourceCollectionPath.replace(/\//g, "-");
+  const formattedPath = filenamify(sourceCollectionPath);
 
   let cursorPositionFile =
     __dirname +


### PR DESCRIPTION
fixes: https://github.com/firebase/extensions/issues/584

When using collections below the root collection of database, the `/`separating the collections  is interpreted as part of the temporary file path which is created. This has been updated to use `-` instead. 