### PR TITLE
feat(bg-change-tracker): add old_data field to the BQ record

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/e2e.test.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/e2e.test.ts
@@ -260,6 +260,39 @@ describe("Partitioning", () => {
       );
     });
 
+    test("old_data is null if is not provided", async () => {
+      const event: FirestoreDocumentChangeEvent = changeTrackerEvent({
+        data: { foo: "foo" },
+      });
+
+      await changeTracker({ datasetId, tableId }).record([event]);
+
+      const [changeLogRows] = await getBigQueryTableData(
+        process.env.PROJECT_ID,
+        datasetId,
+        tableId
+      );
+
+      expect(changeLogRows[0].old_data).toBe("null");
+    });
+
+    test("changeLog table has a value for old_data", async () => {
+      const event: FirestoreDocumentChangeEvent = changeTrackerEvent({
+        old_data: { foo: "foo" },
+        data: { foo: "bar" },
+      });
+
+      await changeTracker({ datasetId, tableId }).record([event]);
+
+      const [changeLogRows] = await getBigQueryTableData(
+        process.env.PROJECT_ID,
+        datasetId,
+        tableId
+      );
+
+      expect(changeLogRows[0].old_data).toBeDefined();
+    });
+
     test("does not partition with without a valid timePartitioningField when including timePartitioning, timePartitioningFieldType and timePartitioningFirestoreField", async () => {
       await changeTracker({
         datasetId,

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/fixtures/changeTracker.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/fixtures/changeTracker.ts
@@ -41,6 +41,7 @@ export const changeTrackerEvent = ({
   documentId = "testing",
   pathParams = { documentId: "12345" },
   data = { end_date: firestore.Timestamp.now() },
+  oldData = null,
 }: any): FirestoreDocumentChangeEvent => {
   return {
     timestamp,
@@ -49,6 +50,7 @@ export const changeTrackerEvent = ({
     eventId,
     documentId,
     data,
+    oldData,
     pathParams,
   };
 };

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -102,7 +102,7 @@ export class FirestoreBigQueryEventHistoryTracker
           document_id: event.documentId,
           operation: ChangeType[event.operation],
           data: JSON.stringify(this.serializeData(event.data)),
-          prevData: JSON.stringify(this.serializeData(event.prevData)),
+          old_data: JSON.stringify(this.serializeData(event.oldData)),
           ...partitionValue,
           ...(this.config.wildcardIds &&
             event.pathParams && { path_params: JSON.stringify(pathParams) }),

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -102,7 +102,9 @@ export class FirestoreBigQueryEventHistoryTracker
           document_id: event.documentId,
           operation: ChangeType[event.operation],
           data: JSON.stringify(this.serializeData(event.data)),
-          old_data: JSON.stringify(this.serializeData(event.oldData)),
+          old_data: event.oldData
+            ? JSON.stringify(this.serializeData(event.oldData))
+            : null,
           ...partitionValue,
           ...(this.config.wildcardIds &&
             event.pathParams && { path_params: JSON.stringify(pathParams) }),

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -102,6 +102,7 @@ export class FirestoreBigQueryEventHistoryTracker
           document_id: event.documentId,
           operation: ChangeType[event.operation],
           data: JSON.stringify(this.serializeData(event.data)),
+          prevData: JSON.stringify(this.serializeData(event.prevData)),
           ...partitionValue,
           ...(this.config.wildcardIds &&
             event.pathParams && { path_params: JSON.stringify(pathParams) }),

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/schema.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/schema.ts
@@ -117,6 +117,13 @@ export const RawChangelogViewSchema = {
       description:
         "The full JSON representation of the current document state.",
     },
+    {
+      name: "old_data",
+      mode: "NULLABLE",
+      type: "STRING",
+      description:
+        "The full JSON representation of the document state before the indicated operation is applied.",
+    },
     documentIdField,
   ],
 };
@@ -156,6 +163,13 @@ export const RawChangelogSchema = {
       type: "STRING",
       description:
         "The full JSON representation of the document state after the indicated operation is applied. This field will be null for DELETE operations.",
+    },
+    {
+      name: "old_data",
+      mode: "NULLABLE",
+      type: "STRING",
+      description:
+        "The full JSON representation of the document state before the indicated operation is applied. This field will be null for CREATE operations.",
     },
     documentIdField,
   ],

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/tracker.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/tracker.ts
@@ -32,7 +32,7 @@ export interface FirestoreDocumentChangeEvent {
   documentId: string;
   pathParams?: { documentId: string; [key: string]: string } | null;
   data: Object;
-  prevData?: Object;
+  oldData: Object;
 }
 
 export interface FirestoreEventHistoryTracker {

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/tracker.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/tracker.ts
@@ -32,7 +32,7 @@ export interface FirestoreDocumentChangeEvent {
   documentId: string;
   pathParams?: { documentId: string; [key: string]: string } | null;
   data: Object;
-  oldData: Object;
+  oldData?: Object | null;
 }
 
 export interface FirestoreEventHistoryTracker {

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/tracker.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/tracker.ts
@@ -32,6 +32,7 @@ export interface FirestoreDocumentChangeEvent {
   documentId: string;
   pathParams?: { documentId: string; [key: string]: string } | null;
   data: Object;
+  prevData?: Object;
 }
 
 export interface FirestoreEventHistoryTracker {


### PR DESCRIPTION
On the way to implement #1208
Add `old_data` field to the BQ changelog and view tables + tests