### PR TITLE
feat(storage-resize-images): include original image data in events

### DIFF
--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -156,6 +156,7 @@ export const generateResizedImage = functions.storage.object().onFinalize(
           type: "firebase.extensions.storage-resize-images.v1.complete",
           subject: filePath,
           data: {
+            input: object,
             outputs: results,
           },
         }));


### PR DESCRIPTION
Include the original image metadata object in the event.
Metadata object shape: https://firebase.google.com/docs/reference/functions/providers_storage.objectmetadata
fixes #1019