### PR TITLE
Add size to metadata

### DIFF
--- a/storage-resize-images/functions/lib/resize-image.js
+++ b/storage-resize-images/functions/lib/resize-image.js
@@ -96,9 +96,10 @@ exports.modifyImage = async ({ bucket, originalFile, fileDir, fileNameWithoutExt
             contentEncoding: objectMetadata.contentEncoding,
             contentLanguage: objectMetadata.contentLanguage,
             contentType: imageContentType,
-            metadata: objectMetadata.metadata || {},
+            metadata: objectMetadata.metadata ? { ...objectMetadata.metadata } : {},
         };
         metadata.metadata.resizedImage = true;
+        metadata.metadata.size = size;
         if (config_1.default.cacheControlHeader) {
             metadata.cacheControl = config_1.default.cacheControlHeader;
         }

--- a/storage-resize-images/functions/src/resize-image.ts
+++ b/storage-resize-images/functions/src/resize-image.ts
@@ -141,6 +141,7 @@ export const modifyImage = async ({
       metadata: objectMetadata.metadata || {},
     };
     metadata.metadata.resizedImage = true;
+    metadata.metadata.size = size;
     if (config.cacheControlHeader) {
       metadata.cacheControl = config.cacheControlHeader;
     } else {

--- a/storage-resize-images/functions/src/resize-image.ts
+++ b/storage-resize-images/functions/src/resize-image.ts
@@ -138,7 +138,7 @@ export const modifyImage = async ({
       contentEncoding: objectMetadata.contentEncoding,
       contentLanguage: objectMetadata.contentLanguage,
       contentType: imageContentType,
-      metadata: objectMetadata.metadata || {},
+      metadata: objectMetadata.metadata ? { ...objectMetadata.metadata } : {},
     };
     metadata.metadata.resizedImage = true;
     metadata.metadata.size = size;


### PR DESCRIPTION
This adds size to the resized image metadata.

When I create these thumbs I want them to save their path to a firestore document with a separate .onFinalize function. This makes it much easier to determine the size without having to parse the path name.