### PR TITLE
feat(firestore-send-email): add TTL support

### DIFF
--- a/_emulator/extensions/firestore-send-email.env.local
+++ b/_emulator/extensions/firestore-send-email.env.local
@@ -6,3 +6,4 @@ SMTP_PASSWORD=secret-password
 DEFAULT_FROM=fakeemail@gmail.com
 DEFAULT_REPLY_TO=fakeemail@gmail.com
 TESTING=true
+FIRESTORE_EXPIRE_AT=day

--- a/_emulator/extensions/firestore-send-email.env.local
+++ b/_emulator/extensions/firestore-send-email.env.local
@@ -6,4 +6,5 @@ SMTP_PASSWORD=secret-password
 DEFAULT_FROM=fakeemail@gmail.com
 DEFAULT_REPLY_TO=fakeemail@gmail.com
 TESTING=true
-FIRESTORE_EXPIRE_AT=day
+TTL_EXPIRE_TYPE=day
+TTL_EXPIRE_VALUE=5

--- a/_emulator/extensions/firestore-send-email.secret.local
+++ b/_emulator/extensions/firestore-send-email.secret.local
@@ -6,3 +6,4 @@ SMTP_PASSWORD=secret-password
 DEFAULT_FROM=fakeemail@gmail.com
 DEFAULT_REPLY_TO=fakeemail@gmail.com
 TESTING=true
+FIRESTORE_EXPIRE_AT=day

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -184,8 +184,9 @@ params:
   - param: TTL_EXPIRE_TYPE
     label: Firestore TTL type
     description: >-
-      Do you want the firestore records to be marked with an expireAt field for a TTL policy? If "Never" is selected then no expireAt field will be added. Otherwise
-      you may specify the unit of time specified by the TTL_EXPIRE_VALUE parameter. Defaults to "Never".
+      Do you want the firestore records to be marked with an expireAt field for a TTL policy?
+      If "Never" is selected then no expireAt field will be added.
+      Otherwise you may specify the unit of time specified by the TTL_EXPIRE_VALUE parameter. Defaults to "Never".
     type: select
     options:
       - label: Never

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -181,12 +181,11 @@ params:
       if the template is specified in the added email document.
     type: string
 
-  - param: FIRESTORE_EXPIRE_AT
-    label: Firestore TTL support option
+  - param: TTL_EXPIRE_TYPE
+    label: Firestore TTL type
     description: >-
