### PR TITLE
@invertase/languages field

### DIFF
--- a/firestore-translate-text/extension.yaml
+++ b/firestore-translate-text/extension.yaml
@@ -169,6 +169,15 @@ params:
     default: translated
     required: true
 
+  - param: LANGUAGES_FIELD_NAME
+    label: Languages field name
+    description: >
+      What is the name of the field that contains the languages that you want to translate into? This field is
+      optional. If you don't specify it, the extension will use the languages specified in the LANGUAGES parameter.
+    example: languages
+    default: languages
+    required: false
+
   - param: DO_BACKFILL
     label: Translate existing documents?
     description: >

--- a/firestore-translate-text/functions/__tests__/__snapshots__/config.test.ts.snap
+++ b/firestore-translate-text/functions/__tests__/__snapshots__/config.test.ts.snap
@@ -10,6 +10,7 @@ Object {
     "de",
     "fr",
   ],
+  "languagesFieldName": undefined,
   "location": "us-central1",
   "outputFieldName": "translated",
 }

--- a/firestore-translate-text/functions/__tests__/config.test.ts
+++ b/firestore-translate-text/functions/__tests__/config.test.ts
@@ -51,7 +51,13 @@ describe("extension config", () => {
   test("config loaded from environment variables", () => {
     const functionsConfig = config();
 
-    expect(functionsConfig).toMatchSnapshot({});
+    expect(functionsConfig).toMatchSnapshot({
+      languages: ["en", "es", "de", "fr"],
+      languagesFieldName: undefined,
+      location: "us-central1",
+      inputFieldName: "input",
+      outputFieldName: "translated",
+    });
   });
 
   test("config is logged on initialize", () => {

--- a/firestore-translate-text/functions/__tests__/functions.test.ts
+++ b/firestore-translate-text/functions/__tests__/functions.test.ts
@@ -250,7 +250,7 @@ describe("extension", () => {
       );
     });
 
-    test("should only translate to english if languages field test specifies that", async () => {
+    test("should only translate to english if languages has "English" as a single array item", async () => {
       beforeSnapshot = snapshot();
 
       afterSnapshot = snapshot({

--- a/firestore-translate-text/functions/__tests__/functions.test.ts
+++ b/firestore-translate-text/functions/__tests__/functions.test.ts
@@ -250,7 +250,7 @@ describe("extension", () => {
       );
     });
 
-    test("should only translate to english if languages has "English" as a single array item", async () => {
+    test('should only translate to english if languages has "English" as a single array item', async () => {
       beforeSnapshot = snapshot();
 
       afterSnapshot = snapshot({
@@ -297,7 +297,7 @@ describe("extension", () => {
       });
     });
 
-    test("should only translate english and spanish if languages field test specifies that", async () => {
+    test('should only translate "English" and "Spanish" if languages field contains English and Spanish as array items', async () => {
       beforeSnapshot = snapshot();
 
       afterSnapshot = snapshot({

--- a/firestore-translate-text/functions/__tests__/functions.test.ts
+++ b/firestore-translate-text/functions/__tests__/functions.test.ts
@@ -11,6 +11,7 @@ const defaultEnvironment = {
   COLLECTION_PATH: "translations",
   INPUT_FIELD_NAME: "input",
   OUTPUT_FIELD_NAME: "translated",
+  LANGUAGES_FIELD_NAME: "langs",
 };
 
 const {
@@ -206,7 +207,50 @@ describe("extension", () => {
       );
     });
 
-    test("function updates translation document with multiple translations", async () => {
+    test("function updates translation document with translations", async () => {
+      await wrappedMockTranslate(documentChange);
+
+      // confirm Google Translation API was called
+      expect(mockTranslateClassMethod).toHaveBeenCalledWith("hello", "en");
+      expect(mockTranslateClassMethod).toHaveBeenCalledWith("hello", "es");
+      expect(mockTranslateClassMethod).toHaveBeenCalledWith("hello", "fr");
+      expect(mockTranslateClassMethod).toHaveBeenCalledWith("hello", "de");
+
+      // confirm document update was called
+      expect(mockFirestoreUpdate).toHaveBeenCalledWith(
+        defaultEnvironment.OUTPUT_FIELD_NAME,
+        testTranslations
+      );
+      const languages = ["en", "es", "de", "fr"];
+
+      const translations = ["hello", "hola", "hallo", "salut"];
+
+      expect(logMock).toHaveBeenCalledWith(
+        messages.translateInputStringToAllLanguages("hello", languages)
+      );
+      // confirm logs were printed
+      languages.forEach((language, i) => {
+        // logs.translateInputString
+        // logs.translateStringComplete TODO: fix this
+        expect(logMock).toHaveBeenCalledWith(
+          messages.translateStringComplete("hello", language, translations[i])
+        );
+      });
+
+      // logs.translateInputStringToAllLanguages
+      expect(logMock).toHaveBeenCalledWith(
+        messages.translateInputStringToAllLanguages(
+          "hello",
+          defaultEnvironment.LANGUAGES.split(",")
+        )
+      );
+      // logs.translateInputToAllLanguagesComplete
+      expect(logMock).toHaveBeenCalledWith(
+        messages.translateInputToAllLanguagesComplete("hello")
+      );
+    });
+
+    test("should only translate to english if languages field test specifies that", async () => {
       beforeSnapshot = snapshot();
 
       afterSnapshot = snapshot({
@@ -214,6 +258,8 @@ describe("extension", () => {
           one: "hello",
           two: "hello",
         },
+        //@ts-ignore
+        langs: ["en"],
       });
 
       documentChange = functionsTest.makeChange(beforeSnapshot, afterSnapshot);
@@ -223,16 +269,59 @@ describe("extension", () => {
       // confirm document update was called
       expect(mockFirestoreUpdate).toHaveBeenCalledWith("translated", {
         one: {
-          de: "hallo",
           en: "hello",
-          es: "hola",
-          fr: "salut",
         },
         two: {
-          de: "hallo",
+          en: "hello",
+        },
+      });
+
+      // confirm logs were printed
+      Object.entries((key, value) => {
+        expect(logMock).toHaveBeenCalledWith(
+          messages.translateInputString(value, key)
+        );
+
+        // logs.translateInputStringToAllLanguages
+        expect(logMock).toHaveBeenCalledWith(
+          messages.translateInputStringToAllLanguages(
+            key,
+            defaultEnvironment.LANGUAGES.split(",")
+          )
+        );
+
+        // logs.translateInputToAllLanguagesComplete
+        expect(logMock).toHaveBeenCalledWith(
+          messages.translateInputToAllLanguagesComplete(value)
+        );
+      });
+    });
+
+    test("should only translate english and spanish if languages field test specifies that", async () => {
+      beforeSnapshot = snapshot();
+
+      afterSnapshot = snapshot({
+        input: {
+          one: "hello",
+          two: "hello",
+        },
+        //@ts-ignore
+        langs: ["en", "es"],
+      });
+
+      documentChange = functionsTest.makeChange(beforeSnapshot, afterSnapshot);
+
+      await wrappedMockTranslate(documentChange);
+
+      // confirm document update was called
+      expect(mockFirestoreUpdate).toHaveBeenCalledWith("translated", {
+        one: {
           en: "hello",
           es: "hola",
-          fr: "salut",
+        },
+        two: {
+          en: "hello",
+          es: "hola",
         },
       });
 

--- a/firestore-translate-text/functions/src/config.ts
+++ b/firestore-translate-text/functions/src/config.ts
@@ -20,4 +20,5 @@ export default {
   location: process.env.LOCATION,
   inputFieldName: process.env.INPUT_FIELD_NAME,
   outputFieldName: process.env.OUTPUT_FIELD_NAME,
+  languagesFieldName: process.env.LANGUAGES_FIELD_NAME,
 };

--- a/firestore-translate-text/functions/src/index.ts
+++ b/firestore-translate-text/functions/src/index.ts
@@ -82,7 +82,7 @@ export const fstranslatebackfill = functions.tasks
       await runtime.setProcessingState(
         "PROCESSING_COMPLETE",
         'Existing documents were not translated because "Translate existing documents?" is configured to false. ' +
-        "If you want to fill in missing translations, reconfigure this instance."
+          "If you want to fill in missing translations, reconfigure this instance."
       );
       return;
     }
@@ -133,19 +133,22 @@ export const fstranslatebackfill = functions.tasks
       if (newErrorCount == 0) {
         return await runtime.setProcessingState(
           "PROCESSING_COMPLETE",
-          `Successfully translated ${newSucessCount} documents in ${Date.now() - startTime
+          `Successfully translated ${newSucessCount} documents in ${
+            Date.now() - startTime
           }ms.`
         );
       } else if (newErrorCount > 0 && newSucessCount > 0) {
         return await runtime.setProcessingState(
           "PROCESSING_WARNING",
-          `Successfully translated ${newSucessCount} documents, ${newErrorCount} errors in ${Date.now() - startTime
+          `Successfully translated ${newSucessCount} documents, ${newErrorCount} errors in ${
+            Date.now() - startTime
           }ms. See function logs for specific error messages.`
         );
       }
       return await runtime.setProcessingState(
         "PROCESSING_FAILED",
-        `Successfully translated ${newSucessCount} documents, ${newErrorCount} errors in ${Date.now() - startTime
+        `Successfully translated ${newSucessCount} documents, ${newErrorCount} errors in ${
+          Date.now() - startTime
         }ms. See function logs for specific error messages.`
       );
     }
@@ -157,7 +160,7 @@ const extractInput = (snapshot: admin.firestore.DocumentSnapshot): any => {
 
 const extractOutput = (snapshot: admin.firestore.DocumentSnapshot): any => {
   return snapshot.get(config.outputFieldName);
-}
+};
 
 const extractLanguages = (
   snapshot: admin.firestore.DocumentSnapshot
@@ -338,7 +341,8 @@ const translateSingleBackfill = async (
   } else if (failedTranslations.length && successfulTranslations.length) {
     logs.partialTranslateError(input, failedTranslations, translations.length);
     // If any translations failed, throw so it is reported as an error.
-    throw `Error while translating '${input}': ${failedTranslations.length
+    throw `Error while translating '${input}': ${
+      failedTranslations.length
     } out of ${languages.length} translations failed: ${failedTranslations.join(
       "\n"
     )}`;
@@ -433,7 +437,8 @@ const translateMultipleBackfill = async (
       translations.length
     );
     // If any translations failed, throw so it is reported as an error.
-    throw `${failedTranslations.length
+    throw `${
+      failedTranslations.length
     } error(s) while translating '${input}': ${failedTranslations.join("\n")}`;
   } else {
     logs.translateInputToAllLanguagesComplete(JSON.stringify(input));


### PR DESCRIPTION
fixes: https://github.com/firebase/extensions/issues/1142

This PR allows for `LANGUAGE_FIELD_NAME` to be set. If a field with this name is added to a document to be translated, the extension will use the languages provided on this field.