### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/firestore-counter/clients/node/index.js
+++ b/firestore-counter/clients/node/index.js
@@ -38,10 +38,10 @@ module.exports = class Counter {
     const shardsRef = doc.collection(SHARD_COLLECTION_ID);
     this.shards[doc.path] = 0;
     this.shards[shardsRef.doc(this.shardId).path] = 0;
-    this.shards[shardsRef.doc("\t" + this.shardId.substr(0, 4)).path] = 0;
-    this.shards[shardsRef.doc("\t\t" + this.shardId.substr(0, 3)).path] = 0;
-    this.shards[shardsRef.doc("\t\t\t" + this.shardId.substr(0, 2)).path] = 0;
-    this.shards[shardsRef.doc("\t\t\t\t" + this.shardId.substr(0, 1)).path] = 0;
+    this.shards[shardsRef.doc("\t" + this.shardId.slice(0, 4)).path] = 0;
+    this.shards[shardsRef.doc("\t\t" + this.shardId.slice(0, 3)).path] = 0;
+    this.shards[shardsRef.doc("\t\t\t" + this.shardId.slice(0, 2)).path] = 0;
+    this.shards[shardsRef.doc("\t\t\t\t" + this.shardId.slice(0, 1)).path] = 0;
   }
 
   /**

--- a/firestore-counter/clients/web/src/index.ts
+++ b/firestore-counter/clients/web/src/index.ts
@@ -46,10 +46,10 @@ export class Counter {
     const shardsRef = doc.collection(SHARD_COLLECTION_ID);
     this.shards[doc.path] = 0;
     this.shards[shardsRef.doc(this.shardId).path] = 0;
-    this.shards[shardsRef.doc("\t" + this.shardId.substr(0, 4)).path] = 0;
-    this.shards[shardsRef.doc("\t\t" + this.shardId.substr(0, 3)).path] = 0;
-    this.shards[shardsRef.doc("\t\t\t" + this.shardId.substr(0, 2)).path] = 0;
-    this.shards[shardsRef.doc("\t\t\t\t" + this.shardId.substr(0, 1)).path] = 0;
+    this.shards[shardsRef.doc("\t" + this.shardId.slice(0, 4)).path] = 0;
+    this.shards[shardsRef.doc("\t\t" + this.shardId.slice(0, 3)).path] = 0;
+    this.shards[shardsRef.doc("\t\t\t" + this.shardId.slice(0, 2)).path] = 0;
+    this.shards[shardsRef.doc("\t\t\t\t" + this.shardId.slice(0, 1)).path] = 0;
   }
 
   /**


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.