### PR TITLE
docs(firestore-send-email): clarify FROM address not working with gmail

### DIFF
--- a/docs/firestore-send-email/get-started.md
+++ b/docs/firestore-send-email/get-started.md
@@ -89,7 +89,7 @@ message: {
 
 The top-level fields of the document supply the email sender and recipient information. Available fields are:
 
-- **from:** The sender's email address. If not specified in the document, uses the configured "Default FROM address" parameter.
+- **from:** The sender's email address. If not specified in the document, uses the configured "Default FROM address" parameter. This parameter does not work with [Gmail SMTP](https://nodemailer.com/usage/using-gmail/).
 - **replyTo:** The reply-to email address. If not specified in the document, uses the configured "Default REPLY-TO address" parameter.
 - **to:** A single recipient email address or an array containing multiple recipient email addresses.
 - **toUids:** An array containing the recipient UIDs.

--- a/firestore-send-email/README.md
+++ b/firestore-send-email/README.md
@@ -82,7 +82,7 @@ password)
 
 * Email documents collection: What is the path to the collection that contains the documents used to build and send the emails?
 
-* Default FROM address: The email address to use as the sender's address (if it's not specified in the added email document).  You can optionally include a name with the email address (`Friendly Firebaser <foobar@example.com>`).
+* Default FROM address: The email address to use as the sender's address (if it's not specified in the added email document). You can optionally include a name with the email address (`Friendly Firebaser <foobar@example.com>`). This parameter does not work with [Gmail SMTP](https://nodemailer.com/usage/using-gmail/).
 
 * Default REPLY-TO address: The email address to use as the reply-to address (if it's not specified in the added email document).
 

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -107,8 +107,10 @@ params:
     label: Default FROM address
     description: >-
       The email address to use as the sender's address (if it's not specified in
-      the added email document).  You can optionally include a name with the
-      email address (`Friendly Firebaser <foobar@example.com>`).
+      the added email document). You can optionally include a name with the
+      email address (`Friendly Firebaser <foobar@example.com>`). This parameter
+      does not work with [Gmail
+      SMTP](https://nodemailer.com/usage/using-gmail/).
     type: string
     example: foobar@example.com
     validationRegex: ^(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$|^.*<(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})>$


### PR DESCRIPTION
Resolves #1938 