### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/firestore-counter/clients/node/index.js
+++ b/firestore-counter/clients/node/index.js
@@ -38,10 +38,10 @@ module.exports = class Counter {
     const shardsRef = doc.collection(SHARD_COLLECTION_ID);
     this.shards[doc.path] = 0;
     this.shards[shardsRef.doc(this.shardId).path] = 0;
-    this.shards[shardsRef.doc("\t" + this.shardId.substr(0, 4)).path] = 0;
-    this.shards[shardsRef.doc("\t\t" + this.shardId.substr(0, 3)).path] = 0;
-    this.shards[shardsRef.doc("\t\t\t" + this.shardId.substr(0, 2)).path] = 0;
-    this.shards[shardsRef.doc("\t\t\t\t" + this.shardId.substr(0, 1)).path] = 0;
+    this.shards[shardsRef.doc("\t" + this.shardId.slice(0, 4)).path] = 0;
+    this.shards[shardsRef.doc("\t\t" + this.shardId.slice(0, 3)).path] = 0;
+    this.shards[shardsRef.doc("\t\t\t" + this.shardId.slice(0, 2)).path] = 0;
+    this.shards[shardsRef.doc("\t\t\t\t" + this.shardId.slice(0, 1)).path] = 0;
   }
 
   /**

--- a/firestore-counter/clients/web/src/index.ts
+++ b/firestore-counter/clients/web/src/index.ts
@@ -56,14 +56,10 @@ export class Counter {
     this.shards[doc.path] = 0;
 
     this.shards[shardsRef.path + "/" + this.shardId] = 0;
-    this.shards[shardsRef.path + "/" + "\t" + this.shardId.substr(0, 4)] = 0;
-    this.shards[shardsRef.path + "/" + "\t\t" + this.shardId.substr(0, 3)] = 0;
-    this.shards[
-      shardsRef.path + "/" + "\t\t\t" + this.shardId.substr(0, 2)
-    ] = 0;
-    this.shards[
-      shardsRef.path + "/" + "\t\t\t" + this.shardId.substr(0, 1)
-    ] = 0;
+    this.shards[shardsRef.path + "/" + "\t" + this.shardId.slice(0, 4)] = 0;
+    this.shards[shardsRef.path + "/" + "\t\t" + this.shardId.slice(0, 3)] = 0;
+    this.shards[shardsRef.path + "/" + "\t\t\t" + this.shardId.slice(0, 2)] = 0;
+    this.shards[shardsRef.path + "/" + "\t\t\t" + this.shardId.slice(0, 1)] = 0;
   }
 
   /**


### PR DESCRIPTION
(reopening https://github.com/firebase/extensions/pull/928 for testing purposes)

.substr() is deprecated so we replace it with .slice() which works similarily but isn't deprecated
