### PR TITLE
fix(delete-resize-images): tif fix

### DIFF
--- a/storage-resize-images/functions/lib/resize-image.js
+++ b/storage-resize-images/functions/lib/resize-image.js
@@ -44,7 +44,7 @@ function convertType(buffer, format) {
             .webp()
             .toBuffer();
     }
-    if (format === "tiff") {
+    if (format === "tiff" || format === "tif") {
         return sharp(buffer)
             .tiff()
             .toBuffer();
@@ -65,6 +65,7 @@ exports.supportedImageContentTypeMap = {
     jpg: "image/jpeg",
     jpeg: "image/jpeg",
     png: "image/png",
+    tif: "image/tif",
     tiff: "image/tiff",
     webp: "image/webp",
 };

--- a/storage-resize-images/functions/src/resize-image.ts
+++ b/storage-resize-images/functions/src/resize-image.ts
@@ -53,7 +53,7 @@ export function convertType(buffer, format) {
       .toBuffer();
   }
 
-  if (format === "tiff") {
+  if (format === "tiff" || format === "tif") {
     return sharp(buffer)
       .tiff()
       .toBuffer();
@@ -76,6 +76,7 @@ export const supportedImageContentTypeMap = {
   jpg: "image/jpeg",
   jpeg: "image/jpeg",
   png: "image/png",
+  tif: "image/tif",
   tiff: "image/tiff",
   webp: "image/webp",
 };


### PR DESCRIPTION
fixes: #787

## Checklist

- [X] fix format tif image conversion

## Tests

**Update Engine**
<img width="1410" alt="Screenshot 2021-11-19 at 22 36 10" src="https://user-images.githubusercontent.com/64485499/142700554-028019ad-9e5f-4f4f-a242-4013cc930f68.png">

**Installed extension with settings**
![Screenshot 2021-11-19 at 22 37 06](https://user-images.githubusercontent.com/64485499/142700524-af241c10-3848-4acc-b1fd-bdbf28becbd4.png)

**Successful result with logs**
![Screenshot 2021-11-19 at 22 31 13](https://user-images.githubusercontent.com/64485499/142700496-bd0632d7-022e-4932-908b-bcaaf4aa5f2b.png)
![Screenshot 2021-11-19 at 22 31 24](https://user-images.githubusercontent.com/64485499/142700499-b4b32542-bfbb-4fae-bb51-1b4c203dbf44.png)


