### PR TITLE
docs(firestore-bigquery-export): clarify cross-project setup

### DIFF
--- a/docs/firestore-bigquery-export/cross-project-support.md
+++ b/docs/firestore-bigquery-export/cross-project-support.md
@@ -1,7 +1,15 @@
 # Cross-Project Support
 
-If you specified an `alternative` project parameter during configuration of the extension, BigQuery will sync data to tables and views in the defined project.
+If you specified an `BIGQUERY_PROJECT_ID` parameter during configuration of the extension, BigQuery will sync data to tables and views in the defined GCP project.
 
 ## Example Scenario
 
 A typical scenario for this would be to install multiple instances of the extension to share the data across multiple (separate) instances without having to support multiple Firestore instances.
+
+## Additional Setup
+
+When defining a specific BigQuery project ID, a manual step to set up permissions is required:
+
+1. Navigate to https://console.cloud.google.com/iam-admin/iam?project=${param:BIGQUERY_PROJECT_ID}
+2. Add the **BigQuery Data Editor** role to the following service account:
+   `ext-${param:EXT_INSTANCE_ID}@${param:PROJECT_ID}.iam.gserviceaccount.com`.

--- a/firestore-bigquery-export/POSTINSTALL.md
+++ b/firestore-bigquery-export/POSTINSTALL.md
@@ -54,9 +54,9 @@ Enabling wildcard references will provide an additional STRING based column. The
 
 `Clustering` will not need to create or modify a table when adding clustering options, this will be updated automatically.
 
-### Configuring Alternative BigQuery Project
+### Configuring Cross-Platform BigQuery Setup
 
-When defining a specific BigQuery project, a manual step to set up permissions is required:
+When defining a specific BigQuery project ID, a manual step to set up permissions is required:
 
 1. Navigate to https://console.cloud.google.com/iam-admin/iam?project=${param:BIGQUERY_PROJECT_ID}
 2. Add the **BigQuery Data Editor** role to the following service account:


### PR DESCRIPTION
Clarify additional IAM setup in docs and rename "alternative" project to cross-project support, specifying a separate GCP project ID for the BigQuery instance.

Should help with issues like #1861.