### PR TITLE
fix: Cannot read property 'forEach' of undefined

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/logs.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/logs.ts
@@ -217,7 +217,7 @@ export const bigQueryTableInsertErrors = (
 ) => {
   logger.warn(`Error when inserting data to table.`);
 
-  insertErrors.forEach((error) => {
+  insertErrors?.forEach((error) => {
     logger.warn("ROW DATA JSON:");
     logger.warn(error.row);
 


### PR DESCRIPTION
Sorry for the sudden PR.

An error was occurring while using the program, so I have made a temporary fix!

The full text of the error that was occurring is as follows

```
TypeError: Cannot read property 'forEach' of undefined
    at Object.exports.bigQueryTableInsertErrors (/home/yuuta3594/.npm/_npx/d906c8461d95e111/node_modules/@firebaseextensions/firestore-bigquery-change-tracker/lib/logs.js:138:18)
    at FirestoreBigQueryEventHistoryTracker.insertData (/home/yuuta3594/.npm/_npx/d906c8461d95e111/node_modules/@firebaseextensions/firestore-bigquery-change-tracker/lib/bigquery/index.js:191:18)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async FirestoreBigQueryEventHistoryTracker.record (/home/yuuta3594/.npm/_npx/d906c8461d95e111/node_modules/@firebaseextensions/firestore-bigquery-change-tracker/lib/bigquery/index.js:74:9)
    at async run (/home/yuuta3594/.npm/_npx/d906c8461d95e111/node_modules/@firebaseextensions/fs-bq-import-collection/lib/index.js:229:9)
Error importing Collection to BigQuery: TypeError: Cannot read property 'forEach' of undefined
```