### PR TITLE
chore(firestore-counter): rename extension

### DIFF
--- a/firestore-counter/README.md
+++ b/firestore-counter/README.md
@@ -1,4 +1,4 @@
-# Distributed Counter
+# Distributed Firestore Counter
 
 **Author**: Firebase (**[https://firebase.google.com](https://firebase.google.com)**)
 

--- a/firestore-counter/clients/dart/pubspec.yaml
+++ b/firestore-counter/clients/dart/pubspec.yaml
@@ -1,5 +1,5 @@
 name: firestore_counter
-description: A Dart client for using Firestore Distributed Counter.
+description: A Dart client for using Firestore Distributed Firestore Counter.
 version: 0.0.1
 
 publish_to: none

--- a/firestore-counter/extension.yaml
+++ b/firestore-counter/extension.yaml
@@ -16,7 +16,7 @@ name: firestore-counter
 version: 0.2.6
 specVersion: v1beta
 
-displayName: Distributed Counter
+displayName: Distributed Firestore Counter
 description: Records event counters at scale to accommodate high-velocity writes to Cloud Firestore.
 
 license: Apache-2.0


### PR DESCRIPTION
This PR renames the extension to "Distributed Firestore Counter"