### PR TITLE
fix(firestore-bigquery-export): updated the bq projectId to be required and to default as the current firebase project

### DIFF
--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -192,10 +192,11 @@ params:
   - param: BIGQUERY_PROJECT_ID
     label: Project Id
     description: >-
-      Override the default project bigquery instance. 
+      Override the default project bigquery instance.
       This can allow updates to be directed to a bigquery instance on another project.
     type: string
-    required: false
+    default: ${param:PROJECT_ID}
+    required: true
 
   - param: COLLECTION_PATH
     label: Collection path

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -195,7 +195,7 @@ params:
       Override the default project bigquery instance.
       This can allow updates to be directed to a bigquery instance on another project.
     type: string
-    default: ${param:PROJECT_ID}
+    default: ${PROJECT_ID}
     required: true
 
   - param: COLLECTION_PATH


### PR DESCRIPTION
Originally a BigQuery Project Id was allowed to be left as an optional field and would default to the current firebase project that the extension is running on.

With this field blank, documentation would show this as an `unspecified parameter`. This update ensures that a `project name` is always provided for the extension to synchronise data with and to always provide a `BigQuery Project Name` for the extensions documentation.


## Testing

### Default Id

<img width="587" alt="image" src="https://user-images.githubusercontent.com/2060661/156645920-954a72f8-ed06-4613-87e6-26551c169179.png">

<img width="561" alt="image" src="https://user-images.githubusercontent.com/2060661/156646261-315966df-d9a5-4f42-bd52-2b594aa968d3.png">



### Alternaitve id

<img width="611" alt="image" src="https://user-images.githubusercontent.com/2060661/156645786-2dfa8eae-7cd5-4e1f-b33c-4531852e11c8.png">

### No Id

<img width="419" alt="image" src="https://user-images.githubusercontent.com/2060661/156646640-5dc1725c-ec71-4e02-ae6d-ae2694fe3841.png">
