### PR TITLE
fix(storage-resize-images): fix samsung encoded jpg resizing

### DIFF
--- a/storage-resize-images/functions/lib/resize-image.js
+++ b/storage-resize-images/functions/lib/resize-image.js
@@ -19,7 +19,7 @@ function resize(file, size) {
     else {
         throw new Error("height and width are not delimited by a ',' or a 'x'");
     }
-    return sharp(file)
+    return sharp(file, { failOnError: false })
         .rotate()
         .resize(parseInt(width, 10), parseInt(height, 10), {
         fit: "inside",

--- a/storage-resize-images/functions/src/resize-image.ts
+++ b/storage-resize-images/functions/src/resize-image.ts
@@ -25,7 +25,7 @@ export function resize(file, size) {
     throw new Error("height and width are not delimited by a ',' or a 'x'");
   }
 
-  return sharp(file)
+  return sharp(file, { failOnError: false })
     .rotate()
     .resize(parseInt(width, 10), parseInt(height, 10), {
       fit: "inside",


### PR DESCRIPTION
fixes: #755

I was able to recreate the issue and apply recommended setting to avoid the bug. I have checked the metadata of the photo and found that it was taken with Samsung phone. Sharp maintainers mentioned this solution in below topics:

[https://github.com/lovell/sharp/issues?q=VipsJpeg%3A+Invalid+SOS+parameters](https://github.com/lovell/sharp/issues?q=VipsJpeg%3A+Invalid+SOS+parameters)

Photo used to recreate the bug:
[https://gist.githubusercontent.com/mnaoumov/060166a995eb75666d95203a1d9f468b/raw/6a2b0f46422beb63a4aea4185463edbda96d04cb/5242.jpg](https://gist.githubusercontent.com/mnaoumov/060166a995eb75666d95203a1d9f468b/raw/6a2b0f46422beb63a4aea4185463edbda96d04cb/5242.jpg)

## Checklist

- [x] add failOnError prop to false for one of the sharp functions

## Test

**Update Engine**
![Screenshot 2021-11-20 at 12 28 15](https://user-images.githubusercontent.com/64485499/142726657-b26f48e9-1fb6-468a-ad04-a923ca5b1270.png)



**Installed extension with settings**
![Screenshot 2021-11-20 at 12 24 47](https://user-images.githubusercontent.com/64485499/142726666-efed4ff3-27c1-4695-bb69-f7e250bd1ab8.png)
![Screenshot 2021-11-20 at 12 24 33](https://user-images.githubusercontent.com/64485499/142726667-6d7adcde-cecf-4cfc-99c7-31f69001e904.png)


**Successful result with logs**
![Screenshot 2021-11-20 at 12 27 50](https://user-images.githubusercontent.com/64485499/142726723-916e85f3-54e4-4d64-befd-457d83a0ef64.png)
![Screenshot 2021-11-20 at 12 43 58](https://user-images.githubusercontent.com/64485499/142731809-472a35d3-d8ec-4202-a368-008c41b493a2.png)
![Screenshot 2021-11-20 at 12 44 17](https://user-images.githubusercontent.com/64485499/142726757-332c7090-533d-4d51-b93b-b6b404afe314.png)



