### PR TITLE
fix(firestore-send-email): fix typo in extension

### DIFF
--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -208,7 +208,7 @@ params:
     label: Firestore TTL value
     description: >-
       In the units specified by TTL_EXPIRE_TYPE, how long do you want records to be ineligible for deletion by a TTL policy? This parameter requires the Firestore TTL type parameter
-      to be set to a value other than "Never". For example, if `Firestore TTL type` is set to `Day` then setting this parameter to `1` will specify a TTL of 1 day.
+      to be set to a value other than `Never`. For example, if `Firestore TTL type` is set to `Day` then setting this parameter to `1` will specify a TTL of 1 day.
     validationRegex: "^[1-9][0-9]*$"
     validationErrorMessage: The value must be an integer value greater than zero.
     default: "1"

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -207,7 +207,7 @@ params:
   - param: TTL_EXPIRE_VALUE
     label: Firestore TTL value
     description: >-
-      In the units specified by TTL_EXPIRE_TYPE, how long do you want records to be ineligible for deletion by a TTL policy? This parameter requires the Firestore TTL type paramter
+      In the units specified by TTL_EXPIRE_TYPE, how long do you want records to be ineligible for deletion by a TTL policy? This parameter requires the Firestore TTL type parameter
       to be set to a value other than "Never".
     validationRegex: "^[1-9][0-9]*$"
     validationErrorMessage: The value must be an integer value greater than zero.

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -208,7 +208,7 @@ params:
     label: Firestore TTL value
     description: >-
       In the units specified by TTL_EXPIRE_TYPE, how long do you want records to be ineligible for deletion by a TTL policy? This parameter requires the Firestore TTL type parameter
-      to be set to a value other than "Never".
+      to be set to a value other than "Never". For example, if `Firestore TTL type` is set to `Day` then setting this parameter to `1` will specify a TTL of 1 day.
     validationRegex: "^[1-9][0-9]*$"
     validationErrorMessage: The value must be an integer value greater than zero.
     default: "1"


### PR DESCRIPTION
This PR fixes a small typo in the extension.yaml