### PR TITLE
feat(firestore-bigquery-export): added JSON data type to the default bigquery schema

### DIFF
--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -323,6 +323,20 @@ params:
     example: data,document_id,timestamp
     required: false
 
+  - param: DATA_FORMAT
+    label: Select how to store data in the big query table
+    description: >-
+      Choose how to store synced firestore data within your bigquery table. 
+      JSON is currently in Beta https://cloud.google.com/bigquery/docs/reference/standard-sql/json-data
+    type: select
+    options:
+      - label: string
+        value: STRING
+      - label: json
+        value: JSON
+    default: string
+    required: true
+
   - param: BACKUP_COLLECTION
     label: Backup Collection Name
     description: >-

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
@@ -10,6 +10,7 @@
   "main": "./lib/index.js",
   "scripts": {
     "build": "npm run clean && npm run compile",
+    "build:watch": "npm run clean && tsc --watch",
     "clean": "rimraf lib",
     "compile": "tsc",
     "test:local": "firebase ext:dev:emulators:exec ./node_modules/.bin/jest --test-params=./src/__tests__/emulator-params.env --project=extensions-testing --config=./src/__tests__/firebase.json",
@@ -39,7 +40,7 @@
     "rimraf": "^2.6.3",
     "nyc": "^14.0.0",
     "jest": "^24.9.0",
-    "chai": "^4.2.0",
+    "chai": "^4.3.6",
     "ts-node": "^7.0.1",
     "ts-jest": "^24.1.0",
     "@types/jest": "^24.0.18",

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/e2e.test.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/e2e.test.ts
@@ -46,6 +46,7 @@ describe("e2e testing", () => {
         await changeTracker({
           datasetId,
           tableId,
+          data_format: "JSON",
         }).record([event]);
 
         const [changelogColumn, latestColumn] = await getTableDataColumns(
@@ -70,8 +71,6 @@ describe("e2e testing", () => {
           datasetId,
           tableId
         );
-
-        console.log(latestRows, changeLogRows);
       });
     });
   });

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/e2e.test.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/e2e.test.ts
@@ -10,6 +10,8 @@ import { FirestoreDocumentChangeEvent } from "../..";
 import { latestConsistentSnapshotView } from "../../bigquery/snapshot";
 import { deleteTable } from "../fixtures/clearTables";
 import { changeTracker, changeTrackerEvent } from "../fixtures/changeTracker";
+import { getBigQueryTableData } from "../fixtures/queries";
+import { getTableDataColumns } from "../fixtures/metadata";
 
 process.env.PROJECT_ID = "extensions-testing";
 
@@ -26,7 +28,7 @@ let dataset: Dataset;
 let table: Table;
 let view: Table;
 
