### PR TITLE
fix(firestore-bigquery-export): rollback timestamp serialization

### DIFF
--- a/firestore-bigquery-export/CHANGELOG.md
+++ b/firestore-bigquery-export/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.39
+
+fix - rollback timestamp serialization
+
 ## Version 0.1.38
 
 fix - backfill value mismatch

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-bigquery-export
-version: 0.1.38
+version: 0.1.39
 specVersion: v1beta
 
 displayName: Stream Firestore to BigQuery

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/package-lock.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@firebaseextensions/firestore-bigquery-change-tracker",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@firebaseextensions/firestore-bigquery-change-tracker",
-      "version": "1.1.28",
+      "version": "1.1.29",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/bigquery": "^4.7.0",

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
@@ -5,7 +5,7 @@
     "url": "github.com/firebase/extensions.git",
     "directory": "firestore-bigquery-export/firestore-bigquery-change-tracker"
   },
-  "version": "1.1.28",
+  "version": "1.1.29",
   "description": "Core change-tracker library for Cloud Firestore Collection BigQuery Exports",
   "main": "./lib/index.js",
   "scripts": {

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -155,9 +155,6 @@ export class FirestoreBigQueryEventHistoryTracker
         if (property.constructor.name === DocumentReference.name) {
           this.update(property.path);
         }
-        if (property instanceof admin.firestore.Timestamp) {
-          this.update(property.toDate());
-        }
       }
     });
 

--- a/firestore-bigquery-export/functions/package.json
+++ b/firestore-bigquery-export/functions/package.json
@@ -13,7 +13,7 @@
   "author": "Jan Wyszynski <wyszynski@google.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.28",
+    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.29",
     "@google-cloud/bigquery": "^4.7.0",
     "@types/chai": "^4.1.6",
     "@types/express-serve-static-core": "4.17.30",

--- a/firestore-bigquery-export/scripts/import/package.json
+++ b/firestore-bigquery-export/scripts/import/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebaseextensions/fs-bq-import-collection",
-  "version": "0.1.18",
+  "version": "0.1.20",
   "description": "Import a Firestore Collection into a BigQuery Changelog Table",
   "main": "./lib/index.js",
   "repository": {
@@ -26,7 +26,7 @@
   "author": "Jan Wyszynski <wyszynski@google.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.17",
+    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.29",
     "@google-cloud/bigquery": "^5.6.0",
     "commander": "5.0.0",
     "filenamify": "^4.2.0",


### PR DESCRIPTION
In version 0.1.37 of the extension, and the latest version of the import CLI script, a breaking change was introducedwhere timestamps were serialized to dates.

This should fix https://github.com/firebase/extensions/issues/1828 and https://github.com/firebase/extensions/issues/1813

This PR will need the changetracker releasing before CI will pass.