### PR TITLE
fix(firestore-shorten-urls-bitly): added secret type

### DIFF
--- a/firestore-shorten-urls-bitly/extension.yaml
+++ b/firestore-shorten-urls-bitly/extension.yaml
@@ -115,6 +115,7 @@ params:
 
   - param: BITLY_ACCESS_TOKEN
     label: Bitly access token
+    type: secret
     description: >
       What is your Bitly access token? Generate this access token using [Bitly](https://bitly.com/a/oauth_apps).
     example: a1b2c3d4e5f6g7


### PR DESCRIPTION

Added new `secret` type to the `bitly` extension. This is ahead of the upcoming update for adding new types for sensitive secret / password configuration 