### PR TITLE
feat(firestore-translate-text): add `LANGUAGES_FIELD_NAME` param

### DIFF
--- a/firestore-translate-text/extension.yaml
+++ b/firestore-translate-text/extension.yaml
@@ -156,3 +156,12 @@ params:
     example: translated
     default: translated
     required: true
+
+  - param: LANGUAGES_FIELD_NAME
+    label: Languages field name
+    description: >
+      What is the name of the field that contains the languages that you want to translate into? This field is
+      optional. If you don't specify it, the extension will use the languages specified in the LANGUAGES parameter.
+    example: languages
+    default: languages
+    required: false

--- a/firestore-translate-text/functions/__tests__/__snapshots__/config.test.ts.snap
+++ b/firestore-translate-text/functions/__tests__/__snapshots__/config.test.ts.snap
@@ -9,6 +9,7 @@ Object {
     "de",
     "fr",
   ],
+  "languagesFieldName": undefined,
   "location": "us-central1",
   "outputFieldName": "translated",
 }

--- a/firestore-translate-text/functions/__tests__/config.test.ts
+++ b/firestore-translate-text/functions/__tests__/config.test.ts
@@ -51,7 +51,13 @@ describe("extension config", () => {
   test("config loaded from environment variables", () => {
     const functionsConfig = config();
 
-    expect(functionsConfig).toMatchSnapshot({});
+    expect(functionsConfig).toMatchSnapshot({
+      languages: ["en", "es", "de", "fr"],
+      languagesFieldName: undefined,
+      location: "us-central1",
+      inputFieldName: "input",
+      outputFieldName: "translated",
+    });
   });
 
   test("config is logged on initialize", () => {

--- a/firestore-translate-text/functions/src/config.ts
+++ b/firestore-translate-text/functions/src/config.ts
@@ -19,4 +19,5 @@ export default {
   location: process.env.LOCATION,
   inputFieldName: process.env.INPUT_FIELD_NAME,
   outputFieldName: process.env.OUTPUT_FIELD_NAME,
+  languagesFieldName: process.env.LANGUAGES_FIELD_NAME,
 };


### PR DESCRIPTION
fixes: #1142
One of the feature requests reported in #1038