### PR TITLE
fix(storage-resize-images): support backfill task in custom region

### DIFF
--- a/storage-resize-images/functions/__tests__/__snapshots__/config.test.ts.snap
+++ b/storage-resize-images/functions/__tests__/__snapshots__/config.test.ts.snap
@@ -13,6 +13,7 @@ Object {
   ],
   "imageTypes": undefined,
   "includePathList": undefined,
+  "location": "us-central1",
   "makePublic": false,
   "outputOptions": undefined,
   "resizedImagesPath": undefined,

--- a/storage-resize-images/functions/src/config.ts
+++ b/storage-resize-images/functions/src/config.ts
@@ -48,4 +48,5 @@ export default {
   imageTypes: paramToArray(process.env.IMAGE_TYPE),
   outputOptions: process.env.OUTPUT_OPTIONS,
   animated: process.env.IS_ANIMATED === "true" || undefined ? true : false,
+  location: process.env.LOCATION,
 };

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -211,7 +211,7 @@ export const backfillResizedImages = functions.tasks
 
     if (nextPageQuery) {
       const queue = getFunctions().taskQueue(
-        `backfillResizedImages`,
+        `locations/${config.location}/functions/backfillResizedImages`,
         process.env.EXT_INSTANCE_ID
       );
       await queue.enqueue({


### PR DESCRIPTION
fixes: #1389

Consider location (region) the extension is installed when loading task queue.

Previously regardless of which region the extension is installed, it will look for a the Task Queue in `us-central1`. 
See documentation for information: https://firebase.google.com/docs/reference/admin/node/firebase-admin.functions.functions.md#functionstaskqueue