-      Do you want the firestore records to be marked with an expireAt field for a TTL policy? If so, how long do you want the records to stay ineligible for deletion by
-      your policy? Note you will have to set up the [TTL policy](https://firebase.google.com/docs/firestore/ttl) for your project yourself. If "Never" is selected then no
-      expireAt field will be added.
+      Do you want the firestore records to be marked with an expireAt field for a TTL policy? If "Never" is selected then no expireAt field will be added. Otherwise
+      you may specify the unit of time specified by the TTL_EXPIRE_VALUE parameter. Defaults to "Never".
     type: select
     options:
       - label: Never
@@ -201,7 +200,17 @@ params:
         value: month
       - label: Year
         value: year
-    default: disabled
+    default: never
+    required: true
+
+  - param: TTL_EXPIRE_VALUE
+    label: Firestore TTL value
+    description: >-
+      In the units specified by TTL_EXPIRE_TYPE, how long do you want records to be ineligible for deletion by a TTL policy? This parameter requires the Firestore TTL type paramter
+      to be set to a value other than "Never".
+    validationRegex: "^[1-9][0-9]*$"
+    validationErrorMessage: The value must be an integer value greater than zero.
+    default: "1"
     required: true
 events:
   - type: firebase.extensions.firestore-send-email.v1.onStart

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -181,6 +181,28 @@ params:
       if the template is specified in the added email document.
     type: string
 
+  - param: FIRESTORE_EXPIRE_AT
+    label: Firestore TTL support option
+    description: >-
+      Do you want the firestore records to be marked with an expireAt field for a TTL policy? If so, how long do you want the records to stay ineligible for deletion by
+      your policy? Note you will have to set up the [TTL policy](https://firebase.google.com/docs/firestore/ttl) for your project yourself. If "Never" is selected then no
+      expireAt field will be added.
+    type: select
+    options:
+      - label: Never
+        value: never
+      - label: Hour
+        value: hour
+      - label: Day
+        value: day
+      - label: Week
+        value: week
+      - label: Month
+        value: month
+      - label: Year
+        value: year
+    default: disabled
+    required: true
 events:
   - type: firebase.extensions.firestore-send-email.v1.onStart
     description: Occurs when the extension starts execution.

--- a/firestore-send-email/functions/__tests__/config.test.ts
+++ b/firestore-send-email/functions/__tests__/config.test.ts
@@ -19,7 +19,8 @@ const environment = {
   DEFAULT_REPLY_TO: "fakeemail@gmail.com",
   USERS_COLLECTION: "users",
   TESTING: "true",
-  firestoreExpireAt: "day",
+  TTL_EXPIRE_TYPE: "day",
+  TTL_EXPIRE_VALUE: "1",
 };
 
 describe("extensions config", () => {

--- a/firestore-send-email/functions/__tests__/config.test.ts
+++ b/firestore-send-email/functions/__tests__/config.test.ts
@@ -19,6 +19,7 @@ const environment = {
   DEFAULT_REPLY_TO: "fakeemail@gmail.com",
   USERS_COLLECTION: "users",
   TESTING: "true",
+  firestoreExpireAt: "day",
 };
 
 describe("extensions config", () => {
@@ -38,6 +39,7 @@ describe("extensions config", () => {
       usersCollection: process.env.USERS_COLLECTION,
       templatesCollection: process.env.TEMPLATES_COLLECTION,
       testing: process.env.TESTING === "true",
+      firestoreExpireAt: process.env.FIRESTORE_EXPIRE_AT,
     };
     const functionsConfig = config();
     expect(functionsConfig).toStrictEqual(testConfig);

--- a/firestore-send-email/functions/__tests__/config.test.ts
+++ b/firestore-send-email/functions/__tests__/config.test.ts
@@ -39,7 +39,8 @@ describe("extensions config", () => {
       usersCollection: process.env.USERS_COLLECTION,
       templatesCollection: process.env.TEMPLATES_COLLECTION,
       testing: process.env.TESTING === "true",
-      firestoreExpireAt: process.env.FIRESTORE_EXPIRE_AT,
+      TTLExpireType: process.env.TTL_EXPIRE_TYPE,
+      TTLExpireValue: parseInt(process.env.TTL_EXPIRE_VALUE),
     };
     const functionsConfig = config();
     expect(functionsConfig).toStrictEqual(testConfig);

--- a/firestore-send-email/functions/__tests__/e2e.test.ts
+++ b/firestore-send-email/functions/__tests__/e2e.test.ts
@@ -44,6 +44,31 @@ describe("e2e testing", () => {
     });
   }, 12000);
 
+  test("the expireAt field should be added, with value a day later than startTime", async (): Promise<void> => {
+    const record = {
+      to: "test-assertion2@email.com",
+      message: {
+        subject: "test2",
+      },
+    };
+
+    const doc = await mailCollection.add(record);
+
+    return new Promise((resolve, reject) => {
+      const unsubscribe = doc.onSnapshot((snapshot) => {
+        const document = snapshot.data();
+
+        if (document.delivery && document.delivery.info) {
+          const startAt = document.delivery.startTime.toDate();
+          const expireAt = document.delivery.expireAt.toDate();
+          expect(expireAt.getTime() - startAt.getTime()).toEqual(86400000);
+          unsubscribe();
+          resolve();
+        }
+      });
+    });
+  }, 12000);
+
   test("empty template attachments should default to message attachments", async (): Promise<void> => {
     //create template
     const template = await templatesCollection.doc("default").set({

--- a/firestore-send-email/functions/__tests__/e2e.test.ts
+++ b/firestore-send-email/functions/__tests__/e2e.test.ts
@@ -44,7 +44,7 @@ describe("e2e testing", () => {
     });
   }, 12000);
 
-  test("the expireAt field should be added, with value a day later than startTime", async (): Promise<void> => {
+  test("the expireAt field should be added, with value 5 days later than startTime", async (): Promise<void> => {
     const record = {
       to: "test-assertion2@email.com",
       message: {
@@ -61,7 +61,7 @@ describe("e2e testing", () => {
         if (document.delivery && document.delivery.info) {
           const startAt = document.delivery.startTime.toDate();
           const expireAt = document.delivery.expireAt.toDate();
-          expect(expireAt.getTime() - startAt.getTime()).toEqual(86400000);
+          expect(expireAt.getTime() - startAt.getTime()).toEqual(5 * 86400000);
           unsubscribe();
           resolve();
         }

--- a/firestore-send-email/functions/src/config.ts
+++ b/firestore-send-email/functions/src/config.ts
@@ -26,6 +26,7 @@ const config: Config = {
   usersCollection: process.env.USERS_COLLECTION,
   templatesCollection: process.env.TEMPLATES_COLLECTION,
   testing: process.env.TESTING === "true",
+  firestoreExpireAt: process.env.FIRESTORE_EXPIRE_AT,
 };
 
 export default config;

--- a/firestore-send-email/functions/src/config.ts
+++ b/firestore-send-email/functions/src/config.ts
@@ -26,7 +26,8 @@ const config: Config = {
   usersCollection: process.env.USERS_COLLECTION,
   templatesCollection: process.env.TEMPLATES_COLLECTION,
   testing: process.env.TESTING === "true",
-  firestoreExpireAt: process.env.FIRESTORE_EXPIRE_AT,
+  TTLExpireType: process.env.TTL_EXPIRE_TYPE,
+  TTLExpireValue: parseInt(process.env.TTL_EXPIRE_VALUE),
 };
 
 export default config;

--- a/firestore-send-email/functions/src/index.ts
+++ b/firestore-send-email/functions/src/index.ts
@@ -78,21 +78,22 @@ function validateFieldArray(field: string, array?: string[]) {
 
 function getExpireAt(startTime: admin.firestore.Timestamp) {
   const now = startTime.toDate();
-  switch (config.firestoreExpireAt) {
+  const value = config.TTLExpireValue;
+  switch (config.TTLExpireType) {
     case "hour":
-      now.setHours(now.getHours() + 1);
+      now.setHours(now.getHours() + value);
       break;
     case "day":
-      now.setDate(now.getDate() + 1);
+      now.setDate(now.getDate() + value);
       break;
     case "week":
-      now.setDate(now.getDate() + 7);
+      now.setDate(now.getDate() + value);
       break;
     case "month":
-      now.setMonth(now.getMonth() + 1);
+      now.setMonth(now.getMonth() + value);
       break;
     case "year":
-      now.setFullYear(now.getFullYear() + 1);
+      now.setFullYear(now.getFullYear() + value);
       break;
   }
   return admin.firestore.Timestamp.fromDate(now);
@@ -110,7 +111,7 @@ async function processCreate(snap: FirebaseFirestore.DocumentSnapshot) {
     error: null,
   };
 
-  if (config.firestoreExpireAt && config.firestoreExpireAt !== "never") {
+  if (config.TTLExpireType && config.TTLExpireType !== "never") {
     delivery["expireAt"] = getExpireAt(startTime);
   }
 

--- a/firestore-send-email/functions/src/types.ts
+++ b/firestore-send-email/functions/src/types.ts
@@ -10,6 +10,7 @@ export interface Config {
   usersCollection?: string;
   templatesCollection?: string;
   testing?: boolean;
+  firestoreExpireAt?: string;
 }
 export interface Attachment {
   filename?: string;

--- a/firestore-send-email/functions/src/types.ts
+++ b/firestore-send-email/functions/src/types.ts
@@ -10,7 +10,8 @@ export interface Config {
   usersCollection?: string;
   templatesCollection?: string;
   testing?: boolean;
-  firestoreExpireAt?: string;
+  TTLExpireType?: string;
+  TTLExpireValue?: number;
 }
 export interface Attachment {
   filename?: string;


### PR DESCRIPTION
This feature allows TTL support for firestore-send-email.

The dev can pick a value for the parameter `FIRESTORE_EXPIRE_AT` and the extension will automatically add an `expireAt` field to firestore records of emails, with a value relative to their creation. The dev can set up a TTL policy on their firestore database to delete these records.

fixes https://github.com/firebase/extensions/issues/1072