### PR TITLE
Tweak "errorDeleting" wording

### DIFF
--- a/storage-resize-images/functions/src/logs.ts
+++ b/storage-resize-images/functions/src/logs.ts
@@ -51,7 +51,7 @@ export const error = (err: Error) => {
 };
 
 export const errorDeleting = (err: Error) => {
-  logger.warn("Error when deleting temporary files", err);
+  logger.warn("Error when deleting files", err);
 };
 
 export const failed = () => {


### PR DESCRIPTION
`errorDeleting` is not exclusively called for temporary files. It is also called when the caller of `remoteFileDeleted` fails, so the current log message is inaccurate.