### PR TITLE
ci: drop Node.js v10 and add v14 to tests job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["10", "12"]
+        node: ["12", "14"]
     name: node.js_${{ matrix.node }}_test
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Dropping Node.js v10 and adding v14 to the CI tests job.

cc @jhuleatt - the branch protection rules on the repo will need updating since `node.js_10_test` is marked as an expected CI status blocking merge - could add `node.js_14_test` in its place. Thanks! 