### PR TITLE
fix(firestore-bigquery-export): import script date

### DIFF
--- a/firestore-bigquery-export/scripts/import/src/index.ts
+++ b/firestore-bigquery-export/scripts/import/src/index.ts
@@ -324,7 +324,7 @@ const run = async (): Promise<number> => {
     cursor = docs[docs.length - 1];
     const rows: FirestoreDocumentChangeEvent[] = docs.map((snapshot) => {
       return {
-        timestamp: new Date(0).toISOString(), // epoch
+        timestamp: new Date().toISOString(), // epoch
         operation: ChangeType.IMPORT,
         documentName: `projects/${projectId}/databases/${FIRESTORE_DEFAULT_DATABASE}/documents/${
           snapshot.ref.path

--- a/firestore-bigquery-export/scripts/import/src/run.ts
+++ b/firestore-bigquery-export/scripts/import/src/run.ts
@@ -135,7 +135,7 @@ async function processCollection(config: CliConfig): Promise<number> {
 
     const rows: FirestoreDocumentChangeEvent = docs.map((document) => {
       return {
-        timestamp: new Date(0).toISOString(),
+        timestamp: new Date().toISOString(),
         operation: ChangeType.IMPORT,
         documentName: `projects/${
           config.projectId

--- a/firestore-bigquery-export/scripts/import/src/worker.ts
+++ b/firestore-bigquery-export/scripts/import/src/worker.ts
@@ -54,7 +54,7 @@ async function processDocuments(
 
   const rows: FirestoreDocumentChangeEvent = docs.map((document) => {
     return {
-      timestamp: new Date(0).toISOString(),
+      timestamp: new Date().toISOString(),
       operation: ChangeType.IMPORT,
       documentName: `projects/${projectId}/databases/(default)/documents/${
         document.ref.path


### PR DESCRIPTION
fixes: #741

## Problems
When using import script timestamp date is 1970-01-01 00:00:00 UTC and it should show the actual date of the import.
<img width="932" alt="Screenshot 2021-12-22 at 15 48 20" src="https://user-images.githubusercontent.com/64485499/147111337-d5fe900f-8cd0-4c22-8ce7-ae833e6904dc.png">


## Solution
Show the actual timestamp date of import.

## Fixes
- fix new Date in index, run and worker

## Successful fix screenshots
<img width="1316" alt="Screenshot 2021-12-22 at 15 50 17" src="https://user-images.githubusercontent.com/64485499/147111518-e5fd2e06-2952-46a6-ba13-47bffa26177b.png">

