### PR TITLE
fix(firestore-send-email) removed duplicate warsaw location

### DIFF
--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -71,8 +71,6 @@ params:
         value: us-east1
       - label: Northern Virginia (us-east4)
         value: us-east4
-      - label: Warsaw (europe-central2)
-        value: europe-central2
       - label: Los Angeles (us-west2)
         value: us-west2
       - label: Salt Lake City (us-west3)


### PR DESCRIPTION
Removed duplicate Warsaw location in `firestore-send-email`.