### PR TITLE
removing error throwing of expected behaviour

### DIFF
--- a/auth-mailchimp-sync/functions/src/index.ts
+++ b/auth-mailchimp-sync/functions/src/index.ts
@@ -63,7 +63,7 @@ export const addUserToList = functions.handler.auth.user.onCreate(
       );
       logs.complete();
     } catch (err) {
-      logs.errorAddUser(err);
+      err.title === 'Member Exists' ? logs.userAlreadyInAudience( ) : logs.errorAddUser(err);
     }
   }
 );
@@ -96,7 +96,7 @@ export const removeUserFromList = functions.handler.auth.user.onDelete(
       logs.userRemoved(uid, hashed, config.mailchimpAudienceId);
       logs.complete();
     } catch (err) {
-      logs.errorRemoveUser(err);
+      err.title === 'Method Not Allowed' ? logs.userNotInAudience() : logs.errorRemoveUser(err);
     }
   }
 );

--- a/auth-mailchimp-sync/functions/src/logs.ts
+++ b/auth-mailchimp-sync/functions/src/logs.ts
@@ -26,10 +26,18 @@ export const complete = () => {
   logger.log("Completed execution of extension");
 };
 
+export const userAlreadyInAudience = () => {
+  logger.log("Attempted added user already in mailchimp audience")
+};
+
 export const errorAddUser = (err: Error) => {
   logger.error("Error when adding user to Mailchimp audience", err);
 };
 
+
+export const userNotInAudience= () =>{
+  logger.log("Attempted removal failed, member deletion not allowed. Probably because member has already been removed from audience")
+}
 export const errorRemoveUser = (err: Error) => {
   logger.error("Error when removing user from Mailchimp audience", err);
 };


### PR DESCRIPTION
Removing Errors of expected behavior in the following two scenarios:

1) Removing a non-existent member throws an error. Non-existence is expected because members unsubscribe regularly from an audience. Should log the info but not throw an error. The final state is the same.

2) Adding a member who already is part of the audience throws an error. You often have multiple ways users can signup to an audience. Firebase auth is only one of them. Should log the into but not throw an error. The final state is the same.