### PR TITLE
fix(firestore-send-email): update the regex to prevent unvalid URLs

### DIFF
--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -69,7 +69,7 @@ params:
        `smtps://username@gmail.com:password@smtp.gmail.com:465`. (username and password)
     type: string
     example: smtps://username@smtp.hostname.com:465
-    validationRegex: ^(smtps:\/\/[^:@]+(:[^:@]*)?@[^:@]+:[0-9]+)$
+    validationRegex: ^(smtp[s]*://.*?(:[^:@]*)?@[^:@]+:[0-9]+(\\?[^ ]*)?)$
     validationErrorMessage: Invalid SMTP connection URI. Must be in the form `smtp(s)://username:password@hostname:port` or `smtp(s)://username@hostname:port`.
     required: true
 

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -69,7 +69,7 @@ params:
        `smtps://username@gmail.com:password@smtp.gmail.com:465`. (username and password)
     type: string
     example: smtps://username@smtp.hostname.com:465
-    validationRegex: ^(smtp[s]*://.*?(:[^:@]*)?@[^:@]+:[0-9]+(\\?[^ ]*)?)$
+    validationRegex: ^(smtp[s]*://(.*?(:[^:@]*)?@)?[^:@]+:[0-9]+(\\?[^ ]*)?)$
     validationErrorMessage: Invalid SMTP connection URI. Must be in the form `smtp(s)://username:password@hostname:port` or `smtp(s)://username@hostname:port`.
     required: true
 

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -69,7 +69,7 @@ params:
        `smtps://username@gmail.com:password@smtp.gmail.com:465`. (username and password)
     type: string
     example: smtps://username@smtp.hostname.com:465
-    validationRegex: ^(smtp[s]*://.*?:[0-9]+.*$)
+    validationRegex: ^(smtps:\/\/[^:@]+(:[^:@]*)?@[^:@]+:[0-9]+)$
     validationErrorMessage: Invalid SMTP connection URI. Must be in the form `smtp(s)://username:password@hostname:port` or `smtp(s)://username@hostname:port`.
     required: true
 

--- a/firestore-send-email/functions/__tests__/helpers.test.ts
+++ b/firestore-send-email/functions/__tests__/helpers.test.ts
@@ -7,11 +7,11 @@ const consoleLogSpy = jest.spyOn(logger, "warn").mockImplementation();
 
 // This is a regex to validate the smtpConnectionUri in extension.yaml
 const regex = new RegExp(
-  "^(smtp[s]*://.*?(:[^:@]*)?@[^:@]+:[0-9]+(\\?[^ ]*)?)$"
+  "^(smtp[s]*://(.*?(:[^:@]*)?@)?[^:@]+:[0-9]+(\\?[^ ]*)?)$"
 );
 
 describe("set server credentials helper function", () => {
-  test(" return smtpServerDomain credentials with new password", () => {
+  test("return smtpServerDomain credentials with new password", () => {
     const config: Config = {
       smtpConnectionUri:
         "smtps://fakeemail@gmail.com:secret-password@smtp.gmail.com:465",
@@ -26,6 +26,9 @@ describe("set server credentials helper function", () => {
     expect(credentials.options.host).toBe("smtp.gmail.com");
     expect(credentials.options.auth.pass).toBe(config.smtpPassword);
     expect(credentials.options.secure).toBe(true);
+
+    // The regex should match the smtpConnectionUri, it should be valid
+    expect(regex.test(config.smtpConnectionUri)).toBe(true);
   });
 
   test("return smtpServerDomain credentials with new password (old deleted)", () => {
@@ -42,6 +45,9 @@ describe("set server credentials helper function", () => {
     expect(credentials.options.host).toBe("smtp.gmail.com");
     expect(credentials.options.auth.pass).toBe(config.smtpPassword);
     expect(credentials.options.secure).toBe(true);
+
+    // The regex should match the smtpConnectionUri, it should be valid
+    expect(regex.test(config.smtpConnectionUri)).toBe(true);
   });
 
   test("return smtpConnectionUri credentials with old password", () => {
@@ -59,6 +65,9 @@ describe("set server credentials helper function", () => {
     expect(credentials.options.auth.user).toBe("fakeemail@gmail.com");
     expect(credentials.options.auth.pass).toBe("secret-password");
     expect(credentials.options.secure).toBe(true);
+
+    // The regex should match the smtpConnectionUri, it should be valid
+    expect(regex.test(config.smtpConnectionUri)).toBe(true);
   });
 
   test("return smtpConnectionUri credentials without any password", () => {
@@ -75,6 +84,9 @@ describe("set server credentials helper function", () => {
     expect(credentials.options.auth.user).toBe("fakeemail@gmail.com");
     expect(credentials.options.auth.pass).toBe("");
     expect(credentials.options.secure).toBe(true);
+
+    // The regex should match the smtpConnectionUri, it should be valid
+    expect(regex.test(config.smtpConnectionUri)).toBe(true);
   });
 
   test("return smtpConnectionUri credentials without any password and username", () => {
@@ -90,6 +102,9 @@ describe("set server credentials helper function", () => {
     expect(credentials.options.host).toBe("smtp.gmail.com");
     expect(credentials.options.auth).toBe(undefined);
     expect(credentials.options.secure).toBe(false);
+
+    // The regex should match the smtpConnectionUri, it should be valid
+    expect(regex.test(config.smtpConnectionUri)).toBe(true);
   });
 
   test("return smtpConnectionUri credentials with query params", () => {
@@ -109,6 +124,9 @@ describe("set server credentials helper function", () => {
     expect(credentials.options.secure).toBe(false);
     expect(credentials.options.pool).toBe(true);
     expect(credentials.options.service).toBe("gmail");
+
+    // The regex should match the smtpConnectionUri, it should be valid
+    expect(regex.test(config.smtpConnectionUri)).toBe(true);
   });
 
   test("return valid smtpConnectionUri credentials with special chars in password config", () => {
@@ -129,6 +147,9 @@ describe("set server credentials helper function", () => {
     expect(credentials.options.secure).toBe(false);
     expect(credentials.options.pool).toBe(true);
     expect(credentials.options.service).toBe("gmail");
+
+    // The regex should match the smtpConnectionUri, it should be valid
+    expect(regex.test(config.smtpConnectionUri)).toBe(true);
   });
 
   test("return valid smtpConnectionUri credentials with valid special chars in connectionUri password", () => {
@@ -149,6 +170,9 @@ describe("set server credentials helper function", () => {
     expect(credentials.options.secure).toBe(false);
     expect(credentials.options.pool).toBe(true);
     expect(credentials.options.service).toBe("gmail");
+
+    // The regex should match the smtpConnectionUri, it should be valid
+    expect(regex.test(config.smtpConnectionUri)).toBe(true);
   });
 
   test("return invalid smtpConnectionUri credentials with invalid special chars in connectionUri password", () => {

--- a/firestore-send-email/functions/__tests__/helpers.test.ts
+++ b/firestore-send-email/functions/__tests__/helpers.test.ts
@@ -161,4 +161,49 @@ describe("set server credentials helper function", () => {
       `invalid url: '${config.smtpConnectionUri}' , please reconfigure with a valid SMTP connection URI`
     );
   });
+  test("return valid smtpConnectionUri credentials with correct seprator", () => {
+    const config: Config = {
+      smtpConnectionUri:
+        "smtp://fakeemail@gmail.com:4,h?dhuNTbv9zMrP4&7&7%*3@smtp.gmail.com:465?pool=true&service=gmail",
+      location: "",
+      mailCollection: "",
+      defaultFrom: "",
+    };
+
+    const regex = new RegExp(
+      "^(smtp[s]*://.*?(:[^:@]*)?@[^:@]+:[0-9]+(\\?[^ ]*)?)$"
+    );
+
+    expect(regex.test(config.smtpConnectionUri)).toBe(true);
+
+    // const credentials = setSmtpCredentials(config);
+
+    // expect(credentials).toBeNull();
+    // expect(consoleLogSpy).toBeCalledWith(
+    //   `invalid url: '${config.smtpConnectionUri}' , please reconfigure with a valid SMTP connection URI`
+    // );
+  });
+
+  test("return invalid smtpConnectionUri credentials with invalid seprator", () => {
+    const config: Config = {
+      smtpConnectionUri:
+        "smtp://fakeemail@gmail.com:4,h?dhuNTbv9zMrP4&7&7%*3:smtp.gmail.com:465?pool=true&service=gmail",
+      location: "",
+      mailCollection: "",
+      defaultFrom: "",
+    };
+
+    const regex = new RegExp(
+      "^(smtp[s]*://.*?(:[^:@]*)?@[^:@]+:[0-9]+(\\?[^ ]*)?)$"
+    );
+
+    expect(regex.test(config.smtpConnectionUri)).toBe(false);
+
+    // const credentials = setSmtpCredentials(config);
+
+    // expect(credentials).toBeNull();
+    // expect(consoleLogSpy).toBeCalledWith(
+    //   `invalid url: '${config.smtpConnectionUri}' , please reconfigure with a valid SMTP connection URI`
+    // );
+  });
 });

--- a/firestore-send-email/functions/__tests__/helpers.test.ts
+++ b/firestore-send-email/functions/__tests__/helpers.test.ts
@@ -175,13 +175,6 @@ describe("set server credentials helper function", () => {
     );
 
     expect(regex.test(config.smtpConnectionUri)).toBe(true);
-
-    // const credentials = setSmtpCredentials(config);
-
-    // expect(credentials).toBeNull();
-    // expect(consoleLogSpy).toBeCalledWith(
-    //   `invalid url: '${config.smtpConnectionUri}' , please reconfigure with a valid SMTP connection URI`
-    // );
   });
 
   test("return invalid smtpConnectionUri credentials with invalid seprator", () => {
@@ -198,12 +191,5 @@ describe("set server credentials helper function", () => {
     );
 
     expect(regex.test(config.smtpConnectionUri)).toBe(false);
-
-    // const credentials = setSmtpCredentials(config);
-
-    // expect(credentials).toBeNull();
-    // expect(consoleLogSpy).toBeCalledWith(
-    //   `invalid url: '${config.smtpConnectionUri}' , please reconfigure with a valid SMTP connection URI`
-    // );
   });
 });

--- a/firestore-send-email/functions/__tests__/helpers.test.ts
+++ b/firestore-send-email/functions/__tests__/helpers.test.ts
@@ -5,6 +5,11 @@ import { Config } from "../src/types";
 const { logger } = require("firebase-functions");
 const consoleLogSpy = jest.spyOn(logger, "warn").mockImplementation();
 
+// This is a regex to validate the smtpConnectionUri in extension.yaml
+const regex = new RegExp(
+  "^(smtp[s]*://.*?(:[^:@]*)?@[^:@]+:[0-9]+(\\?[^ ]*)?)$"
+);
+
 describe("set server credentials helper function", () => {
   test(" return smtpServerDomain credentials with new password", () => {
     const config: Config = {
@@ -170,10 +175,6 @@ describe("set server credentials helper function", () => {
       defaultFrom: "",
     };
 
-    const regex = new RegExp(
-      "^(smtp[s]*://.*?(:[^:@]*)?@[^:@]+:[0-9]+(\\?[^ ]*)?)$"
-    );
-
     expect(regex.test(config.smtpConnectionUri)).toBe(true);
   });
 
@@ -185,10 +186,6 @@ describe("set server credentials helper function", () => {
       mailCollection: "",
       defaultFrom: "",
     };
-
-    const regex = new RegExp(
-      "^(smtp[s]*://.*?(:[^:@]*)?@[^:@]+:[0-9]+(\\?[^ ]*)?)$"
-    );
 
     expect(regex.test(config.smtpConnectionUri)).toBe(false);
   });


### PR DESCRIPTION
Potentially fixes #1472 by updating the validation regex for `SMTP_CONNECTION_URI`.

The new regex rule will check if a colon `:` is used instead of `@` before the SMTP server name.

These will be invalid:
```
smtps://username:smtp.hostname.com:465
smtps://username:password:smtp.hostname.com:465
```

This is valid:
```
smtps://username@smtp.hostname.com:465
smtps://username:password@smtp.hostname.com:465
```