### PR TITLE
feat(firestore-bigquery-change-tracker): expose type declarations

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
@@ -8,6 +8,7 @@
   "version": "1.1.15",
   "description": "Core change-tracker library for Cloud Firestore Collection BigQuery Exports",
   "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "scripts": {
     "build": "npm run clean && npm run compile",
     "clean": "rimraf lib",
@@ -17,6 +18,8 @@
   },
   "files": [
     "lib/*.js",
+    "lib/*.d.ts",
+    "lib/bigquery/*.d.ts",
     "lib/bigquery/*.js"
   ],
   "author": "Jan Wyszynski <wyszynski@google.com>",

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/tsconfig.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "lib",
     "types": ["node", "jest", "chai"],
-    "target": "ES2020"
+    "target": "ES2020",
+    "declaration": true,
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Expose the types in firestore-bigquery-change-tracker so that it can be imported to other projects.