### PR TITLE
fix(firestore-bigquery-export) use modules instead of namespaces

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/jest.config.js
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/jest.config.js
@@ -14,4 +14,8 @@ module.exports = {
   testEnvironment: "node",
   testTimeout: 180000,
   collectCoverage: true,
+  moduleNameMapper: {
+    "firebase-admin/firestore":
+      "<rootDir>/node_modules/firebase-admin/lib/firestore",
+  },
 };

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -15,7 +15,7 @@
  */
 
 import * as bigquery from "@google-cloud/bigquery";
-import * as firebase from "firebase-admin";
+import { DocumentReference } from "firebase-admin/firestore";
 import * as traverse from "traverse";
 import fetch from "node-fetch";
 import {
@@ -148,10 +148,7 @@ export class FirestoreBigQueryEventHistoryTracker
           this.remove();
         }
 
-        if (
-          property.constructor.name ===
-          firebase.firestore.DocumentReference.name
-        ) {
+        if (property.constructor.name === DocumentReference.name) {
           this.update(property.path);
         }
       }

--- a/firestore-bigquery-export/functions/jest.config.js
+++ b/firestore-bigquery-export/functions/jest.config.js
@@ -16,6 +16,8 @@ module.exports = {
   moduleNameMapper: {
     "firebase-admin/eventarc":
       "<rootDir>/node_modules/firebase-admin/lib/eventarc",
+    "firebase-admin/firestore":
+      "<rootDir>/node_modules/firebase-admin/lib/firestore",
     "firebase-functions/v2": "<rootDir>/node_modules/firebase-functions/lib/v2",
   },
 };

--- a/firestore-bigquery-export/scripts/gen-schema-view/jest.config.js
+++ b/firestore-bigquery-export/scripts/gen-schema-view/jest.config.js
@@ -14,4 +14,8 @@ module.exports = {
     "<rootDir>/src/__tests__/bigquery/*.test.ts",
     "<rootDir>/src/__tests__/schema-loader-utils/*.test.ts",
   ],
+  moduleNameMapper: {
+    "firebase-admin/firestore":
+      "<rootDir>/node_modules/firebase-admin/lib/firestore",
+  },
 };


### PR DESCRIPTION
This is a PR to correct the error in the following issue.
https://github.com/firebase/extensions/issues/1533

After checking where the error is occurring, it appears that there is a problem with the require syntax that is importing the module.
I think that the correct code should be as follows (typescripts build to javascripts).

correct:

```js
const firestore = require("firebase-admin/firestore");
```
In other words, I think the problem is using the global admin namespace, as in the following code.
https://github.com/firebase/extensions/blob/firestore-bigquery-export-v0.1.31/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts#L18

This should be redefined as follows (I am aware that it says so in [Use modules instead of namespaces](https://firebase.google.com/docs/admin/migrate-node-v10#typescript)).

```ts
import { DocumentReference } from 'firebase-admin/firestore';
...
    serializeData(eventData) {
        ...
                if (property.constructor.name === DocumentReference.name) {
                    this.update(property.path);
                }
            }
        });
        return data;
    }
```