### PR TITLE
fix(storage-resize-images): update package lock file

### DIFF
--- a/storage-resize-images/functions/package-lock.json
+++ b/storage-resize-images/functions/package-lock.json
@@ -16,6 +16,7 @@
 			"devDependencies": {
 				"@types/jest": "^24.0.18",
 				"@types/mkdirp": "^1.0.1",
+				"@types/node": "^14.0.0",
 				"@types/sharp": "^0.25.0",
 				"firebase-functions-test": "^0.2.3",
 				"image-size": "^0.9.3",
@@ -1072,9 +1073,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "16.10.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.9.tgz",
-			"integrity": "sha512-H9ReOt+yqIJPCutkTYjFjlyK6WEMQYT9hLZMlWtOjFQY2ItppsWZ6RJf8Aw+jz5qTYceuHvFgPIaKOHtLAEWBw=="
+			"version": "14.17.27",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.27.tgz",
+			"integrity": "sha512-94+Ahf9IcaDuJTle/2b+wzvjmutxXAEXU6O81JHblYXUg2BDG+dnBy7VxIPHKAyEEDHzCMQydTJuWvrE+Aanzw=="
 		},
 		"node_modules/@types/qs": {
 			"version": "6.9.7",
@@ -9881,9 +9882,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "16.10.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.10.9.tgz",
-			"integrity": "sha512-H9ReOt+yqIJPCutkTYjFjlyK6WEMQYT9hLZMlWtOjFQY2ItppsWZ6RJf8Aw+jz5qTYceuHvFgPIaKOHtLAEWBw=="
+			"version": "14.17.27",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.27.tgz",
+			"integrity": "sha512-94+Ahf9IcaDuJTle/2b+wzvjmutxXAEXU6O81JHblYXUg2BDG+dnBy7VxIPHKAyEEDHzCMQydTJuWvrE+Aanzw=="
 		},
 		"@types/qs": {
 			"version": "6.9.7",


### PR DESCRIPTION
Update to match the latest node type changes.

Fixes: https://github.com/firebase/extensions/issues/781

See https://github.com/firebase/extensions/pull/779 also for related PR/changes.