### PR TITLE
fix(firestore-bigquery-export): improve help for --use-emulator

### DIFF
--- a/firestore-bigquery-export/scripts/import/src/index.ts
+++ b/firestore-bigquery-export/scripts/import/src/index.ts
@@ -90,7 +90,7 @@ program
   )
   .option(
     "-e, --use-emulator [true|false]",
-    "Whether to use updated latest snapshot query"
+    "Whether to use the firestore emulator"
   );
 
 const run = async (): Promise<number> => {


### PR DESCRIPTION
reopening https://github.com/firebase/extensions/pull/1542 because failing CI.