### PR TITLE
fix(firestore-send-email) empty template attachments fallback to message attachments

### DIFF
--- a/firestore-send-email/functions/__tests__/e2e.test.ts
+++ b/firestore-send-email/functions/__tests__/e2e.test.ts
@@ -33,4 +33,39 @@ describe("e2e testing", () => {
       });
     });
   }, 8000);
+
+  // TODO Requires fix https://github.com/firebase/extensions/pull/713
+  // test("empty template attachments should default to message attachments", async (): Promise<
+  //   void
+  // > => {
+  //   //create template
+  //   const template = await templateCollection.doc("default").set({
+  //     subject: "@{{username}} is now following you!",
+  //   });
+
+  //   const record = {
+  //     to: "test-assertion@email.com",
+  //     message: {
+  //       subject: "test",
+  //       attachments: [{ filename: "{{username}}.jpg" }],
+  //     },
+  //     template: { name: "default", data: { username: "foo" } },
+  //   };
+
+  //   const doc = await mailCollection.add(record);
+
+  //   return new Promise((resolve, reject) => {
+  //     const unsubscribe = doc.onSnapshot((snapshot) => {
+  //       const document = snapshot.data();
+
+  //       if (document.delivery && document.delivery.info) {
+  //         expect(document.delivery.info.accepted[0]).toEqual(record.to);
+  //         expect(document.delivery.info.response).toContain("250 Accepted");
+  //         expect(document.message.attachments.length.toEqual(1));
+  //         unsubscribe();
+  //         resolve();
+  //       }
+  //     });
+  //   });
+  // }, 8000);
 });

--- a/firestore-send-email/functions/lib/index.js
+++ b/firestore-send-email/functions/lib/index.js
@@ -93,7 +93,14 @@ async function preparePayload(payload) {
         if (!template.name) {
             throw new Error(`Template object is missing a 'name' parameter.`);
         }
-        payload.message = Object.assign(payload.message || {}, await templates.render(template.name, template.data));
+        const templateRender = await templates.render(template.name, template.data);
+        const mergeMessage = payload.message || {};
+        const attachments = templateRender.attachments
+            ? templateRender.attachments
+            : mergeMessage.attachments;
+        payload.message = Object.assign(mergeMessage, templateRender, {
+            attachments: attachments || [],
+        });
     }
     let to = [];
     let cc = [];

--- a/firestore-send-email/functions/src/index.ts
+++ b/firestore-send-email/functions/src/index.ts
@@ -103,10 +103,17 @@ async function preparePayload(payload: QueuePayload): Promise<QueuePayload> {
       throw new Error(`Template object is missing a 'name' parameter.`);
     }
 
-    payload.message = Object.assign(
-      payload.message || {},
-      await templates.render(template.name, template.data)
-    );
+    const templateRender = await templates.render(template.name, template.data);
+
+    const mergeMessage = payload.message || {};
+
+    const attachments = templateRender.attachments
+      ? templateRender.attachments
+      : mergeMessage.attachments;
+
+    payload.message = Object.assign(mergeMessage, templateRender, {
+      attachments: attachments || [],
+    });
   }
 
   let to: string[] = [];


### PR DESCRIPTION
fixes: https://github.com/firebase/extensions/issues/716