### PR TITLE
feat(firestore-bigquery-export): add clustering

### DIFF
--- a/firestore-bigquery-export/README.md
+++ b/firestore-bigquery-export/README.md
@@ -60,6 +60,8 @@ To install an extension, your project must be on the [Blaze (pay as you go) plan
 
 * BigQuery SQL table partitioning option: This parameter will allow you to partition the BigQuery table and BigQuery view  created by the extension based on data ingestion time. You may select the granularity of partitioning based upon one of: HOUR, DAY, MONTH, YEAR. This will generate one partition per day, hour, month or year, respectively. 
 
+* BigQuery SQL table clustering (experimental): This parameter will allow you to set up Clustering for the BigQuery Table created by the extension. (for example: `data,document_id,timestamp`- no whitespaces). You can select up to 4 coma separated fields(order matters).  Available schema extensions table fields for clustering: `document_id, timestamp, event_id, operation, data`.
+
 
 
 **Cloud Functions:**

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -249,4 +249,15 @@ params:
         value: NONE
     default: NONE
     required: true
-    
+
+  - param: CLUSTERING
+    label: BigQuery SQL table clustering (experimental)
+    description: >-
+      This parameter will allow you to set up Clustering for the BigQuery Table
+      created by the extension. (for example: `data,document_id,timestamp`- no whitespaces). You can select up to 4 coma separated fields(order matters). 
+      Available schema extensions table fields for clustering: `document_id, timestamp, event_id, operation, data`.
+    type: string
+    validationRegex: ^[^,\s]+(?:,[^,\s]+){0,3}$
+    validationErrorMessage: No whitespaces. Max 4 fields. e.g. `data,timestamp,event_id,operation`
+    example: data,document_id,timestamp
+    required: false

--- a/firestore-bigquery-export/functions/__tests__/__snapshots__/config.test.ts.snap
+++ b/firestore-bigquery-export/functions/__tests__/__snapshots__/config.test.ts.snap
@@ -2,6 +2,10 @@
 
 exports[`extension config config loaded from environment variables 1`] = `
 Object {
+  "clustering": Array [
+    "data",
+    "timestamp",
+  ],
   "collectionPath": undefined,
   "datasetId": "my_dataset",
   "datasetLocation": undefined,
@@ -9,6 +13,19 @@ Object {
   "location": "us-central1",
   "tableId": "my_table",
   "tablePartitioning": null,
+}
+`;
+
+exports[`extension config config.clustering param exists 1`] = `
+Object {
+  "description": "This parameter will allow you to set up Clustering for the BigQuery Table created by the extension. (for example: \`data,document_id,timestamp\`- no whitespaces). You can select up to 4 coma separated fields(order matters).  Available schema extensions table fields for clustering: \`document_id, timestamp, event_id, operation, data\`.",
+  "example": "data,document_id,timestamp",
+  "label": "BigQuery SQL table clustering (experimental)",
+  "param": "CLUSTERING",
+  "required": false,
+  "type": "string",
+  "validationErrorMessage": "No whitespaces. Max 4 fields. e.g. \`data,timestamp,event_id,operation\`",
+  "validationRegex": "^[^,\\\\s]+(?:,[^,\\\\s]+){0,3}$",
 }
 `;
 

--- a/firestore-bigquery-export/functions/__tests__/config.test.ts
+++ b/firestore-bigquery-export/functions/__tests__/config.test.ts
@@ -5,6 +5,8 @@ import { resolve as pathResolve } from "path";
 import * as yaml from "js-yaml";
 import mockedEnv from "mocked-env";
 
+import { clustering } from "../src/config";
+
 let restoreEnv;
 let extensionYaml;
 let extensionParams;
@@ -13,6 +15,7 @@ const environment = {
   LOCATION: "us-central1",
   DATASET_ID: "my_dataset",
   TABLE_ID: "my_table",
+  CLUSTERING: "data,timestamp",
 };
 
 const { config } = global;
@@ -41,7 +44,9 @@ describe("extension config", () => {
       location: environment.LOCATION,
       datasetId: environment.DATASET_ID,
       tableId: environment.TABLE_ID,
+      clustering: clustering(environment.CLUSTERING),
     };
+
     expect(config()).toMatchSnapshot(env);
   });
 
@@ -98,6 +103,45 @@ describe("extension config", () => {
         expect(
           Boolean("my_table".match(new RegExp(validationRegex)))
         ).toBeTruthy();
+      });
+    });
+  });
+
+  // CLUSTERING TESTING
+  describe("config.clustering", () => {
+    test("param exists", () => {
+      const extensionParam = extensionParams["CLUSTERING"];
+      expect(extensionParam).toMatchSnapshot();
+    });
+
+    describe("validationRegex", () => {
+      // test("does not allow empty strings", () => {
+      //   expect(Boolean("".match(new RegExp(validationRegex)))).toBeFalsy();
+      // });
+      test("does not allow spaces", () => {
+        const { validationRegex } = extensionParams["CLUSTERING"];
+        console.log(validationRegex);
+        expect(
+          Boolean("foo, bar".match(new RegExp(validationRegex)))
+        ).toBeFalsy();
+      });
+
+      test("allows a alphanumeric underscore ids", () => {
+        const { validationRegex } = extensionParams["CLUSTERING"];
+        expect(
+          Boolean("event_id,timestamp".match(new RegExp(validationRegex)))
+        ).toBeTruthy();
+      });
+
+      test("allows max 4 fields", () => {
+        const { validationRegex } = extensionParams["CLUSTERING"];
+        expect(
+          Boolean(
+            "document_id,timestamp,event_id,operation,data".match(
+              new RegExp(validationRegex)
+            )
+          )
+        ).toBeFalsy();
       });
     });
   });

