### PR TITLE
fix(storage-resize-images): default sharpOptions

### DIFF
--- a/storage-resize-images/functions/__tests__/__snapshots__/config.test.ts.snap
+++ b/storage-resize-images/functions/__tests__/__snapshots__/config.test.ts.snap
@@ -18,6 +18,6 @@ Object {
   "makePublic": false,
   "outputOptions": undefined,
   "resizedImagesPath": undefined,
-  "sharpOptions": undefined,
+  "sharpOptions": "{}",
 }
 `;

--- a/storage-resize-images/functions/src/config.ts
+++ b/storage-resize-images/functions/src/config.ts
@@ -56,7 +56,7 @@ export default {
   failedImagesPath: process.env.FAILED_IMAGES_PATH,
   deleteOriginalFile: deleteOriginalFile(process.env.DELETE_ORIGINAL_FILE),
   imageTypes: paramToArray(process.env.IMAGE_TYPE),
-  sharpOptions: process.env.SHARP_OPTIONS,
+  sharpOptions: process.env.SHARP_OPTIONS || "{}",
   outputOptions: process.env.OUTPUT_OPTIONS,
   animated: allowAnimated(
     process.env.SHARP_OPTIONS,


### PR DESCRIPTION
This will suppress a warning which will happen if no default is provided in sharpOptions