### PR TITLE
fix: fix resource error caused by latest snapshot script

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/snapshot.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/snapshot.ts
@@ -61,16 +61,16 @@ export function buildLatestSnapshotViewQuery(
     --   data: A raw JSON payload of the current state of the document.
     --   document_id: The document id as defined in the Firestore database
     WITH latest AS (
-      SELECT max(${timestampColumnName}) as latest_timestamp, document_id
+      SELECT max(${timestampColumnName}) as latest_timestamp, document_name
       FROM \`${process.env.PROJECT_ID}.${datasetId}.${tableName}\`
-      GROUP BY document_id
+      GROUP BY document_name
     )
     SELECT
-    document_name,
-    t.document_id${groupByColumns.length > 0 ? `,` : ``}
+    t.document_name,
+    document_id${groupByColumns.length > 0 ? `,` : ``}
       ${groupByColumns.join(",")}
     FROM \`${process.env.PROJECT_ID}.${datasetId}.${tableName}\` AS t
-    JOIN latest ON (t.document_id = latest.document_id AND t.${timestampColumnName} = latest.latest_timestamp)
+    JOIN latest ON (t.document_name = latest.document_name AND t.${timestampColumnName} = latest.latest_timestamp)
     WHERE operation != "DELETE"
     GROUP BY document_name, document_id${groupByColumns.length > 0 ? `, ` : ``
     }${groupByColumns.join(",")}`

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
@@ -116,18 +116,18 @@ export const buildLatestSchemaSnapshotViewQuery = (
 
   let query = `
       WITH latest AS (
-        SELECT max(timestamp) as latest_timestamp, document_id
+        SELECT max(timestamp) as latest_timestamp, document_name
         FROM \`${process.env.PROJECT_ID}.${datasetId}.${rawTableName}\`
-        GROUP BY document_id
+        GROUP BY document_name
       )
       SELECT
-        document_name,
-        t.document_id,
+        t.document_name,
+        document_id,
         timestamp,
         operation${fieldValueSelectorClauses.length > 0 ? `,` : ``}
         ${fieldValueSelectorClauses}
       FROM \`${process.env.PROJECT_ID}.${datasetId}.${rawTableName}\` AS t
-      JOIN latest ON (t.document_id = latest.document_id AND t.timestamp = latest.latest_timestamp)
+      JOIN latest ON (t.document_name = latest.document_name AND t.timestamp = latest.latest_timestamp)
       WHERE operation != "DELETE"
   `;
   const groupableExtractors = Object.keys(schemaFieldExtractors).filter(


### PR DESCRIPTION
Reopened https://github.com/firebase/extensions/pull/703 (rebased on next).

todo:
- add relevant stress tests
- tests for the case `Will this cover if there are null time stamps or the latest entry for a document has two entries with the same timestamp?` (mentioned [in this comment](https://github.com/firebase/extensions/pull/703#issuecomment-1302438030))