### PR TITLE
chore(auth-mailchimp-sync): rename extension

### DIFF
--- a/auth-mailchimp-sync/README.md
+++ b/auth-mailchimp-sync/README.md
@@ -1,4 +1,4 @@
-# Sync with Mailchimp
+# Sync Auth with MailChimp
 
 **Author**: Firebase (**[https://firebase.google.com](https://firebase.google.com)**)
 

--- a/auth-mailchimp-sync/extension.yaml
+++ b/auth-mailchimp-sync/extension.yaml
@@ -16,7 +16,7 @@ name: auth-mailchimp-sync
 version: 0.2.2
 specVersion: v1beta
 
-displayName: Sync with Mailchimp
+displayName: Sync Auth with MailChimp
 description:
   Adds new users from Firebase Authentication to a specified Mailchimp audience.
 


### PR DESCRIPTION
This PR renames the extension to "Sync Auth with MailChimp"