### PR TITLE
Set lib compiler option to es2018 in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["es6"],
+    "lib": ["es2018"],
     "module": "commonjs",
     "noImplicitReturns": true,
     "sourceMap": false,


### PR DESCRIPTION
Github checks fail with this error:
```
Error: node_modules/@google-cloud/firestore/types/v1/firestore_client.d.ts(768,6): error TS2583: Cannot find name 'AsyncIterable'. Do you need to change your target library? Try changing the 'lib' compiler option to 'es2018' or later.
```
This PR fixes that.