### PR TITLE
fix(firestore-bigquery-export): Remove broken partition table check

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/partitioning.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/partitioning.ts
@@ -128,13 +128,9 @@ export class Partitioning {
   }
 
   private async isTablePartitioned() {
-    if (!this.table) return Promise.resolve(false);
     // No table provided, cannot evaluate
-    if (this.table.exists()) {
-      logs.cannotPartitionExistingTable(this.table);
-      return Promise.resolve(false);
-    }
-
+    if (!this.table) return Promise.resolve(false);
+    
     /*** No table exists, return */
     const [tableExists] = await this.table.exists();
     if (!tableExists) return Promise.resolve(false);

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/partitioning.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/partitioning.ts
@@ -130,7 +130,7 @@ export class Partitioning {
   private async isTablePartitioned() {
     // No table provided, cannot evaluate
     if (!this.table) return Promise.resolve(false);
-    
+
     /*** No table exists, return */
     const [tableExists] = await this.table.exists();
     if (!tableExists) return Promise.resolve(false);

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/logs.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/logs.ts
@@ -235,12 +235,6 @@ export const removedClustering = (tableName: string) => {
   logger.info(`Clustering removed on ${tableName}`);
 };
 
-export const cannotPartitionExistingTable = (table: Table) => {
-  logger.warn(
-    `Cannot partition an existing table ${table.dataset.id}_${table.id}`
-  );
-};
-
 export function invalidProjectIdWarning(bqProjectId: string) {
   logger.warn(`Invalid project Id ${bqProjectId}, data cannot be synchronized`);
 }


### PR DESCRIPTION
This commit removes a misplaced guard found in the isTablePartitioned method of the Partitioning class. The removed conditional was erroneously checking the truthfulness of a result of a method which returns a promise, thereby always evaluating to being true. Additionally, the removed logging operation is unrelated to the purpose of the method. This errant code likely ended up here as a result of a failed merge. This addresses an issue where firestore-bigquery-export needlessly fills the logs with errors about not being able to partition an existing table even when partitioning is disabled.

The log message called upon by the removed guard is also removed as it is no longer used. It may want to be reintroduced as part of the partitioning table creation phase in a future update, but that is outside of the scope of this update.

Additional discussion found in #1368