### PR TITLE
chore: remove package-lock.json from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ build
 *.iml
 local.properties
 coverage
-package-lock.json
 yarn.lock
 
 firestore-debug.log

--- a/firestore-counter/.gitignore
+++ b/firestore-counter/.gitignore
@@ -2,7 +2,6 @@ test-project-key.json
 
 .vscode
 node_modules
-package-lock.json
 *.js.map
 functions/lib/test/*.js
 stress_test/**/*.js


### PR DESCRIPTION
Removing package-lock.json from .gitignore, for a few reasons:
 - Not having these committed caused a broken release of the bigquery extension a few weeks back 
 - npms official help docs say that it is intended to be commited: https://github.com/npm/cli/blob/release-6.14.7/docs/content/configuring-npm/package-lock-json.md
 - The Cloud Build code for node14 runs npm ci, which will not generate a new package-lock.json

I didn't go through and generate package-locks for each extension - I figure we can add these alongside normal PRs to each extension. 