### PR TITLE
fix(firestore-bigquery-export): updated bigquery.googleapis.com api reference

### DIFF
--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -38,7 +38,7 @@ contributors:
 billingRequired: true
 
 apis:
-  - apiName: bigquery-json.googleapis.com
+  - apiName: bigquery.googleapis.com
     reason: Mirrors data from your Cloud Firestore collection in BigQuery.
 
 roles:


### PR DESCRIPTION
The api resource `bigquery-json.googleapis.com` appears to now been fully deprecated when publishing an extension.

Updating to `bigquery.googleapis.com`