### PR TITLE
feat(storage-resize-images): add an option to make the resized images public

### DIFF
--- a/storage-resize-images/README.md
+++ b/storage-resize-images/README.md
@@ -52,6 +52,8 @@ To install an extension, your project must be on the [Blaze (pay as you go) plan
 
 * Deletion of original file: Do you want to automatically delete the original file from the Cloud Storage bucket? Note that these deletions cannot be undone.
 
+* Make resized images public: Do you want to make the resized images public automatically? So you can access them by URL. For example: https://storage.googleapis.com/{bucket}/{path}
+
 * Cloud Storage path for resized images: A relative path in which to store resized images. For example, if you specify a path here of `thumbs` and you upload an image to `/images/original.jpg`, then the resized image is stored at `/images/thumbs/original_200x200.jpg`. If you prefer to store resized images at the root of your bucket, leave this field empty.
 
 

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -162,9 +162,22 @@ params:
       - label: No
         value: false
       - label: Delete on successful resize
-        value: on_success  
+        value: on_success
     default: false
     required: true
+
+  - param: MAKE_PUBLIC
+    label: Make resized images public
+    description: >-
+      Do you want to make the resized images public automatically? So you can access them by URL.
+      For example: https://storage.googleapis.com/{bucket}/{path}
+    type: select
+    options:
+      - label: Yes
+        value: true
+      - label: No
+        value: false
+    default: false
 
   - param: RESIZED_IMAGES_PATH
     label: Cloud Storage path for resized images

--- a/storage-resize-images/functions/src/config.ts
+++ b/storage-resize-images/functions/src/config.ts
@@ -39,6 +39,7 @@ export default {
   bucket: process.env.IMG_BUCKET,
   cacheControlHeader: process.env.CACHE_CONTROL_HEADER,
   imageSizes: process.env.IMG_SIZES.split(","),
+  makePublic: process.env.MAKE_PUBLIC === "true",
   resizedImagesPath: process.env.RESIZED_IMAGES_PATH,
   includePathList: paramToArray(process.env.INCLUDE_PATH_LIST),
   excludePathList: paramToArray(process.env.EXCLUDE_PATH_LIST),

--- a/storage-resize-images/functions/src/resize-image.ts
+++ b/storage-resize-images/functions/src/resize-image.ts
@@ -222,11 +222,16 @@ export const modifyImage = async ({
 
     // Uploading the modified image.
     logs.imageUploading(modifiedFilePath);
-    await bucket.upload(modifiedFile, {
+    const uploadResponse = await bucket.upload(modifiedFile, {
       destination: modifiedFilePath,
       metadata,
     });
     logs.imageUploaded(modifiedFile);
+
+    // Make uploaded image public.
+    if (config.makePublic) {
+      await uploadResponse[0].makePublic();
+    }
 
     return { size, outputFilePath: modifiedFilePath, success: true };
   } catch (err) {


### PR DESCRIPTION
Add an opt-in param to make the generated resized images public automatically, so they can be accessed by URL like: https://storage.googleapis.com/{bucket}/{path}

fixes: #140
fixes: https://github.com/firebase/extensions/issues/1029