### PR TITLE
fix(storage-resize-images): re-add input object data to the complete event

### DIFF
--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -109,6 +109,7 @@ const generateResizedImageHandler = async (
         type: "firebase.extensions.storage-resize-images.v1.complete",
         subject: filePath,
         data: {
+          input: object,
           outputs: results,
         },
       }));


### PR DESCRIPTION
Re-introduced object data as input for resize-image `completion events`