### PR TITLE
fix(firestore-send-email): Move warning until after checking for templates

### DIFF
--- a/firestore-send-email/functions/src/index.ts
+++ b/firestore-send-email/functions/src/index.ts
@@ -354,12 +354,9 @@ async function processWrite(
       }
 
       const payload = snapshot.data();
-      if (!payload.delivery) {
-        logs.missingDeliveryField(change.after.ref);
-        return null;
-      }
 
       if (!payload.delivery) {
+        logs.missingDeliveryField(change.after.ref);
         const startTime = Timestamp.fromDate(new Date());
 
         const delivery = {

--- a/firestore-send-email/functions/src/logs.ts
+++ b/firestore-send-email/functions/src/logs.ts
@@ -97,7 +97,7 @@ export function templatesLoaded(names) {
 
 export function invalidMessage(message) {
   logger.warn(
-    `message '${message}' is not a valid object - please add as an object or firestore map, otherwise you may experience unexpected results.`
+    `message '${message}' is not a valid object and no handlebars template has been provided instead - please add as an object or firestore map, otherwise you may experience unexpected results.`
   );
 }
 


### PR DESCRIPTION
This PR moves the warning about missing messages until after the payload has been checked for template references. As mentioned [here ](https://github.com/firebase/extensions/issues/1418) this warning isn't necessary if a template is provided, as the message will be constructed from the template.

fixes: https://github.com/firebase/extensions/issues/1418