### PR TITLE
ci: remove node14 from test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,9 @@ name: Testing
 
 on:
   push:
-    branches:
-      - next
+    branches: [next]
   pull_request:
-    branches:
-      - "**"
+    branches: ["**"]
 
 jobs:
   nodejs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["14", "16", "18"]
+        node: ["16", "18"]
     name: node.js_${{ matrix.node }}_test
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Testing
 on:
   push:
     branches:
-      - "**"
+      - next
   pull_request:
     branches:
       - "**"


### PR DESCRIPTION
Node 14 will be deprecated soon in functions & all extensions' resources are now on node 16 and higher, hence is no need to run tests against it.