### PR TITLE
Update the SQL script used for generating latest snapshot.

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/snapshot.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/snapshot.ts
@@ -57,16 +57,16 @@ export function buildLatestSnapshotViewQuery(
     --   data: A raw JSON payload of the current state of the document.
     --   document_id: The document id as defined in the Firestore database
     WITH latest AS (
-      SELECT max(${timestampColumnName}) as latest_timestamp, document_id
+      SELECT max(${timestampColumnName}) as latest_timestamp, document_name
       FROM \`${process.env.PROJECT_ID}.${datasetId}.${tableName}\`
-      GROUP BY document_id
+      GROUP BY document_name
     )
     SELECT
-    document_name,
-    t.document_id${groupByColumns.length > 0 ? `,` : ``}
+    t.document_name,
+    document_id${groupByColumns.length > 0 ? `,` : ``}
       ${groupByColumns.join(",")}
     FROM \`${process.env.PROJECT_ID}.${datasetId}.${tableName}\` AS t
-    JOIN latest ON (t.document_id = latest.document_id AND t.${timestampColumnName} = latest.latest_timestamp)
+    JOIN latest ON (t.document_name = latest.document_name AND t.${timestampColumnName} = latest.latest_timestamp)
     WHERE operation != "DELETE"
     GROUP BY document_name, document_id${groupByColumns.length > 0 ? `, ` : ``
     }${groupByColumns.join(",")}`

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/snapshot.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/snapshot.ts
@@ -56,31 +56,19 @@ export function buildLatestSnapshotViewQuery(
     --   event_id: The id of the event that triggered the cloud function mirrored the event.
     --   data: A raw JSON payload of the current state of the document.
     --   document_id: The document id as defined in the Firestore database
+    WITH latest AS (
+      SELECT max(${timestampColumnName}) as latest_timestamp, document_id
+      FROM \`${process.env.PROJECT_ID}.${datasetId}.${tableName}\`
+      GROUP BY document_id
+    )
     SELECT
     document_name,
-    document_id${groupByColumns.length > 0 ? `,` : ``}
+    t.document_id${groupByColumns.length > 0 ? `,` : ``}
       ${groupByColumns.join(",")}
-    FROM (
-      SELECT
-        document_name,
-        document_id,
-        ${groupByColumns
-          .map(
-            (columnName) =>
-              `FIRST_VALUE(${columnName})
-            OVER(PARTITION BY document_name ORDER BY ${timestampColumnName} DESC)
-            AS ${columnName}`
-          )
-          .join(",")}${groupByColumns.length > 0 ? `,` : ``}
-        FIRST_VALUE(operation)
-          OVER(PARTITION BY document_name ORDER BY ${timestampColumnName} DESC) = "DELETE"
-          AS is_deleted
-      FROM \`${process.env.PROJECT_ID}.${datasetId}.${tableName}\`
-      ORDER BY document_name, ${timestampColumnName} DESC
-    )
-    WHERE NOT is_deleted
-    GROUP BY document_name, document_id${
-      groupByColumns.length > 0 ? `, ` : ``
+    FROM \`${process.env.PROJECT_ID}.${datasetId}.${tableName}\` AS t
+    JOIN latest ON (t.document_id = latest.document_id AND t.${timestampColumnName} = latest.latest_timestamp)
+    WHERE operation != "DELETE"
+    GROUP BY document_name, document_id${groupByColumns.length > 0 ? `, ` : ``
     }${groupByColumns.join(",")}`
   );
   return query;

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
@@ -116,18 +116,18 @@ export const buildLatestSchemaSnapshotViewQuery = (
 
   let query = `
       WITH latest AS (
-        SELECT max(timestamp) as latest_timestamp, document_id
+        SELECT max(timestamp) as latest_timestamp, document_name
         FROM \`${process.env.PROJECT_ID}.${datasetId}.${rawTableName}\`
-        GROUP BY document_id
+        GROUP BY document_name
       )
       SELECT
-        document_name,
-        t.document_id,
+        t.document_name,
+        document_id,
         timestamp,
         operation${fieldValueSelectorClauses.length > 0 ? `,` : ``}
         ${fieldValueSelectorClauses}
       FROM \`${process.env.PROJECT_ID}.${datasetId}.${rawTableName}\` AS t
-      JOIN latest ON (t.document_id = latest.document_id AND t.timestamp = latest.latest_timestamp)
+      JOIN latest ON (t.document_name = latest.document_name AND t.timestamp = latest.latest_timestamp)
       WHERE operation != "DELETE"
   `;
   const groupableExtractors = Object.keys(schemaFieldExtractors).filter(

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
@@ -65,13 +65,10 @@ export const buildLatestSchemaSnapshotViewQuery = (
   rawTableName: string,
   schema: FirestoreSchema
 ): any => {
-  const firstValue = (selector: string) => {
-    return `FIRST_VALUE(${selector}) OVER(PARTITION BY document_name ORDER BY timestamp DESC)`;
-  };
   // We need to pass the dataset id into the parser so that we can call the
   // fully qualified json2array persistent user-defined function in the proper
   // scope.
-  const result = processFirestoreSchema(datasetId, "data", schema, firstValue);
+  const result = processFirestoreSchema(datasetId, "data", schema);
   const [
     schemaFieldExtractors,
     schemaFieldArrays,
@@ -111,9 +108,6 @@ export const buildLatestSchemaSnapshotViewQuery = (
     );
   }
 
-  const fieldNameSelectorClauses = Object.keys(schemaFieldExtractors).join(
-    ", "
-  );
   const fieldValueSelectorClauses = Object.values(schemaFieldExtractors).join(
     ", "
   );
@@ -121,25 +115,20 @@ export const buildLatestSchemaSnapshotViewQuery = (
   const schemaHasGeopoints = schemaFieldGeopoints.length > 0;
 
   let query = `
+      WITH latest AS (
+        SELECT max(timestamp) as latest_timestamp, document_id
+        FROM \`${process.env.PROJECT_ID}.${datasetId}.${rawTableName}\`
+        GROUP BY document_id
+      )
       SELECT
         document_name,
-        document_id,
+        t.document_id,
         timestamp,
-        operation${fieldNameSelectorClauses.length > 0 ? `,` : ``}
-        ${fieldNameSelectorClauses}
-      FROM (
-        SELECT
-          document_name,
-          document_id,
-          ${firstValue(`timestamp`)} AS timestamp,
-          ${firstValue(`operation`)} AS operation,
-          ${firstValue(`operation`)} = "DELETE" AS is_deleted${
-    fieldValueSelectorClauses.length > 0 ? `,` : ``
-  }
-          ${fieldValueSelectorClauses}
-        FROM \`${process.env.PROJECT_ID}.${datasetId}.${rawTableName}\`
-      )
-      WHERE NOT is_deleted
+        operation${fieldValueSelectorClauses.length > 0 ? `,` : ``}
+        ${fieldValueSelectorClauses}
+      FROM \`${process.env.PROJECT_ID}.${datasetId}.${rawTableName}\` AS t
+      JOIN latest ON (t.document_id = latest.document_id AND t.timestamp = latest.latest_timestamp)
+      WHERE operation != "DELETE"
   `;
   const groupableExtractors = Object.keys(schemaFieldExtractors).filter(
     (name) =>
@@ -154,46 +143,43 @@ export const buildLatestSchemaSnapshotViewQuery = (
       document_id,
       timestamp,
       operation${groupableExtractors.length > 0 ? `,` : ``}
-      ${
-        groupableExtractors.length > 0
-          ? `${groupableExtractors.join(`, `)}`
-          : ``
-      }
+      ${groupableExtractors.length > 0
+      ? `${groupableExtractors.join(`, `)}`
+      : ``
+    }
   `;
   if (hasNonGroupableFields) {
     query = `
         ${subSelectQuery(
-          query,
+      query,
           /*except=*/ schemaFieldArrays.concat(schemaFieldGeopoints)
-        )}
+    )}
         ${rawTableName}
         ${schemaFieldArrays
-          .map(
-            (
-              arrayFieldName
-            ) => `LEFT JOIN UNNEST(${rawTableName}.${arrayFieldName})
+        .map(
+          (
+            arrayFieldName
+          ) => `LEFT JOIN UNNEST(${rawTableName}.${arrayFieldName})
             AS ${arrayFieldName}_member
             WITH OFFSET ${arrayFieldName}_index`
-          )
-          .join(" ")}
+        )
+        .join(" ")}
       `;
     query = `
         ${query}
         ${groupBy}
-        ${
-          schemaHasArrays
-            ? `, ${schemaFieldArrays
-                .map((name) => `${name}_index, ${name}_member`)
-                .join(", ")}`
-            : ``
-        }
-        ${
-          schemaHasGeopoints
-            ? `, ${schemaFieldGeopoints
-                .map((name) => `${name}_latitude, ${name}_longitude`)
-                .join(", ")}`
-            : ``
-        }
+        ${schemaHasArrays
+        ? `, ${schemaFieldArrays
+          .map((name) => `${name}_index, ${name}_member`)
+          .join(", ")}`
+        : ``
+      }
+        ${schemaHasGeopoints
+        ? `, ${schemaFieldGeopoints
+          .map((name) => `${name}_latitude, ${name}_longitude`)
+          .join(", ")}`
+        : ``
+      }
       `;
   } else {
     query = `


### PR DESCRIPTION
The old script uses FIRST_VALUE and OVER, which sorts the entire changelog and finds the first record for each document. It can result in a memory issue when running BigQuery reading from the latest snapshot. (Resources exceeded during query execution: The query could not be executed in the allotted memory. Peak usage: 110% of limit. Top memory consumer(s):  sort operations used for analytic OVER() clauses: 96%)

The updated script selects the maximum timestamp for each document_id, and joins back with the table by the latest timestamp instead.