### PR TITLE
chore(firestore-bigquery-export): revert PR to add envs (not needed)

### DIFF
--- a/firestore-bigquery-export/scripts/gen-schema-view/src/index.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/index.ts
@@ -126,8 +126,6 @@ async function run(): Promise<number> {
       databaseURL: `https://${config.projectId}.firebaseio.com`,
     });
   }
-  process.env.PROJECT_ID = config.projectId;
-  process.env.GOOGLE_CLOUD_PROJECT = config.projectId;
 
   // @ts-ignore string not assignable to enum
   if (Object.keys(config.schemas).length === 0) {


### PR DESCRIPTION
This PR reverts a small patch, these lines were already present and did not need adding.