### PR TITLE
fix(firestore-bigquery-export): set environmental variables after initialization

### DIFF
--- a/firestore-bigquery-export/scripts/gen-schema-view/src/index.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/index.ts
@@ -120,10 +120,12 @@ async function run(): Promise<number> {
   process.env.GOOGLE_CLOUD_PROJECT = config.projectId;
 
   // Initialize Firebase
-  firebase.initializeApp({
-    credential: firebase.credential.applicationDefault(),
-    databaseURL: `https://${config.projectId}.firebaseio.com`,
-  });
+  if (!firebase.apps.length) {
+    firebase.initializeApp({
+      credential: firebase.credential.applicationDefault(),
+      databaseURL: `https://${config.projectId}.firebaseio.com`,
+    });
+  }
 
   // @ts-ignore string not assignable to enum
   if (Object.keys(config.schemas).length === 0) {

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/index.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/index.ts
@@ -126,6 +126,8 @@ async function run(): Promise<number> {
       databaseURL: `https://${config.projectId}.firebaseio.com`,
     });
   }
+  process.env.PROJECT_ID = config.projectId;
+  process.env.GOOGLE_CLOUD_PROJECT = config.projectId;
 
   // @ts-ignore string not assignable to enum
   if (Object.keys(config.schemas).length === 0) {

--- a/firestore-bigquery-export/scripts/import/src/index.ts
+++ b/firestore-bigquery-export/scripts/import/src/index.ts
@@ -121,11 +121,12 @@ const run = async (): Promise<number> => {
   // Initialize Firebase
   // This uses applicationDefault to authenticate
   // Please see https://cloud.google.com/docs/authentication/production
-  firebase.initializeApp({
-    credential: firebase.credential.applicationDefault(),
-    databaseURL: `https://${projectId}.firebaseio.com`,
-  });
-
+  if (!firebase.apps.length) {
+    firebase.initializeApp({
+      credential: firebase.credential.applicationDefault(),
+      databaseURL: `https://${projectId}.firebaseio.com`,
+    });
+  }
   // Set project ID, so it can be used in BigQuery initialization
   process.env.PROJECT_ID = projectId;
   process.env.GOOGLE_CLOUD_PROJECT = projectId;


### PR DESCRIPTION
at the moment running this script will trigger a warning about certain environmental variables being undefined. This PR is to set them, as we do in the import script.

should fix https://github.com/firebase/extensions/issues/978