### PR TITLE
feat(firestore-counter): Add Node.js Admin SDK Implementation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - "**"
+  pull_request:
+    branches:
+      - "**"
 
 jobs:
   nodejs:

--- a/firestore-counter/POSTINSTALL.md
+++ b/firestore-counter/POSTINSTALL.md
@@ -19,7 +19,7 @@ match /databases/{database}/documents/pages/{page} {
 }
 ```
 
-#### Client samples for incrementing counter and retrieving its value
+#### Client/Admin samples for incrementing counter and retrieving its value
 
 ##### Web Client
 
@@ -157,6 +157,37 @@ class ViewController: UIViewController {
   }
 }
 
+```
+
+
+##### Node.js Admin
+
+1. Follow the steps in [Add Firebase Admin SDK to your server](https://firebase.google.com/docs/admin/setup) to use Firebase in your app.
+
+2.  Download and copy the [Node.js Admin sample](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/node/index.js) into your application project.
+
+```js
+  // Initialize Firebase.
+  const admin = require('firebase-admin');
+  admin.initializeApp();
+  const db = admin.firestore();
+
+  const Counter = require("./distributed_counter")
+
+  const visits = new Counter(db.collection("pages").doc("hello-world"), "visits")
+
+  // Increment the field "visits" of the document "pages/hello-world".
+  visits.incrementBy(1);
+
+  // Listen to locally consistent values.
+  visits.onSnapshot((snap) => {
+    console.log("Locally consistent view of visits: " + snap.data());
+  });
+
+  // Alternatively, if you don't mind counter delays, you can listen to the document directly.
+  db.collection("pages").doc("hello-world").onSnapshot((snap) => {
+    console.log("Eventually consistent view of visits: " + snap.get("visits"));
+  });
 ```
 
 #### Upgrading from v0.1.3 and earlier

--- a/firestore-counter/PREINSTALL.md
+++ b/firestore-counter/PREINSTALL.md
@@ -10,6 +10,7 @@ Here are some features of this extension:
 
 Note that this extension requires client-side logic to work. We provide a [TypeScript client sample implementation](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/src/index.ts) and its [compiled minified JavaScript](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/dist/sharded-counter.js). You can use this extension on other platforms if you'd like to develop your own client code based on the provided client sample.
 
+We also provide a [Node.js admin sample implementation](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/node/index.js)
 
 #### Additional setup
 
@@ -18,7 +19,7 @@ Before installing this extension, make sure that you've [set up a Cloud Firestor
 After installing this extension, you'll need to:
 
 - Update your [database security rules](https://firebase.google.com/docs/rules).
-- Use the provided [client sample](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/src/index.ts) or your own client code to specify your document path and increment values.
+- Use the provided [client sample](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/src/index.ts), the provided [Node.js admin sample](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/node/index.js) or your own client code to specify your document path and increment values.
 
 Detailed information for these post-installation tasks are provided after you install this extension.
 

--- a/firestore-counter/README.md
+++ b/firestore-counter/README.md
@@ -18,6 +18,8 @@ Here are some features of this extension:
 
 Note that this extension requires client-side logic to work. We provide a [TypeScript client sample implementation](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/src/index.ts) and its [compiled minified JavaScript](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/dist/sharded-counter.js). You can use this extension on other platforms if you'd like to develop your own client code based on the provided client sample.
 
+We also provide a [Node.js admin sample implementation](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/node/index.js)
+
 
 #### Additional setup
 
@@ -26,7 +28,7 @@ Before installing this extension, make sure that you've [set up a Cloud Firestor
 After installing this extension, you'll need to:
 
 - Update your [database security rules](https://firebase.google.com/docs/rules).
-- Use the provided [client sample](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/src/index.ts) or your own client code to specify your document path and increment values.
+- Use the provided [client sample](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/web/src/index.ts), the provided [Node.js admin sample](https://github.com/firebase/extensions/blob/master/firestore-counter/clients/node/index.js) or your own client code to specify your document path and increment values.
 
 Detailed information for these post-installation tasks are provided after you install this extension.
 

--- a/firestore-counter/clients/node/index.js
+++ b/firestore-counter/clients/node/index.js
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const uuid = require("uuid")
+const admin = require("firebase-admin")
+
+const SHARD_COLLECTION_ID = "_counter_shards_"
+
+module.exports = class Counter {
+  /**
+   * Constructs a sharded counter object that references to a field
+   * in a document that is a counter.
+   *
+   * @param doc A reference to a document with a counter field.
+   * @param field A path to a counter field in the above document.
+   */
+  constructor(doc, field) {
+    this.shards = {}
+    this.notifyPromise = null
+    this.doc = doc
+    this.field = field
+    this.db = doc.firestore
+    this.shardId = getShardId()
+
+    const shardsRef = doc.collection(SHARD_COLLECTION_ID)
+    this.shards[doc.path] = 0
+    this.shards[shardsRef.doc(this.shardId).path] = 0
+    this.shards[shardsRef.doc("\t" + this.shardId.substr(0, 4)).path] = 0
+    this.shards[shardsRef.doc("\t\t" + this.shardId.substr(0, 3)).path] = 0
+    this.shards[shardsRef.doc("\t\t\t" + this.shardId.substr(0, 2)).path] = 0
+    this.shards[shardsRef.doc("\t\t\t\t" + this.shardId.substr(0, 1)).path] = 0
+  }
+
+  /**
+   * Get latency compensated view of the counter.
+   *
+   * All local increments will be reflected in the counter even if the main
+   * counter hasn't been updated yet.
+   */
+  async get(options) {
+    const valuePromises = Object.keys(this.shards).map(async (path) => {
+      const shard = await this.db.doc(path).get(options)
+      return shard.get(this.field) || 0
+    })
+    const values = await Promise.all(valuePromises)
+    return values.reduce((a, b) => a + b, 0)
+  }
+
+  /**
+   * Listen to latency compensated view of the counter.
+   *
+   * All local increments to this counter will be immediately visible in the
+   * snapshot.
+   */
+  onSnapshot(observable) {
+    Object.keys(this.shards).forEach((path) => {
+      this.db.doc(path).onSnapshot((snap) => {
+        this.shards[snap.ref.path] = snap.get(this.field) || 0
+        if (this.notifyPromise !== null) return
+        this.notifyPromise = schedule(() => {
+          const sum = Object.values(this.shards).reduce((a, b) => a + b, 0)
+          observable({
+            exists: true,
+            data: () => sum,
+          })
+          this.notifyPromise = null
+        })
+      })
+    })
+  }
+
+  /**
+   * Increment the counter by a given value.
+   *
+   * e.g.
+   * const counter = new sharded.Counter(db.doc("path/document"), "counter");
+   * counter.incrementBy(1);
+   */
+  incrementBy(val) {
+    const increment = admin.firestore.FieldValue.increment(val)
+    const update = this.field
+      .split(".")
+      .reverse()
+      .reduce((value, name) => ({ [name]: value }), increment)
+    return this.doc
+      .collection(SHARD_COLLECTION_ID)
+      .doc(this.shardId)
+      .set(update, { merge: true })
+  }
+
+  /**
+   * Access the assigned shard directly. Useful to update multiple counters
+   * at the same time, batches or transactions.
+   *
+   * e.g.
+   * const counter = new sharded.Counter(db.doc("path/counter"), "");
+   * const shardRef = counter.shard();
+   * shardRef.set({"counter1", firestore.FieldValue.Increment(1),
+   *               "counter2", firestore.FieldValue.Increment(1));
+   */
+  shard() {
+    return this.doc.collection(SHARD_COLLECTION_ID).doc(this.shardId)
+  }
+}
+
+async function schedule(func) {
+  return new Promise(async (resolve) => {
+    setTimeout(async () => {
+      const result = func()
+      resolve(result)
+    }, 0)
+  })
+}
+
+function getShardId() {
+  const shardId = uuid.v4()
+  return shardId
+}

--- a/firestore-counter/clients/node/package.json
+++ b/firestore-counter/clients/node/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "firestore-counter-node",
+  "version": "1.0.0",
+  "description": "Node.js admin SDK to access sharded counters",
+  "main": "index.js",
+  "author": "Mansehej Singh <mansehej@gmail.com>",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "firebase-admin": "^9.10.0"
+  },
+  "dependencies": {
+    "uuid": "^8.3.2"
+  }
+}


### PR DESCRIPTION
The firestore distributed counter SDK does not exist for backend services like Node.js (#28).
This PR aims to solve that by converting the web client Typescript implementation into Node.js.