### PR TITLE
fix(storage-resize-images): check if the outputOptions param is undefined to prevent unnecessary error log

### DIFF
--- a/storage-resize-images/functions/src/resize-image.ts
+++ b/storage-resize-images/functions/src/resize-image.ts
@@ -43,10 +43,12 @@ export function convertType(buffer, format) {
     tiff: {},
     tif: {},
   };
-  try {
-    outputOptions = JSON.parse(config.outputOptions);
-  } catch (e) {
-    logs.errorOutputOptionsParse(e);
+  if (config.outputOptions) {
+    try {
+      outputOptions = JSON.parse(config.outputOptions);
+    } catch (e) {
+      logs.errorOutputOptionsParse(e);
+    }
   }
   const { jpeg, jpg, png, webp, tiff, tif } = outputOptions;
 


### PR DESCRIPTION
Currently, if no OUTPUT_OPTIONS is provided then an error log is printed, even though this param is optional: 
<img width="985" alt="image" src="https://user-images.githubusercontent.com/5347038/162259703-37daf40b-b82e-4d45-a1e3-288bfe9b3ac3.png">

This PR updates to first check if a value has actually been set.