### PR TITLE
feat(firestore-send-email): Added EventArc handler to send messages

### DIFF
--- a/firestore-send-email/POSTINSTALL.md
+++ b/firestore-send-email/POSTINSTALL.md
@@ -36,6 +36,21 @@ admin
   .then(() => console.log("Queued email for delivery!"));
 ```
 
+Or, send the payload to be written to the `${param:MAIL_COLLECTION}` collection via an EventArc event. Other extensions with permissions to send the `firebase.extensions.firestore-send-email.v1.onSend` event type will also be able to trigger email send operations.
+
+```js
+getEventarc().channel().publish({
+  type: "firebase.extensions.firestore-send-email.v1.onSend",
+  data: {
+    to: "someone@example.com",
+    message: {
+      subject: "Hello from Firebase!",
+      text: "This is the plaintext section of the email body.",
+      html: "This is the <code>HTML</code> section of the email body.",
+    },
+});
+```
+
 ### Using this extension
 
 See the [official documentation](https://firebase.google.com/docs/extensions/official/firestore-send-email) for information on using this extension, including advanced use cases such as using Handlebars templates and managing email delivery status.

--- a/firestore-send-email/PREINSTALL.md
+++ b/firestore-send-email/PREINSTALL.md
@@ -14,6 +14,20 @@ admin.firestore().collection('mail').add({
 })
 ```
 
+Alternatively, the same payload can be sent to this extension via an EventArc event. The `data` field will be written to the specified Firestore collection and trigger the send operation.
+
+```js
+getEventarc().channel().publish({
+  type: "firebase.extensions.firestore-send-email.v1.onSend",
+  data: {
+    to: 'someone@example.com',
+    message: {
+      subject: 'Hello from Firebase!',
+      html: 'This is an <code>HTML</code> email body.',
+    },
+});
+```
+
 You can also optionally configure this extension to render emails using [Handlebar](https://handlebarsjs.com/) templates. Each template is a document stored in a Cloud Firestore collection.
 
 When you configure this extension, you'll need to supply your **SMTP credentials for mail delivery**. Note that this extension is for use with bulk email service providers, like SendGrid, Mailgun, etc.

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -38,6 +38,12 @@ contributors:
 
 billingRequired: true
 
+apis:
+  - apiName: eventarc.googleapis.com
+    reason: Powers all events and triggers
+  - apiName: run.googleapis.com
+    reason: Powers v2 functions
+
 roles:
   - role: datastore.user
     reason: Allows this extension to access Cloud Firestore to read and process added email documents.
@@ -54,6 +60,20 @@ resources:
       eventTrigger:
         eventType: providers/cloud.firestore/eventTypes/document.write
         resource: projects/${param:PROJECT_ID}/databases/(default)/documents/${param:MAIL_COLLECTION}/{id}
+  - name: onsend
+    type: firebaseextensions.v1beta.v2function
+    description:
+      Listens for events emitted from your application or other extensions, that you granted permission to emit this event, and sends the provided message.
+    properties:
+      location: ${param:LOCATION}
+      buildConfig:
+        runtime: nodejs14
+      serviceConfig:
+        availableMemory: 512M
+        timeoutSeconds: 60
+      eventTrigger:
+        eventType: firebase.extensions.firestore-send-email.v1.onSend
+        channel: projects/${param:PROJECT_ID}/locations/${param:LOCATION}/channels/firebase
 
 params:
   - param: LOCATION

--- a/firestore-send-email/functions/src/index.ts
+++ b/firestore-send-email/functions/src/index.ts
@@ -25,6 +25,7 @@ import Templates from "./templates";
 import { QueuePayload } from "./types";
 import { setSmtpCredentials } from "./helpers";
 import * as events from "./events";
+import { eventarc } from "firebase-functions/v2";
 
 logs.init();
 
@@ -482,5 +483,21 @@ export const processQueue = functions.firestore
       await events.recordCompleteEvent(change);
 
       logs.complete();
+    }
+  );
+
+  export const onsend = eventarc.onCustomEventPublished(
+    "firebase.extensions.firestore-send-email.v1.onSend",
+    async (event) => {
+      try {
+        await initialize();
+
+        return admin.firestore()
+          .collection(config.mailCollection)
+          .add(event.data)
+
+      } catch(err) {
+        return Promise.reject(err);
+      }
     }
   );


### PR DESCRIPTION

1. Added an event handler for the new Custom Events feature of Firebase extensions to allow the user, or third-party Extensions authorized by the user, to send emails without the need to know the Firestore collection name being monitored by the extension. This would be helpful for other Extensions to send email notifications, for example, the Pangea 'Known Malware Detection' ext can notify the app owner when a user uploads a malicious file to Cloud Storage.    

To Send an email:

import {getEventarc} from "firebase-admin/eventarc";

getEventarc().channel().publish({
  type: "firebase.extensions.firestore-send-email.v1.onSend",
  data: {
    to: "someone@example.com",
    message: {
      subject: "Hello from Firebase!",
      text: "This is the plaintext section of the email body.",
      html: "This is the <code>HTML</code> section of the email body.",
    },
});
