### PR TITLE
Simplify parsed path passing

### DIFF
--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -30,7 +30,7 @@ import {
 } from "./resize-image";
 import config, { deleteImage } from "./config";
 import * as logs from "./logs";
-import { extractFileNameWithoutExtension, startsWithArray } from "./util";
+import { startsWithArray } from "./util";
 
 sharp.cache(false);
 
@@ -100,12 +100,7 @@ export const generateResizedImage = functions.storage
 
     const bucket = admin.storage().bucket(object.bucket);
     const filePath = object.name; // File path in the bucket.
-    const fileDir = path.dirname(filePath);
-    const fileExtension = path.extname(filePath);
-    const fileNameWithoutExtension = extractFileNameWithoutExtension(
-      filePath,
-      fileExtension
-    );
+    const parsedPath = path.parse(filePath);
     const objectMetadata = object;
 
     let originalFile;
@@ -139,9 +134,7 @@ export const generateResizedImage = functions.storage
             modifyImage({
               bucket,
               originalFile,
-              fileDir,
-              fileNameWithoutExtension,
-              fileExtension,
+              parsedPath,
               contentType,
               size,
               objectMetadata: objectMetadata,

--- a/storage-resize-images/functions/src/resize-image.ts
+++ b/storage-resize-images/functions/src/resize-image.ts
@@ -112,9 +112,7 @@ const supportedExtensions = Object.keys(supportedImageContentTypeMap).map(
 export const modifyImage = async ({
   bucket,
   originalFile,
-  fileDir,
-  fileNameWithoutExtension,
-  fileExtension,
+  parsedPath,
   contentType,
   size,
   objectMetadata,
@@ -122,14 +120,17 @@ export const modifyImage = async ({
 }: {
   bucket: Bucket;
   originalFile: string;
-  fileDir: string;
-  fileNameWithoutExtension: string;
-  fileExtension: string;
+  parsedPath: path.ParsedPath;
   contentType: string;
   size: string;
   objectMetadata: ObjectMetadata;
   format: string;
 }): Promise<ResizedImageResult> => {
+  const {
+    ext: fileExtension,
+    dir: fileDir,
+    name: fileNameWithoutExtension,
+  } = parsedPath;
   const shouldFormatImage = format !== "false";
   const imageContentType = shouldFormatImage
     ? supportedImageContentTypeMap[format]

--- a/storage-resize-images/functions/src/util.ts
+++ b/storage-resize-images/functions/src/util.ts
@@ -1,12 +1,5 @@
 import * as path from "path";
 
-export const extractFileNameWithoutExtension = (
-  filePath: string,
-  ext: string
-) => {
-  return path.basename(filePath, ext);
-};
-
 export const startsWithArray = (
   userInputPaths: string[],
   imagePath: string


### PR DESCRIPTION
The previous code involved many assignments at the caller's level and a helper function; this PR removes the helper function and moves the assignments into the function body using a destructuring assignment.

I'm not sure about the variable names I chose, so please be opinionated if you'd like. I kept the old variable names where possible to minimize the diff size.

Looking forward to your thoughts.