### PR TITLE
docs(firestore-bigquery-export): improve clustering description on installation guide

### DIFF
--- a/firestore-bigquery-export/README.md
+++ b/firestore-bigquery-export/README.md
@@ -102,7 +102,7 @@ To install an extension, your project must be on the [Blaze (pay as you go) plan
 
 * BigQuery SQL Time Partitioning table schema field(column) type: Parameter for BigQuery SQL schema field type for the selected Time Partitioning Firestore Document field option. Cannot be changed if Table is already partitioned.
 
-* BigQuery SQL table clustering: This parameter will allow you to set up Clustering for the BigQuery Table created by the extension. (for example: `data,document_id,timestamp`- no whitespaces). You can select up to 4 comma separated fields(order matters).  Available schema extensions table fields for clustering: `document_id, timestamp, event_id, operation, data`.
+* BigQuery SQL table clustering: This parameter will allow you to set up Clustering for the BigQuery Table created by the extension. (for example: `data,document_id,timestamp`- no whitespaces). You can select up to 4 comma separated fields. When you specify multiple columns, the order of the columns determines how the data is sorted. For example, if the table is clustered by columns a, b and c, the data is sorted in the same order: first by column a, then by column b, and then by column c. As a best practice, place the most frequently filtered or aggregated column first.  Available schema extensions table fields for clustering: `document_id, timestamp, event_id, operation, data`.
 
 * Backup Collection Name: This (optional) parameter will allow you to specify a collection for which failed BigQuery updates will be written to.
 

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -146,7 +146,7 @@ params:
       - label: Sao Paulo (southamerica-east1)
         value: southamerica-east1
       - label: South Carolina (us-east1)
-        value: us-east1    
+        value: us-east1
       - label: Belgium (europe-west1)
         value: europe-west1
       - label: Finland (europe-north1)
@@ -156,7 +156,7 @@ params:
       - label: London (europe-west2)
         value: europe-west2
       - label: Netherlands (europe-west4)
-        value: europe-west4  
+        value: europe-west4
       - label: Zurich (europe-west6)
         value: europe-west6
       - label: Taiwan (asia-east1)
@@ -176,7 +176,7 @@ params:
       - label: Singapore (asia-southeast1)
         value: asia-southeast1
       - label: Sydney (australia-southeast1)
-        value: australia-southeast1  
+        value: australia-southeast1
       - label: Taiwan (asia-east1)
         value: asia-east1
       - label: Tokyo (asia-northeast1)
@@ -184,10 +184,10 @@ params:
       - label: United States (multi-regional)
         value: us
       - label: Europe (multi-regional)
-        value: eu      
+        value: eu
     default: us
     required: true
-    immutable: true 
+    immutable: true
 
   - param: BIGQUERY_PROJECT_ID
     label: Project Id
@@ -269,13 +269,13 @@ params:
       - label: day
         value: DAY
       - label: month
-        value: MONTH 
+        value: MONTH
       - label: year
         value: YEAR
       - label: none
         value: NONE
     default: NONE
-    required: true 
+    required: true
 
   - param: TIME_PARTITIONING_FIELD
     label: BigQuery Time Partitioning column name
@@ -315,7 +315,7 @@ params:
     label: BigQuery SQL table clustering
     description: >-
       This parameter will allow you to set up Clustering for the BigQuery Table
-      created by the extension. (for example: `data,document_id,timestamp`- no whitespaces). You can select up to 4 comma separated fields(order matters). 
+      created by the extension. (for example: `data,document_id,timestamp`- no whitespaces). You can select up to 4 comma separated fields. When you specify multiple columns, the order of the columns determines how the data is sorted. For example, if the table is clustered by columns a, b and c, the data is sorted in the same order: first by column a, then by column b, and then by column c. As a best practice, place the most frequently filtered or aggregated column first. 
       Available schema extensions table fields for clustering: `document_id, timestamp, event_id, operation, data`.
     type: string
     validationRegex: ^[^,\s]+(?:,[^,\s]+){0,3}$
@@ -329,7 +329,7 @@ params:
       This (optional) parameter will allow you to specify a collection for which failed BigQuery updates
       will be written to.
     type: string
-    
+
   - param: TRANSFORM_FUNCTION
     label: Transform function URL
     description: >-
@@ -338,4 +338,3 @@ params:
     example: https://us-west1-my-project-id.cloudfunctions.net/myTransformFunction
     type: string
     required: false
-    


### PR DESCRIPTION
Update the clustering param ordering description

fixes: #958