### PR TITLE
feat(storage-resize-images): add AVIF codec support

### DIFF
--- a/storage-resize-images/PREINSTALL.md
+++ b/storage-resize-images/PREINSTALL.md
@@ -11,6 +11,8 @@ You can even configure the extension to create resized images of different dimen
 
 The extension automatically copies the following metadata, if present, from the original image to the resized image(s): `Cache-Control`, `Content-Disposition`, `Content-Encoding`, `Content-Language`, `Content-Type`, and user-provided metadata (a new Firebase storage download token will be generated on the resized image(s) if the original metadata contains a token). Note that you can optionally configure the extension to overwrite the [`Cache-Control`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control) value for the resized image(s).
 
+The extension supports resizing images in `JPEG`, `PNG`, `WebP`, `GIF`, `AVIF` and `TIFF` formats, and the output can be in one or more of these formats.
+
 The extension can publish a resize completion event which you can optionally enable when you install the extension. If you enable events, you can [write custom event handlers](https://firebase.google.com/docs/extensions/install-extensions#eventarc) that respond to these events. You can always enable or disable events later. Events will be emitted via Eventarc.
 
 #### Detailed configuration information

--- a/storage-resize-images/README.md
+++ b/storage-resize-images/README.md
@@ -19,6 +19,8 @@ You can even configure the extension to create resized images of different dimen
 
 The extension automatically copies the following metadata, if present, from the original image to the resized image(s): `Cache-Control`, `Content-Disposition`, `Content-Encoding`, `Content-Language`, `Content-Type`, and user-provided metadata (a new Firebase storage download token will be generated on the resized image(s) if the original metadata contains a token). Note that you can optionally configure the extension to overwrite the [`Cache-Control`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control) value for the resized image(s).
 
+The extension supports resizing images in `JPEG`, `PNG`, `WebP`, `GIF`, `AVIF` and `TIFF` formats, and the output can be in one or more of these formats.
+
 The extension can publish a resize completion event which you can optionally enable when you install the extension. If you enable events, you can [write custom event handlers](https://firebase.google.com/docs/extensions/install-extensions#eventarc) that respond to these events. You can always enable or disable events later. Events will be emitted via Eventarc.
 
 #### Detailed configuration information

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -256,6 +256,8 @@ params:
         value: tiff
       - label: gif
         value: gif
+      - label: avif
+        value: avif
       - label: original
         value: false
     default: false

--- a/storage-resize-images/functions/src/resize-image.ts
+++ b/storage-resize-images/functions/src/resize-image.ts
@@ -43,6 +43,7 @@ export function convertType(buffer, format) {
     webp: {},
     tiff: {},
     tif: {},
+    avif: {},
   };
   if (config.outputOptions) {
     try {
@@ -51,7 +52,7 @@ export function convertType(buffer, format) {
       logs.errorOutputOptionsParse(e);
     }
   }
-  const { jpeg, jpg, png, webp, tiff, tif } = outputOptions;
+  const { jpeg, jpg, png, webp, tiff, tif, avif } = outputOptions;
 
   if (format === "jpeg") {
     return sharp(buffer)
@@ -95,6 +96,12 @@ export function convertType(buffer, format) {
       .toBuffer();
   }
 
+  if (format === "avif") {
+    return sharp(buffer)
+      .avif(avif)
+      .toBuffer();
+  }
+
   return buffer;
 }
 
@@ -107,6 +114,7 @@ export const supportedContentTypes = [
   "image/tiff",
   "image/webp",
   "image/gif",
+  "image/avif",
 ];
 
 export const supportedImageContentTypeMap = {
@@ -117,6 +125,7 @@ export const supportedImageContentTypeMap = {
   tiff: "image/tiff",
   webp: "image/webp",
   gif: "image/gif",
+  avif: "image/avif",
 };
 
 const supportedExtensions = Object.keys(supportedImageContentTypeMap).map(


### PR DESCRIPTION
fixes: #1209 
> **Note** test cases not included as the [image-type](https://www.npmjs.com/package/image-type) library used to check the file type while testing doesn't support AVIF codec.