### PR TITLE
Add the from field to the example document.

### DIFF
--- a/firestore-send-email/README.md
+++ b/firestore-send-email/README.md
@@ -15,6 +15,7 @@ Here's a basic example document write that would trigger this extension:
 ```js
 admin.firestore().collection('mail').add({
   to: 'someone@example.com',
+  from: 'somebodyelse@example.com',
   message: {
     subject: 'Hello from Firebase!',
     html: 'This is an <code>HTML</code> email body.',


### PR DESCRIPTION
The from field is required for some email providers, so adding it to the example 
makes it obvious where it should be.