--- a/firestore-bigquery-export/functions/lib/config.js
+++ b/firestore-bigquery-export/functions/lib/config.js
@@ -24,6 +24,9 @@ function tablePartitioning(type) {
     }
     return null;
 }
+function clustering(clusters) {
+    return clusters ? clusters.split(",").slice(0, 4) : null;
+}
 exports.default = {
     collectionPath: process.env.COLLECTION_PATH,
     datasetId: process.env.DATASET_ID,
@@ -32,4 +35,5 @@ exports.default = {
     initialized: false,
     datasetLocation: process.env.DATASET_LOCATION,
     tablePartitioning: tablePartitioning(process.env.TABLE_PARTITIONING),
+    clustering: clustering(process.env.CLUSTERING),
 };

--- a/firestore-bigquery-export/functions/lib/index.js
+++ b/firestore-bigquery-export/functions/lib/index.js
@@ -25,6 +25,7 @@ const eventTracker = new firestore_bigquery_change_tracker_1.FirestoreBigQueryEv
     datasetId: config_1.default.datasetId,
     datasetLocation: config_1.default.datasetLocation,
     tablePartitioning: config_1.default.tablePartitioning,
+    clustering: config_1.default.clustering,
 });
 logs.init();
 exports.fsexportbigquery = functions.handler.firestore.document.onWrite(async (change, context) => {

--- a/firestore-bigquery-export/functions/src/config.ts
+++ b/firestore-bigquery-export/functions/src/config.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-function tablePartitioning(type) {
+function tablePartitioning(type: string) {
   if (
     type === "HOUR" ||
     type === "DAY" ||
@@ -27,6 +27,10 @@ function tablePartitioning(type) {
   return null;
 }
 
+export function clustering(clusters: string | undefined) {
+  return clusters ? clusters.split(",").slice(0, 4) : null;
+}
+
 export default {
   collectionPath: process.env.COLLECTION_PATH,
   datasetId: process.env.DATASET_ID,
@@ -35,4 +39,5 @@ export default {
   initialized: false,
   datasetLocation: process.env.DATASET_LOCATION,
   tablePartitioning: tablePartitioning(process.env.TABLE_PARTITIONING),
+  clustering: clustering(process.env.CLUSTERING),
 };

--- a/firestore-bigquery-export/functions/src/index.ts
+++ b/firestore-bigquery-export/functions/src/index.ts
@@ -30,6 +30,7 @@ const eventTracker: FirestoreEventHistoryTracker = new FirestoreBigQueryEventHis
     datasetId: config.datasetId,
     datasetLocation: config.datasetLocation,
     tablePartitioning: config.tablePartitioning,
+    clustering: config.clustering,
   }
 );
 


### PR DESCRIPTION
**DO NOT MERGE** 
 #851  NEED TO BE PUBLISHED FIRST AND VERSION OF `firestore-bigquery-extension-tracker`  ON `package.json` NEED TO BE UPDATED BEFORE MERGING.

fixes: #550 



## Feature
 - add clustering on portioned BigQuery created table
 
 ## Jobs
- [x] pass clustering parameter to `firestore-bigquery-extension-tracker` function.
- [x] add `clustering` function for config.ts to trim to the correct maximum amount of clustering fields (4)
- [x] add `clustering` config.test.ts unit tests(4)
- [x] add regex validation (4 words, no whitespaces) with error message
- [x] update config.test.ts snapshot
- [x] add config.test.ts unit tests
- [x] make manual tests screenshots with update on `firestore-bigquery-extension-tracker` deployed  on npm for tests: #851 
 
## Tests
**Update Engine**
![Screenshot 2022-01-15 at 15 51 27](https://user-images.githubusercontent.com/64485499/149630048-c45009af-6303-4db5-b7ba-cfa8d512f7b8.png)

**Installation and configuration of extension**
![Screenshot 2022-01-15 at 15 40 30](https://user-images.githubusercontent.com/64485499/149630046-59955085-16e7-4cff-8820-c2893e011bbb.png)

**Successful results**
![Screenshot 2022-01-15 at 15 50 34](https://user-images.githubusercontent.com/64485499/149630076-dd2fdb68-b672-4b42-9773-592896a51d8a.png)
![Screenshot 2022-01-15 at 15 40 19](https://user-images.githubusercontent.com/64485499/149630105-286ac140-e437-4cf4-a745-92a54f776a79.png)


## Extra tests
**No Clustering**
![Screenshot 2022-01-15 at 16 14 32](https://user-images.githubusercontent.com/64485499/149630137-3af1a02a-c59b-4fe6-9f77-1e92f1d60d4a.png)
![Screenshot 2022-01-15 at 16 15 33](https://user-images.githubusercontent.com/64485499/149630144-1b8fc60a-d84e-447b-a076-b04ebc3479bc.png)
![Screenshot 2022-01-15 at 16 14 56](https://user-images.githubusercontent.com/64485499/149630151-49f35912-b36d-4d1d-996c-683a1f5592a6.png)
![Screenshot 2022-01-15 at 16 14 12](https://user-images.githubusercontent.com/64485499/149630185-4ee436b7-3aa6-44a0-aa3c-f0ebf21c322f.png)

