### PR TITLE
change `missingDeliveryField` logging from `error` to `warn`

### DIFF
--- a/firestore-send-email/functions/src/logs.ts
+++ b/firestore-send-email/functions/src/logs.ts
@@ -68,7 +68,7 @@ export function deliveryError(
 }
 
 export function missingDeliveryField(ref: admin.firestore.DocumentReference) {
-  logger.error(`message=${ref.path} is missing 'delivery' field`);
+  logger.warn(`message=${ref.path} is missing 'delivery' field`);
 }
 
 export function missingUids(uids: string[]) {


### PR DESCRIPTION
Given the calling code handles this and creates the `delivery` field before attempting to send make it feel like `warn` is more suitable.

Currently, at `error` level this is tripping our error reporting we use for cloud functions, where we have configured against `error` logs.

fixes #1516