### PR TITLE
[storage-resize-images] Always use posix paths when writing to storage

### DIFF
--- a/storage-resize-images/functions/src/resize-image.ts
+++ b/storage-resize-images/functions/src/resize-image.ts
@@ -157,8 +157,8 @@ export const modifyImage = async ({
   // Path where modified image will be uploaded to in Storage.
   const modifiedFilePath = path.normalize(
     config.resizedImagesPath
-      ? path.join(fileDir, config.resizedImagesPath, modifiedFileName)
-      : path.join(fileDir, modifiedFileName)
+      ? path.posix.join(fileDir, config.resizedImagesPath, modifiedFileName)
+      : path.posix.join(fileDir, modifiedFileName)
   );
   let modifiedFile: string;
 


### PR DESCRIPTION
Switch storage-resize-images to always use POSIX paths when writing to Storage.

This addresses an issue (https://github.com/firebase/firebase-tools/issues/5430) where, when emulating this extension on a Windows machine, resized images would be written to the root of the bucket with the Windows path as the filename.

Fixes https://github.com/firebase/firebase-tools/issues/5430.