### PR TITLE
feat(firestore-bigquery-export) Add us-central-1 as a dataset location option

### DIFF
--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -118,6 +118,8 @@ params:
       guide](https://cloud.google.com/bigquery/docs/locations).
     type: select
     options:
+      - label: Iowa (us-central1)
+        value: us-central1
       - label: Las Vegas (us-west4)
         value: us-west4
       - label: Los Angeles (us-west2)


### PR DESCRIPTION
fixes: https://github.com/firebase/extensions/issues/602