### PR TITLE
chore(firestore-translate-text): rename extension

### DIFF
--- a/docs/firestore-translate-text/get-started.md
+++ b/docs/firestore-translate-text/get-started.md
@@ -1,8 +1,8 @@
 # Get started
 
-## **Using the Translate Text extension**
+## **Using the Translate Text in Firestore extension**
 
-The Translate Text extension (`firestore-translate-text`) lets you translate strings written to a Cloud Firestore collection into multiple languages using the [Cloud Translation API](https://cloud.google.com/translate). Adding a document to the collection triggers this extension to translate the contents of a field within a document to one or more languages. The extension supports either translating a single string or multiple strings at once.
+The Translate Text in Firestore extension (`firestore-translate-text`) lets you translate strings written to a Cloud Firestore collection into multiple languages using the [Cloud Translation API](https://cloud.google.com/translate). Adding a document to the collection triggers this extension to translate the contents of a field within a document to one or more languages. The extension supports either translating a single string or multiple strings at once.
 
 Here’s a basic example document write that would trigger this extension:
 

--- a/firestore-translate-text/README.md
+++ b/firestore-translate-text/README.md
@@ -1,4 +1,4 @@
-# Translate Text
+# Translate Text in Firestore
 
 **Author**: Firebase (**[https://firebase.google.com](https://firebase.google.com)**)
 

--- a/firestore-translate-text/extension.yaml
+++ b/firestore-translate-text/extension.yaml
@@ -16,7 +16,7 @@ name: firestore-translate-text
 version: 0.1.10
 specVersion: v1beta
 
-displayName: Translate Text
+displayName: Translate Text in Firestore
 description:
   Translates strings written to a Cloud Firestore collection into multiple languages (uses Cloud Translation API).
 

--- a/firestore-translate-text/functions/package.json
+++ b/firestore-translate-text/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firestore-translate-text-functions",
-  "description": "Firebase Cloud Functions for the Firestore Translate Text Extension",
+  "description": "Firebase Cloud Functions for the Firestore Translate Text in Firestore Extension",
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
This PR renames the extension to "Translate Text in Firestore"