-describe("Partitioning", () => {
+describe("e2e testing", () => {
   beforeEach(async () => {
     randomID = (Math.random() + 1).toString(36).substring(7);
     datasetId = `dataset_${randomID}`;
@@ -36,243 +38,278 @@ describe("Partitioning", () => {
   });
 
   afterEach(async () => {
-    await deleteTable({
-      datasetId,
+    await deleteTable({ datasetId });
+  });
+  describe("Schema", () => {
+    describe("a non existing dataset and table", () => {
+      test("successfully creates a data column as a JSON data type", async () => {
+        await changeTracker({
+          datasetId,
+          tableId,
+        }).record([event]);
+
+        const [changelogColumn, latestColumn] = await getTableDataColumns(
+          process.env.PROJECT_ID,
+          datasetId,
+          tableId,
+          "data"
+        );
+
+        /* check valid field type */
+        expect(changelogColumn).toBeDefined();
+        expect(changelogColumn.type).toEqual("JSON");
+
+        expect(latestColumn).toBeDefined();
+        expect(latestColumn.type).toEqual("JSON");
+
+        /* TODO: Add JSON data checks when preview available / feature enabled.
+         * See preview statement https://cloud.google.com/bigquery/docs/reference/standard-sql/json-data
+         */
+        const [changeLogRows, latestRows] = await getBigQueryTableData(
+          process.env.PROJECT_ID,
+          datasetId,
+          tableId
+        );
+
+        console.log(latestRows, changeLogRows);
+      });
     });
   });
 
-  describe("a non existing dataset and table", () => {
-    test("does not partition without a defined timePartitioning option", async () => {
-      await changeTracker({
-        datasetId,
-        tableId,
-      }).record([event]);
+  describe("Partitioning", () => {
+    describe("a non existing dataset and table", () => {
+      test("does not partition without a defined timePartitioning option", async () => {
+        await changeTracker({
+          datasetId,
+          tableId,
+        }).record([event]);
 
-      const [metadata] = await dataset.table(tableId_raw).getMetadata();
+        const [metadata] = await dataset.table(tableId_raw).getMetadata();
 
-      expect(metadata.timePartitioning).toBeUndefined();
-    });
-
-    test("does not partition with an unrecognized timePartitioning option", async () => {
-      await changeTracker({
-        datasetId,
-        tableId,
-        timePartitioning: "UNKNOWN",
-      }).record([event]);
-
-      const [metadata] = await dataset.table(tableId_raw).getMetadata();
-
-      expect(metadata.timePartitioning).toBeUndefined();
-    });
-
-    test("successfully partitions a changelog table with a timePartitioning option only", async () => {
-      await changeTracker({
-        datasetId,
-        tableId,
-        timePartitioning: "HOUR",
-      }).record([event]);
-
-      const [metadata] = await dataset.table(tableId_raw).getMetadata();
-
-      expect(metadata.timePartitioning).toBeDefined();
-    });
-
-    test("successfully partitions latest view table with a timePartitioning option only", async () => {
-      await changeTracker({
-        datasetId,
-        tableId,
-        timePartitioning: "HOUR",
-      }).record([event]);
-
-      const [metadata] = await dataset
-        .table(`${tableId}_raw_latest`)
-        .getMetadata();
-
-      expect(metadata.timePartitioning).toBeDefined();
-    });
-
-    test("does not partition with without a valid timePartitioningField when including timePartitioning, timePartitioningFieldType and timePartitioningFirestoreField", async () => {
-      await changeTracker({
-        datasetId,
-        tableId,
-        timePartitioning: "HOUR",
-        timePartitioningField: null,
-        timePartitioningFieldType: "TIMESTAMP",
-        timePartitioningFirestoreField: "end_date",
-      }).record([event]);
-
-      const [metadata] = await dataset.table(tableId_raw).getMetadata();
-
-      expect(metadata.timePartitioning).toBeUndefined();
-    });
-
-    test("does not partition with without a valid timePartitioningFieldType", async () => {
-      await changeTracker({
-        datasetId,
-        tableId,
-        timePartitioning: "HOUR",
-        timePartitioningField: "endDate",
-        timePartitioningFirestoreField: "end_date",
-      }).record([event]);
-
-      const [metadata] = await dataset.table(tableId_raw).getMetadata();
-
-      expect(metadata.timePartitioning).toBeUndefined();
-    });
-
-    test("does not partition with an unknown timePartitioningFieldType", async () => {
-      await changeTracker({
-        datasetId,
-        tableId,
-        timePartitioning: "HOUR",
-        timePartitioningField: "endDate",
-        timePartitioningFieldType: "unknown",
-        timePartitioningFirestoreField: "end_date",
-      }).record([event]);
-
-      const [metadata] = await dataset.table(tableId_raw).getMetadata();
-
-      expect(metadata.timePartitioning).toBeUndefined();
-    });
-
-    test("does not partition with an unknown timePartitioningFirestoreField", async () => {
-      await changeTracker({
-        datasetId,
-        tableId,
-        timePartitioning: "HOUR",
-        timePartitioningField: "endDate",
-        timePartitioningFieldType: "TIMESTAMP",
-        // timePartitioningFirestoreField: "unknown",
-      }).record([event]);
-
-      const [metadata] = await dataset.table(tableId_raw).getMetadata();
-
-      expect(metadata.timePartitioning).toBeUndefined();
-    });
-
-    test("Should not partition when timePartitioningFieldType is a DATE type HOUR has been set as timePartitioning field", async () => {
-      await changeTracker({
-        datasetId,
-        tableId,
-        timePartitioning: "HOUR",
-        timePartitioningField: "endDate",
-        timePartitioningFieldType: "DATE",
-        timePartitioningFirestoreField: "end_date",
-      }).record([event]);
-
-      const [metadata] = await dataset.table(tableId_raw).getMetadata();
-
-      expect(metadata.timePartitioning).toBeUndefined();
-    });
-  });
-
-  describe("a pre existing dataset, table and view", () => {
-    beforeEach(async () => {
-      [dataset] = await bq.dataset(datasetId).create();
-      [table] = await dataset.createTable(tableId_raw, {
-        schema: RawChangelogSchema,
+        expect(metadata.timePartitioning).toBeUndefined();
       });
 
-      const latestSnapshot = latestConsistentSnapshotView(
-        datasetId,
-        tableId_raw,
-        RawChangelogViewSchema
-      );
+      test("does not partition with an unrecognized timePartitioning option", async () => {
+        await changeTracker({
+          datasetId,
+          tableId,
+          timePartitioning: "UNKNOWN",
+        }).record([event]);
 
-      [view] = await dataset.createTable(`${tableId}_raw_latest`, {
-        view: latestSnapshot,
+        const [metadata] = await dataset.table(tableId_raw).getMetadata();
+
+        expect(metadata.timePartitioning).toBeUndefined();
+      });
+
+      test("successfully partitions a changelog table with a timePartitioning option only", async () => {
+        await changeTracker({
+          datasetId,
+          tableId,
+          timePartitioning: "HOUR",
+        }).record([event]);
+
+        const [metadata] = await dataset.table(tableId_raw).getMetadata();
+
+        expect(metadata.timePartitioning).toBeDefined();
+      });
+
+      test("successfully partitions latest view table with a timePartitioning option only", async () => {
+        await changeTracker({
+          datasetId,
+          tableId,
+          timePartitioning: "HOUR",
+        }).record([event]);
+
+        const [metadata] = await dataset
+          .table(`${tableId}_raw_latest`)
+          .getMetadata();
+
+        expect(metadata.timePartitioning).toBeDefined();
+      });
+
+      test("does not partition with without a valid timePartitioningField when including timePartitioning, timePartitioningFieldType and timePartitioningFirestoreField", async () => {
+        await changeTracker({
+          datasetId,
+          tableId,
+          timePartitioning: "HOUR",
+          timePartitioningField: null,
+          timePartitioningFieldType: "TIMESTAMP",
+          timePartitioningFirestoreField: "end_date",
+        }).record([event]);
+
+        const [metadata] = await dataset.table(tableId_raw).getMetadata();
+
+        expect(metadata.timePartitioning).toBeUndefined();
+      });
+
+      test("does not partition with without a valid timePartitioningFieldType", async () => {
+        await changeTracker({
+          datasetId,
+          tableId,
+          timePartitioning: "HOUR",
+          timePartitioningField: "endDate",
+          timePartitioningFirestoreField: "end_date",
+        }).record([event]);
+
+        const [metadata] = await dataset.table(tableId_raw).getMetadata();
+
+        expect(metadata.timePartitioning).toBeUndefined();
+      });
+
+      test("does not partition with an unknown timePartitioningFieldType", async () => {
+        await changeTracker({
+          datasetId,
+          tableId,
+          timePartitioning: "HOUR",
+          timePartitioningField: "endDate",
+          timePartitioningFieldType: "unknown",
+          timePartitioningFirestoreField: "end_date",
+        }).record([event]);
+
+        const [metadata] = await dataset.table(tableId_raw).getMetadata();
+
+        expect(metadata.timePartitioning).toBeUndefined();
+      });
+
+      test("does not partition with an unknown timePartitioningFirestoreField", async () => {
+        await changeTracker({
+          datasetId,
+          tableId,
+          timePartitioning: "HOUR",
+          timePartitioningField: "endDate",
+          timePartitioningFieldType: "TIMESTAMP",
+          // timePartitioningFirestoreField: "unknown",
+        }).record([event]);
+
+        const [metadata] = await dataset.table(tableId_raw).getMetadata();
+
+        expect(metadata.timePartitioning).toBeUndefined();
+      });
+
+      test("Should not partition when timePartitioningFieldType is a DATE type HOUR has been set as timePartitioning field", async () => {
+        await changeTracker({
+          datasetId,
+          tableId,
+          timePartitioning: "HOUR",
+          timePartitioningField: "endDate",
+          timePartitioningFieldType: "DATE",
+          timePartitioningFirestoreField: "end_date",
+        }).record([event]);
+
+        const [metadata] = await dataset.table(tableId_raw).getMetadata();
+
+        expect(metadata.timePartitioning).toBeUndefined();
       });
     });
 
-    test("does not update an existing non partitioned table, that has a valid schema with timePartitioning only", async () => {
-      await changeTracker({
-        datasetId,
-        tableId,
-        timePartitioning: "HOUR",
-      }).record([event]);
+    describe("a pre existing dataset, table and view", () => {
+      beforeEach(async () => {
+        [dataset] = await bq.dataset(datasetId).create();
+        [table] = await dataset.createTable(tableId_raw, {
+          schema: RawChangelogSchema,
+        });
 
-      const [metadata] = await dataset.table(tableId_raw).getMetadata();
+        const latestSnapshot = latestConsistentSnapshotView(
+          datasetId,
+          tableId_raw,
+          RawChangelogViewSchema
+        );
 
-      expect(metadata.timePartitioning).toBeUndefined();
-
-      expect(consoleLogSpyWarn).toBeCalledWith(
-        `Cannot partition an existing table ${datasetId}_${tableId_raw}`
-      );
-      expect(consoleLogSpyWarn).toBeCalledWith(
-        `Cannot partition an existing table ${datasetId}_${tableId}_raw_latest`
-      );
-      expect(consoleLogSpy).toBeCalledWith(
-        `BigQuery dataset already exists: ${datasetId}`
-      );
-      expect(consoleLogSpy).toBeCalledWith(
-        `BigQuery table with name ${tableId_raw} already exists in dataset ${datasetId}!`
-      );
-      expect(consoleLogSpy).toBeCalledWith(
-        `View with id ${tableId}_raw_latest already exists in dataset ${datasetId}.`
-      );
-    });
-
-    test("does not update an existing non partitioned table, that has valid custom partitioning configuration", async () => {
-      await changeTracker({
-        datasetId,
-        tableId,
-        timePartitioning: "HOUR",
-        timePartitioningField: "endDate",
-        timePartitioningFieldType: "DATE",
-        timePartitioningFirestoreField: "end_date",
-      }).record([event]);
-
-      const [metadata] = await dataset.table(tableId_raw).getMetadata();
-
-      expect(metadata.timePartitioning).toBeUndefined();
-    });
-
-    test("does not update add a custom partitioning column when the relevant partitioning exists", async () => {
-      await changeTracker({
-        datasetId,
-        tableId,
-        timePartitioning: "HOUR",
-        timePartitioningField: "endDate",
-        timePartitioningFieldType: "DATE",
-        timePartitioningFirestoreField: "end_date",
-      }).record([event]);
-
-      const [metadata] = await dataset.table(tableId_raw).getMetadata();
-
-      expect(
-        metadata.schema.fields.filter(($) => $.name === "endDate").length
-      ).toBe(0);
-
-      expect(metadata.timePartitioning).toBeUndefined();
-    });
-
-    test("does not add an additional custom when the field column already exists", async () => {
-      // Add a custom field to the table.
-      const [metaData] = await table.getMetadata();
-
-      metaData.schema.fields.push({
-        name: "custom_field",
-        mode: "NULLABLE",
-        type: "Date",
-        description: "example custom field",
+        [view] = await dataset.createTable(`${tableId}_raw_latest`, {
+          view: latestSnapshot,
+        });
       });
 
-      await table.setMetadata(metaData);
+      test("does not update an existing non partitioned table, that has a valid schema with timePartitioning only", async () => {
+        await changeTracker({
+          datasetId,
+          tableId,
+          timePartitioning: "HOUR",
+        }).record([event]);
 
-      await changeTracker({
-        datasetId,
-        tableId,
-        timePartitioning: "DAY",
-        timePartitioningField: "custom_field",
-        timePartitioningFieldType: "DATE",
-        timePartitioningFirestoreField: "custom_field",
-      }).record([event]);
+        const [metadata] = await dataset.table(tableId_raw).getMetadata();
 
-      const [metadata] = await dataset.table(tableId_raw).getMetadata();
+        expect(metadata.timePartitioning).toBeUndefined();
 
-      expect(
-        metadata.schema.fields.filter(($) => $.name === "custom_field").length
-      ).toBe(1);
+        expect(consoleLogSpyWarn).toBeCalledWith(
+          `Cannot partition an existing table ${datasetId}_${tableId_raw}`
+        );
+        expect(consoleLogSpyWarn).toBeCalledWith(
+          `Cannot partition an existing table ${datasetId}_${tableId}_raw_latest`
+        );
+        expect(consoleLogSpy).toBeCalledWith(
+          `BigQuery dataset already exists: ${datasetId}`
+        );
+        expect(consoleLogSpy).toBeCalledWith(
+          `BigQuery table with name ${tableId_raw} already exists in dataset ${datasetId}!`
+        );
+        expect(consoleLogSpy).toBeCalledWith(
+          `View with id ${tableId}_raw_latest already exists in dataset ${datasetId}.`
+        );
+      });
+
+      test("does not update an existing non partitioned table, that has valid custom partitioning configuration", async () => {
+        await changeTracker({
+          datasetId,
+          tableId,
+          timePartitioning: "HOUR",
+          timePartitioningField: "endDate",
+          timePartitioningFieldType: "DATE",
+          timePartitioningFirestoreField: "end_date",
+        }).record([event]);
+
+        const [metadata] = await dataset.table(tableId_raw).getMetadata();
+
+        expect(metadata.timePartitioning).toBeUndefined();
+      });
+
+      test("does not update add a custom partitioning column when the relevant partitioning exists", async () => {
+        await changeTracker({
+          datasetId,
+          tableId,
+          timePartitioning: "HOUR",
+          timePartitioningField: "endDate",
+          timePartitioningFieldType: "DATE",
+          timePartitioningFirestoreField: "end_date",
+        }).record([event]);
+
+        const [metadata] = await dataset.table(tableId_raw).getMetadata();
+
+        expect(
+          metadata.schema.fields.filter(($) => $.name === "endDate").length
+        ).toBe(0);
+
+        expect(metadata.timePartitioning).toBeUndefined();
+      });
+
+      test("does not add an additional custom when the field column already exists", async () => {
+        // Add a custom field to the table.
+        const [metaData] = await table.getMetadata();
+
+        metaData.schema.fields.push({
+          name: "custom_field",
+          mode: "NULLABLE",
+          type: "Date",
+          description: "example custom field",
+        });
+
+        await table.setMetadata(metaData);
+
+        await changeTracker({
+          datasetId,
+          tableId,
+          timePartitioning: "DAY",
+          timePartitioningField: "custom_field",
+          timePartitioningFieldType: "DATE",
+          timePartitioningFirestoreField: "custom_field",
+        }).record([event]);
+
+        const [metadata] = await dataset.table(tableId_raw).getMetadata();
+
+        expect(
+          metadata.schema.fields.filter(($) => $.name === "custom_field").length
+        ).toBe(1);
+      });
     });
   });
 });

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/snapshot.test.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/snapshot.test.ts
@@ -46,6 +46,7 @@ const trackerInstance = new FirestoreBigQueryEventHistoryTracker({
   timePartitioningFieldType: undefined,
   timePartitioningFirestoreField: undefined,
   clustering: null,
+  data_format: "STRING",
   bqProjectId: null,
 });
 

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/fixtures/changeTracker.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/fixtures/changeTracker.ts
@@ -16,6 +16,7 @@ export const changeTracker = ({
   timePartitioningFirestoreField = null,
   transformFunction = null,
   clustering = null,
+  data_format = "STRING",
   bqProjectId = "extensions-testing",
 }): FirestoreBigQueryEventHistoryTracker => {
   return new FirestoreBigQueryEventHistoryTracker({
@@ -29,6 +30,7 @@ export const changeTracker = ({
     timePartitioningFirestoreField,
     transformFunction,
     clustering,
+    data_format,
     bqProjectId,
   });
 };

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/fixtures/metadata.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/fixtures/metadata.ts
@@ -1,0 +1,30 @@
+import { BigQuery } from "@google-cloud/bigquery";
+
+export const getTableDataColumns = async (
+  bqProjectId,
+  datasetId,
+  tableId,
+  column_name
+) => {
+  const bq = new BigQuery();
+
+  const [latest_metadata] = await bq
+    .dataset(bqProjectId)
+    .table(`${tableId}_raw_changelog`)
+    .getMetadata();
+
+  const latest_dataColumn = latest_metadata.schema.fields.filter(
+    ($) => $.name === column_name
+  )[0];
+
+  const [changelog_metadata] = await bq
+    .dataset(datasetId)
+    .table(`${tableId}_raw_latest`)
+    .getMetadata();
+
+  const changelog_dataColumn = changelog_metadata.schema.fields.filter(
+    ($) => $.name === column_name
+  )[0];
+
+  return [latest_dataColumn, changelog_dataColumn];
+};

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/fixtures/metadata.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/fixtures/metadata.ts
@@ -1,15 +1,15 @@
 import { BigQuery } from "@google-cloud/bigquery";
 
 export const getTableDataColumns = async (
-  bqProjectId,
+  projectId,
   datasetId,
   tableId,
   column_name
 ) => {
-  const bq = new BigQuery();
+  const bq = new BigQuery({ projectId });
 
   const [latest_metadata] = await bq
-    .dataset(bqProjectId)
+    .dataset(datasetId)
     .table(`${tableId}_raw_changelog`)
     .getMetadata();
 

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/schema.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/schema.ts
@@ -22,7 +22,8 @@ export type BigQueryFieldType =
   | "NUMERIC"
   | "RECORD"
   | "STRING"
-  | "TIMESTAMP";
+  | "TIMESTAMP"
+  | "JSON";
 export type BigQueryField = {
   fields?: BigQueryField[];
   mode: BigQueryFieldMode;
@@ -43,7 +44,7 @@ const bigQueryField = (
 });
 
 // These field types form the basis of the `raw` data table
-export const dataField = bigQueryField("data", "STRING", "NULLABLE");
+export const dataField = bigQueryField("data", "JSON", "NULLABLE");
 export const documentNameField = bigQueryField(
   "document_name",
   "STRING",
@@ -113,7 +114,7 @@ export const RawChangelogViewSchema = {
     {
       name: "data",
       mode: "NULLABLE",
-      type: "STRING",
+      type: "JSON",
       description:
         "The full JSON representation of the current document state.",
     },
@@ -153,7 +154,7 @@ export const RawChangelogSchema = {
     {
       name: "data",
       mode: "NULLABLE",
-      type: "STRING",
+      type: "JSON",
       description:
         "The full JSON representation of the document state after the indicated operation is applied. This field will be null for DELETE operations.",
     },

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/schema.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/schema.ts
@@ -77,6 +77,78 @@ export const documentPathParams = {
     "JSON string representing wildcard params with Firestore Document ids",
 };
 
+const defaultSchemaFields = [
+  {
+    name: "timestamp",
+    mode: "REQUIRED",
+    type: "TIMESTAMP",
+    description:
+      "The commit timestamp of this change in Cloud Firestore. If the operation is IMPORT, this timestamp is epoch to ensure that any operation on an imported document supersedes the IMPORT.",
+  },
+  {
+    name: "event_id",
+    mode: "REQUIRED",
+    type: "STRING",
+    description:
+      "The ID of the document change event that triggered the Cloud Function created by the extension. Empty for imports.",
+  },
+  {
+    name: "document_name",
+    mode: "REQUIRED",
+    type: "STRING",
+    description:
+      "The full name of the changed document, for example, projects/collection/databases/(default)/documents/users/me).",
+  },
+  {
+    name: "operation",
+    mode: "REQUIRED",
+    type: "STRING",
+    description: "One of CREATE, UPDATE, IMPORT, or DELETE.",
+  },
+];
+
+const defaultViewSchemaFields = [
+  {
+    name: "timestamp",
+    mode: "NULLABLE",
+    type: "TIMESTAMP",
+    description:
+      "The commit timestamp of this change in Cloud Firestore. If the operation is IMPORT, this timestamp is epoch to ensure that any operation on an imported document supersedes the IMPORT.",
+  },
+  {
+    name: "event_id",
+    mode: "NULLABLE",
+    type: "STRING",
+    description:
+      "The ID of the most-recent document change event that triggered the Cloud Function created by the extension. Empty for imports.",
+  },
+  {
+    name: "document_name",
+    mode: "NULLABLE",
+    type: "STRING",
+    description:
+      "The full name of the changed document, for example, projects/collection/databases/(default)/documents/users/me).",
+  },
+  {
+    name: "operation",
+    mode: "NULLABLE",
+    type: "STRING",
+    description: "One of CREATE, UPDATE, IMPORT.",
+  },
+];
+
+export const SelectRawChangelogViewSchema = (type = "STRING") => {
+  if (type === "STRING") return RawChangelogViewSchema;
+
+  return RawChangelogJSONViewSchema;
+};
+
+export const SelectRawChangelogSchema = (type = "STRING") => {
+  if (type === "STRING") return RawChangelogSchema;
+
+  return RawChangelogJSONSchema;
+};
+
 /*
  * We cannot specify a schema for view creation, and all view columns default
  * to the NULLABLE mode.
@@ -84,33 +156,21 @@ export const documentPathParams = {
 
 export const RawChangelogViewSchema = {
   fields: [
+    ...defaultViewSchemaFields,
     {
-      name: "timestamp",
-      mode: "NULLABLE",
-      type: "TIMESTAMP",
-      description:
-        "The commit timestamp of this change in Cloud Firestore. If the operation is IMPORT, this timestamp is epoch to ensure that any operation on an imported document supersedes the IMPORT.",
-    },
-    {
-      name: "event_id",
+      name: "data",
       mode: "NULLABLE",
       type: "STRING",
       description:
-        "The ID of the most-recent document change event that triggered the Cloud Function created by the extension. Empty for imports.",
+        "The full JSON representation of the current document state.",
     },
-    {
-      name: "document_name",
-      mode: "NULLABLE",
-      type: "STRING",
-      description:
-        "The full name of the changed document, for example, projects/collection/databases/(default)/documents/users/me).",
-    },
-    {
-      name: "operation",
-      mode: "NULLABLE",
-      type: "STRING",
-      description: "One of CREATE, UPDATE, IMPORT.",
-    },
+    documentIdField,
+  ],
+};
+
+export const RawChangelogJSONViewSchema = {
+  fields: [
+    ...defaultViewSchemaFields,
     {
       name: "data",
       mode: "NULLABLE",
@@ -124,33 +184,21 @@ export const RawChangelogViewSchema = {
 
 export const RawChangelogSchema = {
   fields: [
+    ...defaultSchemaFields,
     {
-      name: "timestamp",
-      mode: "REQUIRED",
-      type: "TIMESTAMP",
-      description:
-        "The commit timestamp of this change in Cloud Firestore. If the operation is IMPORT, this timestamp is epoch to ensure that any operation on an imported document supersedes the IMPORT.",
-    },
-    {
-      name: "event_id",
-      mode: "REQUIRED",
+      name: "data",
+      mode: "NULLABLE",
       type: "STRING",
       description:
-        "The ID of the document change event that triggered the Cloud Function created by the extension. Empty for imports.",
+        "The full JSON representation of the document state after the indicated operation is applied. This field will be null for DELETE operations.",
     },
-    {
-      name: "document_name",
-      mode: "REQUIRED",
-      type: "STRING",
-      description:
-        "The full name of the changed document, for example, projects/collection/databases/(default)/documents/users/me).",
-    },
-    {
-      name: "operation",
-      mode: "REQUIRED",
-      type: "STRING",
-      description: "One of CREATE, UPDATE, IMPORT, or DELETE.",
-    },
+    documentIdField,
+  ],
+};
+
+export const RawChangelogJSONSchema = {
+  fields: [
+    ...defaultSchemaFields,
     {
       name: "data",
       mode: "NULLABLE",

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/snapshot.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/snapshot.ts
@@ -62,7 +62,9 @@ export function buildLatestSnapshotViewQuery(
     SELECT
     document_name,
     document_id${groupByColumns.length > 0 ? `,` : ``}
-      ${groupByColumns.join(",")}
+      ${groupByColumns
+        .map(($) => ($ !== "data" ? $ : "TO_JSON_STRING(data) as data"))
+        .join(",")}
     FROM (
       SELECT
         document_name,

--- a/firestore-bigquery-export/functions/src/config.ts
+++ b/firestore-bigquery-export/functions/src/config.ts
@@ -49,5 +49,6 @@ export default {
       : undefined,
   timePartitioningFirestoreField: process.env.TIME_PARTITIONING_FIRESTORE_FIELD,
   clustering: clustering(process.env.CLUSTERING),
+  data_format: process.env.DATA_FORMAT || "STRING",
   wildcardIds: process.env.WILDCARD_IDS === "true" ? true : false,
 };

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
@@ -210,7 +210,9 @@ export function updateFirestoreSchemaFields(fields: FirestoreField[]) {
  */
 function decorateSchemaWithChangelogFields(schema: any): any {
   let decorated: any = { fields: schema.fields };
-  const changelogSchemaFields: any[] = RawChangelogViewSchema.fields;
+  const changelogSchemaFields: any[] = RawChangelogViewSchema(
+    this.config.data_format
+  ).fields;
   for (let i = 0; i < changelogSchemaFields.length; i++) {
     if (
       changelogSchemaFields[i].name === "event_id" ||


### PR DESCRIPTION
The BigQuery extension currently uses a `stringified` JSON object to store data when synching from Firestore. This PR prepares for when a JSON type becomes available.

A new JSON datatype is currently in preview and can be tracked here https://cloud.google.com/bigquery/docs/reference/standard-sql/json-data

- [x] Update the default schema to use a JSON datatype
- [ ] Ensure new tables are generated with the new datatype

fixes: https://github.com/firebase/extensions/issues/1775