### PR TITLE
fix(firestore-bigquery-export): make MAX_DISPATCHES_PER_SECOND take effect

### DIFF
--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -304,8 +304,8 @@ params:
       This parameter will set the maximum number of syncronised documents per second with BQ. Please note, any other external updates to a Big Query table will be included within this quota.
       Ensure that you have a set a low enough number to componsate. Defaults to 10.
     type: string
-    validationRegex: ^(?:[1-9]|\d{2,3}|[1-4]\d{3})$
-    validationErrorMessage: Please select a number between 1 and 100
+    validationRegex: ^([1-9]|[1-9][0-9]|[1-4][0-9]{2}|500)$
+    validationErrorMessage: Please select a number between 1 and 500
     example: 10
     required: false
 

--- a/firestore-bigquery-export/functions/src/index.ts
+++ b/firestore-bigquery-export/functions/src/index.ts
@@ -66,7 +66,7 @@ export const syncBigQuery = functions.tasks
     },
     rateLimits: {
       maxConcurrentDispatches: 1000,
-      maxDispatchesPerSecond: 500,
+      maxDispatchesPerSecond: config.maxDispatchesPerSecond,
     },
   })
   .onDispatch(


### PR DESCRIPTION
fixes #1884 