### PR TITLE
feat: add version to the bigquery import script

### DIFF
--- a/firestore-bigquery-export/scripts/import/src/index.ts
+++ b/firestore-bigquery-export/scripts/import/src/index.ts
@@ -101,8 +101,12 @@ const validateLocation = (value: string) => {
   return index !== -1;
 };
 
+const packageJson = require("../package.json");
+
 program
   .name("fs-bq-import-collection")
+  .description(packageJson.description)
+  .version(packageJson.version)
   .option(
     "--non-interactive",
     "Parse all input from command line flags instead of prompting the caller.",


### PR DESCRIPTION
Just to check the version of the used script, will be easier to ask users what version is crashing.