### PR TITLE
fix(firestore-send-email): move log statement outside of forEach loop

### DIFF
--- a/firestore-send-email/functions/src/logs.ts
+++ b/firestore-send-email/functions/src/logs.ts
@@ -93,8 +93,8 @@ export function partialRegistered(name) {
   logger.log(`registered partial '${name}'`);
 }
 
-export function templateLoaded(name) {
-  logger.log(`loaded template '${name}'`);
+export function templatesLoaded(names) {
+  logger.log(`loaded templates (${names})`);
 }
 
 export function invalidMessage(message) {

--- a/firestore-send-email/functions/src/templates.ts
+++ b/firestore-send-email/functions/src/templates.ts
@@ -20,10 +20,10 @@ import { TemplateGroup, TemplateData, Attachment } from "./types";
 
 import {
   registeredPartial,
-  templateLoaded,
   noPartialAttachmentSupport,
   checkingMissingTemplate,
   foundMissingTemplate,
+  templatesLoaded,
 } from "./logs";
 
 const subjHandlebars = create();
@@ -83,7 +83,7 @@ export default class Templates {
       registeredPartial(p.name);
     });
 
-    templates.forEach((t) => {
+    const loadedTemplates = templates.map((t) => {
       const tgroup: TemplateGroup = {};
       if (t.subject) {
         tgroup.subject = subjHandlebars.compile(t.subject, { noEscape: true });
@@ -106,8 +106,10 @@ export default class Templates {
 
       this.templateMap[t.name] = tgroup;
 
-      templateLoaded(t.name);
+      return t.name;
     });
+    templatesLoaded(loadedTemplates);
+
     this.ready = true;
     this.waits.forEach((wait) => wait());
   }

--- a/firestore-send-email/functions/src/templates.ts
+++ b/firestore-send-email/functions/src/templates.ts
@@ -103,9 +103,8 @@ export default class Templates {
           { strict: true }
         );
       }
-
+      
       this.templateMap[t.name] = tgroup;
-
       return t.name;
     });
     templatesLoaded(loadedTemplates);

--- a/firestore-send-email/functions/src/templates.ts
+++ b/firestore-send-email/functions/src/templates.ts
@@ -103,8 +103,9 @@ export default class Templates {
           { strict: true }
         );
       }
-      
+
       this.templateMap[t.name] = tgroup;
+
       return t.name;
     });
     templatesLoaded(loadedTemplates);


### PR DESCRIPTION
Currently, there is a logger inside the template loading forEach loop. It logs `loaded template {template-name}` message after each template loads.

Moved the logger outside the forEach and converted the message to `loaded templates {template,name,array}` to log the message only once.

fixes: #944