### PR TITLE
fix(firestore-bigquery-change-tracker): added additional checks on table creation

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -148,6 +148,11 @@ export class FirestoreBigQueryEventHistoryTracker
     return isRetryable;
   }
 
+  /**
+   * Tables can often take time to create and propagate.
+   * A half a second delay is added per check while the function
+   * continually re-checks until the referenced dataset and table become available.
+   */
   private async waitForInitialization(dataset, table) {
     return new Promise((resolve) => {
       let handle = setTimeout(async () => {

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -158,7 +158,7 @@ export class FirestoreBigQueryEventHistoryTracker
           clearTimeout(handle);
           return resolve(table);
         }
-      }, 2000);
+      }, 500);
     });
   }
 

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -155,12 +155,12 @@ export class FirestoreBigQueryEventHistoryTracker
    */
   private async waitForInitialization(dataset, table) {
     return new Promise((resolve) => {
-      let handle = setTimeout(async () => {
+      let handle = setInterval(async () => {
         const [datasetExists] = await dataset.exists();
         const [tableExists] = await table.exists();
 
         if (datasetExists && tableExists) {
-          clearTimeout(handle);
+          clearInterval(handle);
           return resolve(table);
         }
       }, 500);

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/logs.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/logs.ts
@@ -168,3 +168,7 @@ export const timestampMissingValue = (fieldName: string) => {
 export const addDocumentIdColumn = (table) => {
   logger.log(`Updated '${table}' table with a 'document_id' column`);
 };
+
+export const tableCreationError = (table, message) => {
+  logger.warn(`Error caught creating table`, message);
+};


### PR DESCRIPTION
  - [x] Table creation errors are now caught, allowing records to still be written if creating through a race condition.
  - [x] Additional database checks added before writing data to BigQuery


fixes: https://github.com/firebase/extensions/issues/869