### PR TITLE
Specify location for taskQueues so that they dont default to us-central1

### DIFF
--- a/firestore-translate-text/functions/src/index.ts
+++ b/firestore-translate-text/functions/src/index.ts
@@ -118,7 +118,7 @@ export const fstranslatebackfill = functions.tasks
       // Stil have more documents to translate, enqueue another task.
       logs.enqueueNext(offset + DOCS_PER_BACKFILL);
       const queue = getFunctions().taskQueue(
-        "fstranslatebackfill",
+        `locations/${config.location}/functions/fstranslatebackfill`,
         process.env.EXT_INSTANCE_ID
       );
       await queue.enqueue({

--- a/samples/rtdb-uppercase-messages/functions/index.js
+++ b/samples/rtdb-uppercase-messages/functions/index.js
@@ -73,7 +73,7 @@ export const backfilldata = tasks.taskQueue().onDispatch(async () => {
 
   if (promises.length > 0) {
     const queue = getFunctions().taskQueue(
-      "backfilldata",
+      `locations/${process.env.LOCATION}/functions/backfilldata`,
       process.env.EXT_INSTANCE_ID
     );
     return queue.enqueue({});


### PR DESCRIPTION
It turns out that if you do not specify the location when getting a taskQueue, it defaults to us-central1 (https://github.com/firebase/firebase-admin-node/blob/master/src/functions/functions.ts#L50). This fixes an issue where these backfills would not work in other regions.