### PR TITLE
fix(storage-resize-images): add gif for first frame resize

### DIFF
--- a/storage-resize-images/README.md
+++ b/storage-resize-images/README.md
@@ -18,6 +18,7 @@ You can even configure the extension to create resized images of different dimen
 
 The extension automatically copies the following metadata, if present, from the original image to the resized image(s): `Cache-Control`, `Content-Disposition`, `Content-Encoding`, `Content-Language`, `Content-Type`, and user-provided metadata (a new Firebase storage download token will be generated on the resized image(s) if the original metadata contains a token). Note that you can optionally configure the extension to overwrite the [`Cache-Control`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control) value for the resized image(s).
 
+Please note. This extension does not  support animation for GIF and WEBP formats. You can convert the image and receive a resized static image with first frame of the animation. To convert all other images formats as GIFs you can use "original" option as an output types. (GIF=>GIF case).
 #### Detailed configuration information
 
 To configure this extension, you specify a maximum width and a maximum height (in pixels, px). This extension keeps the aspect ratio of uploaded images constant and shrinks the image until the resized image's dimensions are at or under your specified max width and height.

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -228,7 +228,7 @@ params:
     label: Convert image to preferred types
     description: >
       The image types you'd like your source image to convert to. The default for this option will 
-      be to keep the original file type.
+      be to keep the original file type. (animated types will result with static images with first frame of the animation)
     type: multiSelect
     options:
       - label: jpeg

--- a/storage-resize-images/functions/lib/resize-image.js
+++ b/storage-resize-images/functions/lib/resize-image.js
@@ -60,6 +60,7 @@ exports.supportedContentTypes = [
     "image/png",
     "image/tiff",
     "image/webp",
+    "image/gif",
 ];
 exports.supportedImageContentTypeMap = {
     jpg: "image/jpeg",
@@ -68,6 +69,7 @@ exports.supportedImageContentTypeMap = {
     tif: "image/tif",
     tiff: "image/tiff",
     webp: "image/webp",
+    gif: "image/gif",
 };
 const supportedExtensions = Object.keys(exports.supportedImageContentTypeMap).map((type) => `.${type}`);
 exports.modifyImage = async ({ bucket, originalFile, fileDir, fileNameWithoutExtension, fileExtension, contentType, size, objectMetadata, format, }) => {

--- a/storage-resize-images/functions/src/resize-image.ts
+++ b/storage-resize-images/functions/src/resize-image.ts
@@ -70,6 +70,7 @@ export const supportedContentTypes = [
   "image/png",
   "image/tiff",
   "image/webp",
+  "image/gif",
 ];
 
 export const supportedImageContentTypeMap = {
@@ -79,6 +80,7 @@ export const supportedImageContentTypeMap = {
   tif: "image/tif",
   tiff: "image/tiff",
   webp: "image/webp",
+  gif: "image/gif",
 };
 
 const supportedExtensions = Object.keys(supportedImageContentTypeMap).map(


### PR DESCRIPTION


## Jobs

- [x] add gif and webp support for converting an image with first frame animation and annotation

## Testing
**Update Engine**
![Screenshot 2021-11-25 at 17 58 15](https://user-images.githubusercontent.com/64485499/143485666-a73dc2e4-85a8-4839-aff0-277881750ac0.png)

**Installation and configuration of extension**
![Screenshot 2021-11-25 at 17 41 58](https://user-images.githubusercontent.com/64485499/143485383-f6c844fc-0c94-4282-9d0f-ab72267ed5c4.png)
![Screenshot 2021-11-25 at 17 41 47](https://user-images.githubusercontent.com/64485499/143485393-4de9999b-f471-4a95-a1a7-297d35ad112b.png)

**Successful results**
![Screenshot 2021-11-25 at 17 41 19](https://user-images.githubusercontent.com/64485499/143485807-93461dda-7a6b-48c0-a6bb-f2fda0c796ad.png)
![Screenshot 2021-11-25 at 17 41 25](https://user-images.githubusercontent.com/64485499/143485810-8062b49e-66c4-4dd1-a62c-6d2d3ee66b99.png)


