### PR TITLE
Solves the problem of forcing resized images to be placed in the root…

### DIFF
--- a/storage-resize-images/functions/src/resize-image.ts
+++ b/storage-resize-images/functions/src/resize-image.ts
@@ -155,10 +155,10 @@ export const modifyImage = async ({
   }
 
   // Path where modified image will be uploaded to in Storage.
-  const modifiedFilePath = path.normalize(
+  const modifiedFilePath = path.posix.normalize(
     config.resizedImagesPath
-      ? path.join(fileDir, config.resizedImagesPath, modifiedFileName)
-      : path.join(fileDir, modifiedFileName)
+      ? path.posix.join(fileDir, config.resizedImagesPath, modifiedFileName)
+      : path.posix.join(fileDir, modifiedFileName)
   );
   let modifiedFile: string;
 


### PR DESCRIPTION
… of the bucket when emulated on windows.

This is a case of an emulator on windows.
The modifiedFilePath variable is used as the upload destination for the resized images. In this case, bucket.upload method will not result in an error, but the image will be uploaded to the root of the bucket. Therefore, we use path.posix to convert the path to unix format.