### PR TITLE
Update import script docs to warn about duplication on multiple runs

### DIFF
--- a/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
+++ b/firestore-bigquery-export/guides/IMPORT_EXISTING_DOCUMENTS.md
@@ -19,6 +19,8 @@ You may pause and resume the import script from the last batch at any point.
 
 - You cannot use wildcard notation in the collection path (i.e. `/collection/{document}/sub_collection}`). Instead, you can use a [collectionGroup](https://firebase.google.com/docs/firestore/query-data/queries#collection-group-query) query. To use a `collectionGroup` query, provide the collection name value as `${COLLECTION_PATH}`, and set `${COLLECTION_GROUP_QUERY}` to `true`.
 
+- Warning: The import operation is not idempotent; running it twice, or running it after documents have been imported will likely produce duplicate data in your bigquery table.
+
   Warning: A `collectionGroup` query will target every collection in your Firestore project with the provided `${COLLECTION_PATH}`. For example, if you have 10,000 documents with a sub-collection named: `landmarks`, the import script will query every document in 10,000 `landmarks` collections.
 
 ### Run the script


### PR DESCRIPTION
As mentioned in the thread https://github.com/firebase/extensions/issues/1060 

Running the import script twice duplicates data, and it is not advised to be used as a resync, in its current behaviour.