### PR TITLE
fix(firestore-bigquery-export): parse batchSize correctly

### DIFF
--- a/firestore-bigquery-export/scripts/import/src/config.ts
+++ b/firestore-bigquery-export/scripts/import/src/config.ts
@@ -250,7 +250,7 @@ export async function parseConfig(): Promise<CliConfig | CliConfigError> {
     sourceCollectionPath: sourceCollectionPath,
     datasetId: dataset,
     tableId: table,
-    batchSize: batchSize,
+    batchSize: parseInt(batchSize),
     queryCollectionGroup: queryCollectionGroup,
     datasetLocation: datasetLocation,
     multiThreaded: multiThreaded,


### PR DESCRIPTION
Parse parameter `batchSize` correctly in the interactive `import` script flow.

Fixes #1470 and #911