### PR TITLE
fix(firestore-bigquery-export): Added support for callable transform functions 

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -129,7 +129,8 @@ export class FirestoreBigQueryEventHistoryTracker
         headers: { "Content-Type": "application/json" },
       });
       const responseJson = await response.json();
-      return responseJson.data;
+      // To support callable functions, first check result.data
+      return responseJson?.result?.data ?? responseJson.data;
     }
     return rows;
   }


### PR DESCRIPTION
Callable functions return the http response in the response.result field. To support setting the transform function to callable functions we can return the response.result.data field if it is defined, otherwise result the response.data field for http functions. Supporting callable transform functions can be useful for users that want to configure transform functions defined in other extensions, for example the Pangea Redact Text extension.