### PR TITLE
chore(firestore-bigquery-export): migration to Node.js v14

### DIFF
--- a/firestore-bigquery-export/PREINSTALL.md
+++ b/firestore-bigquery-export/PREINSTALL.md
@@ -34,4 +34,4 @@ To install an extension, your project must be on the [Blaze (pay as you go) plan
 - This extension uses other Firebase and Google Cloud Platform services, which have associated charges if you exceed the service’s free tier:
   - BigQuery (this extension writes to BigQuery with [streaming inserts](https://cloud.google.com/bigquery/pricing#streaming_pricing))
   - Cloud Firestore
-  - Cloud Functions (Node.js 10+ runtime. [See FAQs](https://firebase.google.com/support/faq#expandable-24))
+  - Cloud Functions (Node.js 10+ runtime. [See FAQs](https://firebase.google.com/support/faq#extensions-pricing))

--- a/firestore-bigquery-export/README.md
+++ b/firestore-bigquery-export/README.md
@@ -42,7 +42,7 @@ To install an extension, your project must be on the [Blaze (pay as you go) plan
 - This extension uses other Firebase and Google Cloud Platform services, which have associated charges if you exceed the service’s free tier:
   - BigQuery (this extension writes to BigQuery with [streaming inserts](https://cloud.google.com/bigquery/pricing#streaming_pricing))
   - Cloud Firestore
-  - Cloud Functions (Node.js 10+ runtime. [See FAQs](https://firebase.google.com/support/faq#expandable-24))
+  - Cloud Functions (Node.js 10+ runtime. [See FAQs](https://firebase.google.com/support/faq#extensions-pricing))
 
 
 

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -53,7 +53,7 @@ resources:
       then exports the changes into BigQuery.
     properties:
       location: ${param:LOCATION}
-      runtime: nodejs12
+      runtime: nodejs14
       eventTrigger:
         eventType: providers/cloud.firestore/eventTypes/document.write
         resource: projects/${param:PROJECT_ID}/databases/(default)/documents/${param:COLLECTION_PATH}/{documentId}

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -53,7 +53,7 @@ resources:
       then exports the changes into BigQuery.
     properties:
       location: ${param:LOCATION}
-      runtime: nodejs10
+      runtime: nodejs12
       eventTrigger:
         eventType: providers/cloud.firestore/eventTypes/document.write
         resource: projects/${param:PROJECT_ID}/databases/(default)/documents/${param:COLLECTION_PATH}/{documentId}

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
@@ -23,7 +23,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@google-cloud/bigquery": "^4.7.0",
-    "firebase-admin": "^7.1.1",
+    "firebase-admin": "^8.0.0",
     "firebase-functions": "^3.13.2",
     "generate-schema": "^2.6.0",
     "inquirer": "^6.4.0",

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@google-cloud/bigquery": "^4.7.0",
     "firebase-admin": "^7.1.1",
-    "firebase-functions": "^3.9.0",
+    "firebase-functions": "^3.13.2",
     "generate-schema": "^2.6.0",
     "inquirer": "^6.4.0",
     "lodash": "^4.17.14",

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/tsconfig.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest", "chai"],
-    "target": "es2018"
+    "target": "ES2020"
   },
   "include": ["src"]
 }

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/tsconfig.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest", "chai"],
-    "target": "es2019"
+    "target": "es2018"
   },
   "include": ["src"]
 }

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/tsconfig.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest", "chai"],
-    "target": "es2018"
+    "target": "es2019"
   },
   "include": ["src"]
 }

--- a/firestore-bigquery-export/functions/package.json
+++ b/firestore-bigquery-export/functions/package.json
@@ -6,7 +6,6 @@
     "build": "npm run clean && npm run compile",
     "clean": "rimraf lib",
     "compile": "tsc",
-    "prepare": "npm run build",
     "test": "jest",
     "generate-readme": "firebase ext:info .. --markdown > ../README.md"
   },

--- a/firestore-bigquery-export/functions/package.json
+++ b/firestore-bigquery-export/functions/package.json
@@ -18,7 +18,7 @@
     "@types/chai": "^4.1.6",
     "chai": "^4.2.0",
     "firebase-admin": "^8.1.0",
-    "firebase-functions": "^3.9.0",
+    "firebase-functions": "^3.13.2",
     "firebase-functions-test": "^0.2.3",
     "generate-schema": "^2.6.0",
     "inquirer": "^6.4.0",

--- a/firestore-bigquery-export/functions/tsconfig.json
+++ b/firestore-bigquery-export/functions/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["esnext.asynciterable"],
     "outDir": "lib",
     "types": ["node", "jest", "chai"],
-    "target": "es2018"
+    "target": "es2019"
   },
   "files": ["./__tests__/test.types.d.ts"],
   "include": ["src"]

--- a/firestore-bigquery-export/functions/tsconfig.json
+++ b/firestore-bigquery-export/functions/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["esnext.asynciterable"],
     "outDir": "lib",
     "types": ["node", "jest", "chai"],
-    "target": "es2019"
+    "target": "ES2020"
   },
   "files": ["./__tests__/test.types.d.ts"],
   "include": ["src"]


### PR DESCRIPTION
## Checklist

- [x] Update extension yaml resources -> properties to contain runtime: {runtime: nodejs14}
- [x] Ensure compilerOptions are updated to include es2020
- [x] Update firebase-functions dependency to latest
- [x] Update url for pricing in readme to https://firebase.google.com/support/faq#extensions-pricing