### PR TITLE
fix(firestore-bigquery-export): partition correctly if only timestamp is provided

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/partitioning.test.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/partitioning.test.ts
@@ -488,7 +488,7 @@ describe("updateTableMetadata", () => {
       datasetLocation: "",
       timePartitioning: "MONTH",
       timePartitioningField: "timestamp",
-      timePartitioningFieldType: undefined,
+      timePartitioningFieldType: "omit",
       timePartitioningFirestoreField: undefined,
       transformFunction: "",
       clustering: [],

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/partitioning.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/partitioning.ts
@@ -95,7 +95,7 @@ export class Partitioning {
     /* check if all valid combinations have been provided*/
     const hasOnlyTimestamp =
       timePartitioningField === "timestamp" &&
-      !timePartitioningFieldType &&
+      timePartitioningFieldType === "omit" &&
       !timePartitioningFirestoreField;
     return (
       hasOnlyTimestamp ||


### PR DESCRIPTION
fixes https://github.com/firebase/extensions/issues/1877