### PR TITLE
chore(*): updated CI, cli locked at v11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,6 @@ jobs:
           timeout_minutes: 10
           retry_wait_seconds: 60
           max_attempts: 3
-          command: npm i -g firebase-tools
+          command: npm i -g firebase-tools@11
       - name: npm test
         run: npm run test:ci


### PR DESCRIPTION
The latest version of the Firebase tools CLI requires a minimum version of `Node v16`.

As most modules in this repository are `Node v14`, this fails some CI checks. 

To fix this we will can lock the CLI to `V11`. 

This can be updated when all modules, have been migrated to node v16.