### PR TITLE
chore: update validate workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           node-version: 14
       - name: NPM install
-        run: npm pkg set scripts.postinstall="echo no-postinstall" && npm i
+        run: SKIP_BUILD=yes npm i
       - name: Prettier Lint Check
         run: npm run lint

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,12 +9,12 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 14
       - name: NPM install
-        run: npm i
+        run: npm pkg set scripts.postinstall="echo no-postinstall" && npm i
       - name: Prettier Lint Check
         run: npm run lint

--- a/auth-mailchimp-sync/functions/jest.setup.js
+++ b/auth-mailchimp-sync/functions/jest.setup.js
@@ -1,4 +1,4 @@
-module.exports = async function () {
+module.exports = async function() {
   process.env = Object.assign(process.env, {
     LOCATION: "europe-west2",
     MAILCHIMP_API_KEY: "123456-789",

--- a/auth-mailchimp-sync/functions/jest.teardown.js
+++ b/auth-mailchimp-sync/functions/jest.teardown.js
@@ -1,4 +1,4 @@
-module.exports = async function () {
+module.exports = async function() {
   delete process.env.LOCATION;
   delete process.env.MAILCHIMP_API_KEY;
   delete process.env.MAILCHIMP_AUDIENCE_ID;

--- a/auth-mailchimp-sync/functions/src/index.ts
+++ b/auth-mailchimp-sync/functions/src/index.ts
@@ -84,7 +84,10 @@ export const removeUserFromList = functions.handler.auth.user.onDelete(
     }
 
     try {
-      const hashed = crypto.createHash("md5").update(email).digest("hex");
+      const hashed = crypto
+        .createHash("md5")
+        .update(email)
+        .digest("hex");
 
       logs.userRemoving(uid, hashed, config.mailchimpAudienceId);
       await mailchimp.delete(

--- a/delete-user-data/functions/__tests__/helpers.test.ts
+++ b/delete-user-data/functions/__tests__/helpers.test.ts
@@ -27,7 +27,9 @@ describe("Test Realtime Database URL helper function", () => {
       environment.SELECTED_DATABASE_LOCATION
     );
     expect(serverUrl).toBe(
-      `https://${environment.SELECTED_DATABASE_INSTANCE}.europe-west1.firebasedatabase.app`
+      `https://${
+        environment.SELECTED_DATABASE_INSTANCE
+      }.europe-west1.firebasedatabase.app`
     );
   });
 
@@ -42,7 +44,9 @@ describe("Test Realtime Database URL helper function", () => {
       environment.SELECTED_DATABASE_LOCATION
     );
     expect(serverUrl).toBe(
-      `https://${environment.SELECTED_DATABASE_INSTANCE}.asia-southeast1.firebasedatabase.app`
+      `https://${
+        environment.SELECTED_DATABASE_INSTANCE
+      }.asia-southeast1.firebasedatabase.app`
     );
   });
 

--- a/delete-user-data/functions/__tests__/helpers/index.ts
+++ b/delete-user-data/functions/__tests__/helpers/index.ts
@@ -3,7 +3,9 @@ import { UserRecord } from "firebase-functions/v1/auth";
 import { Query, DocumentData } from "@google-cloud/firestore";
 
 export const createFirebaseUser = async (): Promise<UserRecord> => {
-  const email = `${Math.random().toString(36).substr(2, 5)}@google.com`;
+  const email = `${Math.random()
+    .toString(36)
+    .substr(2, 5)}@google.com`;
   return admin.auth().createUser({ email });
 };
 

--- a/delete-user-data/functions/__tests__/setupTests.ts
+++ b/delete-user-data/functions/__tests__/setupTests.ts
@@ -1,6 +1,6 @@
 import path from "path";
 
-(async function () {
+(async function() {
   const $ = path.resolve(
     __dirname,
     `../../../_emulator/extensions/delete-user-data.env.local`

--- a/delete-user-data/functions/src/index.ts
+++ b/delete-user-data/functions/src/index.ts
@@ -223,7 +223,10 @@ const clearDatabaseData = async (databasePaths: string, uid: string) => {
   const promises = paths.map(async (path) => {
     try {
       logs.rtdbPathDeleting(path);
-      await admin.database().ref(path).remove();
+      await admin
+        .database()
+        .ref(path)
+        .remove();
       logs.rtdbPathDeleted(path);
     } catch (err) {
       logs.rtdbPathError(path, err);

--- a/delete-user-data/functions/src/runBatchPubSubDeletions.ts
+++ b/delete-user-data/functions/src/runBatchPubSubDeletions.ts
@@ -24,9 +24,8 @@ export async function runBatchPubSubDeletions(paths: Paths, uid: string) {
   /** Define batch array variables */
   for await (const chunkedPaths of chunk<string>(firestorePaths, 450)) {
     const topic = pubsub.topic(
-      `projects/${
-        process.env.GOOGLE_CLOUD_PROJECT || process.env.PROJECT_ID
-      }/topics/${config.default.deletionTopic}`
+      `projects/${process.env.GOOGLE_CLOUD_PROJECT ||
+        process.env.PROJECT_ID}/topics/${config.default.deletionTopic}`
     );
     await topic.publish(
       Buffer.from(JSON.stringify({ paths: chunkedPaths, uid }))

--- a/delete-user-data/functions/src/search.ts
+++ b/delete-user-data/functions/src/search.ts
@@ -12,9 +12,8 @@ export const search = async (
   const pubsub = new PubSub();
 
   const topic = pubsub.topic(
-    `projects/${
-      process.env.GOOGLE_CLOUD_PROJECT || process.env.PROJECT_ID
-    }/topics/${config.default.discoveryTopic}`
+    `projects/${process.env.GOOGLE_CLOUD_PROJECT ||
+      process.env.PROJECT_ID}/topics/${config.default.discoveryTopic}`
   );
 
   const collections = !document

--- a/delete-user-data/test-data/index.ts
+++ b/delete-user-data/test-data/index.ts
@@ -48,7 +48,10 @@ const createFirestoreDocument = async (
     field: "value",
   }
 ): Promise<void> => {
-  await firebase.firestore().doc(path).set(value);
+  await firebase
+    .firestore()
+    .doc(path)
+    .set(value);
   console.log(`Created Firestore data at path: '${path}'`);
 };
 
@@ -56,7 +59,10 @@ const createRTDBDocument = async (
   path: string,
   value: any = { field: "value " }
 ): Promise<void> => {
-  await firebase.database().ref(path).set(value);
+  await firebase
+    .database()
+    .ref(path)
+    .set(value);
   console.log(`Created RTDB data at path: '${path}'`);
 };
 

--- a/docs/firestore-translate-text/get-started.md
+++ b/docs/firestore-translate-text/get-started.md
@@ -7,9 +7,12 @@ The Translate Text extension (`firestore-translate-text`) lets you translate str
 Here’s a basic example document write that would trigger this extension:
 
 ```js
-admin.firestore().collection("translations").add({
-  input: "Hello from Firebase!",
-});
+admin
+  .firestore()
+  .collection("translations")
+  .add({
+    input: "Hello from Firebase!",
+  });
 ```
 
 When the extension triggers, the input text would update the document with translations:
@@ -64,8 +67,11 @@ To translate multiple collections, install this extension multiple times, specif
 To translate multiple fields, store a map of input strings in the input field:
 
 ```js
-admin.firestore().collection("translations").add({
-  first: "My name is Bob",
-  second: "Hello, friend",
-});
+admin
+  .firestore()
+  .collection("translations")
+  .add({
+    first: "My name is Bob",
+    second: "Hello, friend",
+  });
 ```

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/e2e.test.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/e2e.test.ts
@@ -191,7 +191,10 @@ describe("Partitioning", () => {
 
     test("successfully partitions with a valid Firebase Timestamp value with a Date partitioning type", async () => {
       const created = firestore.Timestamp.now();
-      const expectedDate = created.toDate().toISOString().substring(0, 10);
+      const expectedDate = created
+        .toDate()
+        .toISOString()
+        .substring(0, 10);
 
       const event: FirestoreDocumentChangeEvent = changeTrackerEvent({
         data: { created },
@@ -222,7 +225,10 @@ describe("Partitioning", () => {
 
     test("successfully partitions with a valid Firebase Timestamp value with a DateTime partitioning type", async () => {
       const created = firestore.Timestamp.now();
-      const expectedDate = created.toDate().toISOString().substring(0, 22);
+      const expectedDate = created
+        .toDate()
+        .toISOString()
+        .substring(0, 22);
 
       const event: FirestoreDocumentChangeEvent = changeTrackerEvent({
         data: { created },

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -69,8 +69,7 @@ export interface FirestoreBigQueryEventHistoryTrackerConfig {
  */
 
 export class FirestoreBigQueryEventHistoryTracker
-  implements FirestoreEventHistoryTracker
-{
+  implements FirestoreEventHistoryTracker {
   bq: bigquery.BigQuery;
   _initialized: boolean = false;
 
@@ -131,7 +130,7 @@ export class FirestoreBigQueryEventHistoryTracker
       return undefined;
     }
 
-    const data = traverse<traverse.Traverse<any>>(eventData).map(function (
+    const data = traverse<traverse.Traverse<any>>(eventData).map(function(
       property
     ) {
       if (property && property.constructor) {

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/snapshot.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/snapshot.ts
@@ -53,8 +53,7 @@ export function buildLatestSnapshotViewQuery(
       throw Error(`Found empty group by column!`);
     }
   }
-  const query =
-    sqlFormatter.format(` -- Retrieves the latest document change events for all live documents.
+  const query = sqlFormatter.format(` -- Retrieves the latest document change events for all live documents.
     --   timestamp: The Firestore timestamp at which the event took place.
     --   operation: One of INSERT, UPDATE, DELETE, IMPORT.
     --   event_id: The id of the event that triggered the cloud function mirrored the event.
@@ -78,9 +77,8 @@ export function buildLatestSnapshotViewQuery(
         FIRST_VALUE(operation)
           OVER(PARTITION BY document_name ORDER BY ${timestampColumnName} DESC) = "DELETE"
           AS is_deleted
-      FROM \`${
-        bqProjectId || process.env.PROJECT_ID
-      }.${datasetId}.${tableName}\`
+      FROM \`${bqProjectId ||
+        process.env.PROJECT_ID}.${datasetId}.${tableName}\`
       ORDER BY document_name, ${timestampColumnName} DESC
     )
     WHERE NOT is_deleted

--- a/firestore-bigquery-export/functions/src/index.ts
+++ b/firestore-bigquery-export/functions/src/index.ts
@@ -24,8 +24,8 @@ import {
 import * as logs from "./logs";
 import { getChangeType, getDocumentId } from "./util";
 
-const eventTracker: FirestoreEventHistoryTracker =
-  new FirestoreBigQueryEventHistoryTracker({
+const eventTracker: FirestoreEventHistoryTracker = new FirestoreBigQueryEventHistoryTracker(
+  {
     tableId: config.tableId,
     datasetId: config.datasetId,
     datasetLocation: config.datasetLocation,
@@ -38,7 +38,8 @@ const eventTracker: FirestoreEventHistoryTracker =
     clustering: config.clustering,
     wildcardIds: config.wildcardIds,
     bqProjectId: config.bqProjectId,
-  });
+  }
+);
 
 logs.init();
 

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/index.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/index.ts
@@ -160,8 +160,12 @@ async function parseConfig(): Promise<CliConfig> {
       schemas: readSchemas(program.schemaFiles),
     };
   }
-  const { project, dataset, tableNamePrefix, schemaFiles } =
-    await inquirer.prompt(questions);
+  const {
+    project,
+    dataset,
+    tableNamePrefix,
+    schemaFiles,
+  } = await inquirer.prompt(questions);
   return {
     projectId: project,
     datasetId: dataset,

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/schema-loader-utils.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/schema-loader-utils.ts
@@ -21,7 +21,9 @@ import { FirestoreSchema } from "./schema";
 
 import { existsSync, readdirSync, lstatSync } from "fs";
 
-export function readSchemas(globs: string[]): {
+export function readSchemas(
+  globs: string[]
+): {
   [schemaName: string]: FirestoreSchema;
 } {
   let schemas = {};
@@ -70,7 +72,9 @@ function expandGlobs(globs: string[]): string[] {
   return results;
 }
 
-function readSchemasFromDirectory(directory: string): {
+function readSchemasFromDirectory(
+  directory: string
+): {
   [schemaName: string]: FirestoreSchema;
 } {
   let results = {};

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/schema.ts
@@ -69,7 +69,7 @@ export type FirestoreSchema = {
  * a BigQuery schema in the same pass that generates the view generation query.
  */
 const firestoreToBigQueryFieldType: {
-  [f in FirestoreFieldType]: BigQueryFieldType;
+  [f in FirestoreFieldType]: BigQueryFieldType
 } = {
   boolean: "BOOLEAN",
   geopoint: "GEOGRAPHY",

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
@@ -72,8 +72,11 @@ export const buildLatestSchemaSnapshotViewQuery = (
   // fully qualified json2array persistent user-defined function in the proper
   // scope.
   const result = processFirestoreSchema(datasetId, "data", schema, firstValue);
-  const [schemaFieldExtractors, schemaFieldArrays, schemaFieldGeopoints] =
-    result.queryInfo;
+  const [
+    schemaFieldExtractors,
+    schemaFieldArrays,
+    schemaFieldGeopoints,
+  ] = result.queryInfo;
   let bigQueryFields = result.fields;
   /*
    * Include additional array schema fields.

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/udf.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/udf.ts
@@ -28,26 +28,36 @@ export const udfs: {
 };
 
 export function firestoreArray(datasetId: string, selector: string): string {
-  return `\`${process.env.PROJECT_ID}.${datasetId}.firestoreArray\`(${selector})`;
+  return `\`${
+    process.env.PROJECT_ID
+  }.${datasetId}.firestoreArray\`(${selector})`;
 }
 
 export function firestoreBoolean(datasetId: string, selector: string): string {
-  return `\`${process.env.PROJECT_ID}.${datasetId}.firestoreBoolean\`(${selector})`;
+  return `\`${
+    process.env.PROJECT_ID
+  }.${datasetId}.firestoreBoolean\`(${selector})`;
 }
 
 export function firestoreNumber(datasetId: string, selector: string): string {
-  return `\`${process.env.PROJECT_ID}.${datasetId}.firestoreNumber\`(${selector})`;
+  return `\`${
+    process.env.PROJECT_ID
+  }.${datasetId}.firestoreNumber\`(${selector})`;
 }
 
 export function firestoreTimestamp(
   datasetId: string,
   selector: string
 ): string {
-  return `\`${process.env.PROJECT_ID}.${datasetId}.firestoreTimestamp\`(${selector})`;
+  return `\`${
+    process.env.PROJECT_ID
+  }.${datasetId}.firestoreTimestamp\`(${selector})`;
 }
 
 export function firestoreGeopoint(datasetId: string, selector: string): string {
-  return `\`${process.env.PROJECT_ID}.${datasetId}.firestoreGeopoint\`(${selector})`;
+  return `\`${
+    process.env.PROJECT_ID
+  }.${datasetId}.firestoreGeopoint\`(${selector})`;
 }
 
 function firestoreArrayFunction(datasetId: string): any {
@@ -60,7 +70,9 @@ function firestoreArrayFunction(datasetId: string): any {
 
 function firestoreArrayDefinition(datasetId: string): string {
   return sqlFormatter.format(`
-    CREATE OR REPLACE FUNCTION \`${process.env.PROJECT_ID}.${datasetId}.firestoreArray\`(json STRING)
+    CREATE OR REPLACE FUNCTION \`${
+      process.env.PROJECT_ID
+    }.${datasetId}.firestoreArray\`(json STRING)
     RETURNS ARRAY<STRING>
     LANGUAGE js AS """
     function getArray(json) {
@@ -97,7 +109,9 @@ function firestoreBooleanFunction(datasetId: string): any {
 
 function firestoreBooleanDefinition(datasetId: string): string {
   return sqlFormatter.format(`
-    CREATE FUNCTION IF NOT EXISTS \`${process.env.PROJECT_ID}.${datasetId}.firestoreBoolean\`(json STRING)
+    CREATE FUNCTION IF NOT EXISTS \`${
+      process.env.PROJECT_ID
+    }.${datasetId}.firestoreBoolean\`(json STRING)
     RETURNS BOOLEAN AS (SAFE_CAST(json AS BOOLEAN));`);
 }
 
@@ -111,7 +125,9 @@ function firestoreNumberFunction(datasetId: string): any {
 
 function firestoreNumberDefinition(datasetId: string): string {
   return sqlFormatter.format(`
-    CREATE FUNCTION IF NOT EXISTS \`${process.env.PROJECT_ID}.${datasetId}.firestoreNumber\`(json STRING)
+    CREATE FUNCTION IF NOT EXISTS \`${
+      process.env.PROJECT_ID
+    }.${datasetId}.firestoreNumber\`(json STRING)
     RETURNS NUMERIC AS (SAFE_CAST(json AS NUMERIC));`);
 }
 
@@ -125,7 +141,9 @@ function firestoreTimestampFunction(datasetId: string): any {
 
 function firestoreTimestampDefinition(datasetId: string): string {
   return sqlFormatter.format(`
-    CREATE FUNCTION IF NOT EXISTS \`${process.env.PROJECT_ID}.${datasetId}.firestoreTimestamp\`(json STRING)
+    CREATE FUNCTION IF NOT EXISTS \`${
+      process.env.PROJECT_ID
+    }.${datasetId}.firestoreTimestamp\`(json STRING)
     RETURNS TIMESTAMP AS
     (TIMESTAMP_MILLIS(SAFE_CAST(JSON_EXTRACT(json, '$._seconds') AS INT64) * 1000 + SAFE_CAST(SAFE_CAST(JSON_EXTRACT(json, '$._nanoseconds') AS INT64) / 1E6 AS INT64)));`);
 }
@@ -140,7 +158,9 @@ function firestoreGeopointFunction(datasetId: string): any {
 
 function firestoreGeopointDefinition(datasetId: string): string {
   return sqlFormatter.format(`
-    CREATE FUNCTION IF NOT EXISTS \`${process.env.PROJECT_ID}.${datasetId}.firestoreGeopoint\`(json STRING)
+    CREATE FUNCTION IF NOT EXISTS \`${
+      process.env.PROJECT_ID
+    }.${datasetId}.firestoreGeopoint\`(json STRING)
     RETURNS GEOGRAPHY AS
     (ST_GEOGPOINT(SAFE_CAST(JSON_EXTRACT(json, '$._longitude') AS NUMERIC), SAFE_CAST(JSON_EXTRACT(json, '$._latitude') AS NUMERIC)));`);
 }

--- a/firestore-bigquery-export/scripts/import/src/index.ts
+++ b/firestore-bigquery-export/scripts/import/src/index.ts
@@ -304,7 +304,10 @@ const run = async (): Promise<number> => {
     `/from-${formattedPath}-to-${projectId}_${datasetId}_${rawChangeLogName}`;
   if (await exists(cursorPositionFile)) {
     let cursorDocumentId = (await read(cursorPositionFile)).toString();
-    cursor = await firebase.firestore().doc(cursorDocumentId).get();
+    cursor = await firebase
+      .firestore()
+      .doc(cursorDocumentId)
+      .get();
     console.log(
       `Resuming import of Cloud Firestore Collection ${sourceCollectionPath} ${
         queryCollectionGroup ? " (via a Collection Group query)" : ""
@@ -342,7 +345,9 @@ const run = async (): Promise<number> => {
       return {
         timestamp: new Date().toISOString(), // epoch
         operation: ChangeType.IMPORT,
-        documentName: `projects/${projectId}/databases/${FIRESTORE_DEFAULT_DATABASE}/documents/${snapshot.ref.path}`,
+        documentName: `projects/${projectId}/databases/${FIRESTORE_DEFAULT_DATABASE}/documents/${
+          snapshot.ref.path
+        }`,
         documentId: snapshot.id,
         pathParams: resolveWildcardIds(sourceCollectionPath, snapshot.ref.path),
         eventId: "",

--- a/firestore-bigquery-export/scripts/import/src/run.ts
+++ b/firestore-bigquery-export/scripts/import/src/run.ts
@@ -95,7 +95,9 @@ async function processCollectionGroup(config: CliConfig): Promise<number> {
 
   console.log("---------------------------------------------------------");
   console.log(
-    `Please see https://console.cloud.google.com/bigquery?p=${config.projectId}&d=${config.datasetId}&t=${config.tableId}_raw_changelog&page=table`
+    `Please see https://console.cloud.google.com/bigquery?p=${
+      config.projectId
+    }&d=${config.datasetId}&t=${config.tableId}_raw_changelog&page=table`
   );
   console.log("---------------------------------------------------------");
 
@@ -135,7 +137,9 @@ async function processCollection(config: CliConfig): Promise<number> {
       return {
         timestamp: new Date().toISOString(),
         operation: ChangeType.IMPORT,
-        documentName: `projects/${config.projectId}/databases/(default)/documents/${document.ref.path}`,
+        documentName: `projects/${
+          config.projectId
+        }/databases/(default)/documents/${document.ref.path}`,
         documentId: document.id,
         eventId: "",
         data: document.data(),

--- a/firestore-bigquery-export/scripts/import/src/worker.ts
+++ b/firestore-bigquery-export/scripts/import/src/worker.ts
@@ -56,7 +56,9 @@ async function processDocuments(
     return {
       timestamp: new Date().toISOString(),
       operation: ChangeType.IMPORT,
-      documentName: `projects/${projectId}/databases/(default)/documents/${document.ref.path}`,
+      documentName: `projects/${projectId}/databases/(default)/documents/${
+        document.ref.path
+      }`,
       documentId: document.id,
       eventId: "",
       data: document.data(),

--- a/firestore-counter/functions/src/aggregator.ts
+++ b/firestore-counter/functions/src/aggregator.ts
@@ -43,7 +43,9 @@ export class NumericUpdate {
    * Exports an object with modified fields in the counter.
    * @param counter The counter data to be updated.
    */
-  public toCounterUpdate(counter: { [key: string]: any }): {
+  public toCounterUpdate(counter: {
+    [key: string]: any;
+  }): {
     [key: string]: any;
   } {
     NumericUpdate.addCommonFieldsRecursive(counter, this.data);
@@ -168,7 +170,9 @@ export class Aggregator {
    * Returns an update object that will subtract the sum of all the fields in a partial.
    * @param partial Snapshot with partial aggregations to be subtracted.
    */
-  public subtractPartial(partial: firestore.DocumentSnapshot): {
+  public subtractPartial(
+    partial: firestore.DocumentSnapshot
+  ): {
     [key: string]: any;
   } {
     const update = new NumericUpdate();

--- a/firestore-counter/functions/src/controller.ts
+++ b/firestore-counter/functions/src/controller.ts
@@ -283,8 +283,9 @@ export class ShardedCounterController {
         })
       );
 
-      let [reshard, slices] =
-        ShardedCounterController.balanceWorkers(shardingInfo);
+      let [reshard, slices] = ShardedCounterController.balanceWorkers(
+        shardingInfo
+      );
       if (reshard) {
         logger.log(
           "Resharding workers, new workers: " +

--- a/firestore-counter/functions/src/worker.ts
+++ b/firestore-counter/functions/src/worker.ts
@@ -129,7 +129,11 @@ export class ShardedCounterWorker {
       }, 1000);
 
       timeoutTimer = setTimeout(
-        () => shutdown().then(writeStats).then(resolve).catch(reject),
+        () =>
+          shutdown()
+            .then(writeStats)
+            .then(resolve)
+            .catch(reject),
         WORKER_TIMEOUT_MS
       );
 
@@ -137,7 +141,9 @@ export class ShardedCounterWorker {
         // if something's changed in the worker metadata since we were called, abort.
         if (!snap.exists || !deepEqual(snap.data(), this.metadata)) {
           logger.log("Shutting down because metadoc changed.");
-          shutdown().then(resolve).catch(reject);
+          shutdown()
+            .then(resolve)
+            .catch(reject);
         }
       });
 
@@ -151,7 +157,10 @@ export class ShardedCounterWorker {
         this.shards = snap.docs;
         if (this.singleRun && this.shards.length === 0) {
           logger.log("Shutting down, single run mode.");
-          shutdown().then(writeStats).then(resolve).catch(reject);
+          shutdown()
+            .then(writeStats)
+            .then(resolve)
+            .catch(reject);
         }
       });
     });
@@ -331,10 +340,7 @@ export class ShardedCounterWorker {
                   update.mergeFrom(u["_data_"]);
                 });
               }
-              t.set(
-                snap.ref,
-                update.toPartialShard(() => uuid.v4())
-              );
+              t.set(snap.ref, update.toPartialShard(() => uuid.v4()));
             }
           } catch (err) {
             logger.log("Partial cleanup failed: " + partial.ref.path);

--- a/firestore-send-email/functions/__tests__/e2e.test.ts
+++ b/firestore-send-email/functions/__tests__/e2e.test.ts
@@ -44,7 +44,9 @@ describe("e2e testing", () => {
     });
   }, 12000);
 
-  test("empty template attachments should default to message attachments", async (): Promise<void> => {
+  test("empty template attachments should default to message attachments", async (): Promise<
+    void
+  > => {
     //create template
     const template = await templatesCollection.doc("default").set({
       subject: "@{{username}} is now following you!",

--- a/firestore-send-email/functions/__tests__/helpers.test.ts
+++ b/firestore-send-email/functions/__tests__/helpers.test.ts
@@ -158,7 +158,9 @@ describe("set server credentials helper function", () => {
 
     expect(credentials).toBeNull();
     expect(consoleLogSpy).toBeCalledWith(
-      `invalid url: '${config.smtpConnectionUri}' , please reconfigure with a valid SMTP connection URI`
+      `invalid url: '${
+        config.smtpConnectionUri
+      }' , please reconfigure with a valid SMTP connection URI`
     );
   });
 });

--- a/firestore-send-email/functions/jest.teardown.js
+++ b/firestore-send-email/functions/jest.teardown.js
@@ -1,4 +1,4 @@
-module.exports = async function () {
+module.exports = async function() {
   delete process.env.LOCATION;
   delete process.env.MAIL_COLLECTION;
   delete process.env.SMTP_CONNECTION_URI;

--- a/firestore-send-email/functions/src/logs.ts
+++ b/firestore-send-email/functions/src/logs.ts
@@ -55,7 +55,11 @@ export function delivered(
   }
 ) {
   logger.log(
-    `Delivered message: ${ref.path} successfully. messageId: ${info.messageId} accepted: ${info.accepted.length} rejected: ${info.rejected.length} pending: ${info.pending.length}`
+    `Delivered message: ${ref.path} successfully. messageId: ${
+      info.messageId
+    } accepted: ${info.accepted.length} rejected: ${
+      info.rejected.length
+    } pending: ${info.pending.length}`
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7778,9 +7778,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
+      "integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:local": "concurrently \"npm run local:emulator\" \"jest\"",
     "test:watch": "concurrently \"npm run local:emulator\" \"jest --watch\"",
     "test-coverage": "jest --coverage --detectOpenHandles --forceExit",
-    "postinstall": "lerna bootstrap --no-ci && lerna run --parallel clean && npm run build && npm run generate-package-locks",
+    "postinstall": "if test \"$SKIP_BUILD\" != \"yes\" ; then lerna bootstrap --no-ci && lerna run --parallel clean && npm run build && npm run generate-package-locks ; fi",
     "generate-package-locks": "lerna exec -- npm i --package-lock-only",
     "generate-readmes": "lerna run --parallel --ignore delete-user-data generate-readme"
   },
@@ -29,7 +29,7 @@
     "concurrently": "^7.2.1",
     "jest": "^24.9.0",
     "lerna": "^3.4.3",
-    "prettier": "2.7.1",
+    "prettier": "1.15.3",
     "ts-jest": "^24.1.0",
     "typescript": "^3.6.3"
   }

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -49,9 +49,8 @@ logs.init();
  * When an image is uploaded in the Storage bucket, we generate a resized image automatically using
  * the Sharp image converting library.
  */
-export const generateResizedImage = functions.storage
-  .object()
-  .onFinalize(async (object): Promise<void> => {
+export const generateResizedImage = functions.storage.object().onFinalize(
+  async (object): Promise<void> => {
     logs.start();
     const { contentType } = object; // This is the image MIME type
 
@@ -194,4 +193,5 @@ export const generateResizedImage = functions.storage
         }
       }
     }
-  });
+  }
+);

--- a/storage-resize-images/functions/src/resize-image.ts
+++ b/storage-resize-images/functions/src/resize-image.ts
@@ -54,31 +54,45 @@ export function convertType(buffer, format) {
   const { jpeg, jpg, png, webp, tiff, tif } = outputOptions;
 
   if (format === "jpeg") {
-    return sharp(buffer).jpeg(jpeg).toBuffer();
+    return sharp(buffer)
+      .jpeg(jpeg)
+      .toBuffer();
   }
 
   if (format === "jpg") {
-    return sharp(buffer).jpeg(jpg).toBuffer();
+    return sharp(buffer)
+      .jpeg(jpg)
+      .toBuffer();
   }
 
   if (format === "png") {
-    return sharp(buffer).png(png).toBuffer();
+    return sharp(buffer)
+      .png(png)
+      .toBuffer();
   }
 
   if (format === "webp") {
-    return sharp(buffer, { animated: config.animated }).webp(webp).toBuffer();
+    return sharp(buffer, { animated: config.animated })
+      .webp(webp)
+      .toBuffer();
   }
 
   if (format === "tif") {
-    return sharp(buffer).tiff(tif).toBuffer();
+    return sharp(buffer)
+      .tiff(tif)
+      .toBuffer();
   }
 
   if (format === "tiff") {
-    return sharp(buffer).tiff(tiff).toBuffer();
+    return sharp(buffer)
+      .tiff(tiff)
+      .toBuffer();
   }
 
   if (format === "gif") {
-    return sharp(buffer, { animated: config.animated }).gif().toBuffer();
+    return sharp(buffer, { animated: config.animated })
+      .gif()
+      .toBuffer();
   }
 
   return buffer;


### PR DESCRIPTION
This PR updates the lint/format action:
- to use recommended versions of `actions/checkout` and `actions/setup-node` (see attached screenshot)
- to skip the postinstall step (which builds everything) when running `npm lint`

<img width="1405" alt="Screenshot 2022-10-26 at 10 39 00" src="https://user-images.githubusercontent.com/32874567/197992537-e4abcb4b-8ad1-46c8-bf6b-679c247afa6a.png">
