### PR TITLE
Stop ignoring .md files, so that all required checks are run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - "**"
-    paths-ignore:
-      - "**/*.md"
 
 jobs:
   nodejs:


### PR DESCRIPTION
We noticed some conflicting settings in this repo:
1) Per gh action workflow config node{10,12} test do not run if the change only includes *.md file
2) Per gh repo setting, merge into next branch MUST include passing result of node{10,12} tests (https://github.com/firebase/extensions/settings/branch_protection_rules/12097847)

This makes the tests always run - we figured it was better to have a few 'wasted' actions than to make these not required or get in the habit of ignoring these checks.