### PR TITLE
fix(firestore-bigquery-export): add missing locations back in

### DIFF
--- a/firestore-bigquery-export/scripts/import/src/config.ts
+++ b/firestore-bigquery-export/scripts/import/src/config.ts
@@ -24,6 +24,8 @@ const validateLocation = (value: string) => {
     "us-west3",
     "southamerica-east1",
     "us-east1",
+    "europe-central2",
+    "europe-north1",
     "europe-west1",
     "europe-north1",
     "europe-west3",


### PR DESCRIPTION
For some reason these were removed in this refactor https://github.com/firebase/extensions/commit/0a246b1a8b8841120be308eae9806caa323ebdd8

this PR adds them back in. The package will probably need publishing

fixes https://github.com/firebase/extensions/issues/1692
