### PR TITLE
chore(firestore-bigquery-export): exclude local import script testing

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   projects: [
     "<rootDir>/*/functions/jest.config.js",
-    "<rootDir>/firestore-bigquery-export/scripts/*/jest.config.js",
+    "<rootDir>/firestore-bigquery-export/scripts/gen-schema-view/jest.config.js",
   ],
   testPathIgnorePatterns: [
     ".*/bin/",


### PR DESCRIPTION
- [x] Exclude BQ import testing as this uses a different version of the Cli and is reliant on BQ which we currently do not have a centralised project for yet. Tests currently passing when ran locally/manually.

![image](https://user-images.githubusercontent.com/2060661/210572352-0d640836-02f3-4e21-a981-ebcc73188df8.png)
