### PR TITLE
chore(firestore-bigquery-export): prep release (2 of 2)

### DIFF
--- a/firestore-bigquery-export/CHANGELOG.md
+++ b/firestore-bigquery-export/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 0.1.46
+
+feature - allow firestore database selection
+
+docs - remove mention of bigquery updating on import
+
 ## Version 0.1.45
 
 feature - bring back the backfill parameter `DO_BACKFILL`

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-bigquery-export
-version: 0.1.45
+version: 0.1.46
 specVersion: v1beta
 
 displayName: Stream Firestore to BigQuery

--- a/firestore-bigquery-export/functions/package-lock.json
+++ b/firestore-bigquery-export/functions/package-lock.json
@@ -7,7 +7,7 @@
       "name": "firestore-bigquery-export",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.31",
+        "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.32",
         "@google-cloud/bigquery": "^4.7.0",
         "@types/chai": "^4.1.6",
         "@types/express-serve-static-core": "4.17.30",
@@ -490,42 +490,20 @@
       }
     },
     "node_modules/@firebaseextensions/firestore-bigquery-change-tracker": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/@firebaseextensions/firestore-bigquery-change-tracker/-/firestore-bigquery-change-tracker-1.1.31.tgz",
-      "integrity": "sha512-n9tYAVPrDqoG2vsbCuXunXXuXPUHSmnwvNoGoD47ZV01SraK+8U/0E1vAC/tY5KD/e8lMUnRQOsD4MDkETuM3A==",
+      "version": "1.1.32",
+      "resolved": "https://registry.npmjs.org/@firebaseextensions/firestore-bigquery-change-tracker/-/firestore-bigquery-change-tracker-1.1.32.tgz",
+      "integrity": "sha512-LxxgKLrk3qVCcYxscW67mL+zR8wo/iqZwg/09W0B0bUNUfjpweLBfgW8SH1tTeKMAIHzERFyLMezNKF0UMuCJg==",
       "dependencies": {
         "@google-cloud/bigquery": "^4.7.0",
         "@google-cloud/resource-manager": "^3.0.0",
-        "firebase-admin": "^11.4.1",
-        "firebase-functions": "^3.13.2",
+        "firebase-admin": "^11.11.1",
+        "firebase-functions": "^4.6.0",
         "generate-schema": "^2.6.0",
         "inquirer": "^6.4.0",
         "lodash": "^4.17.14",
         "node-fetch": "^2.6.1",
         "sql-formatter": "^2.3.3",
         "traverse": "^0.6.6"
-      }
-    },
-    "node_modules/@firebaseextensions/firestore-bigquery-change-tracker/node_modules/firebase-functions": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.24.1.tgz",
-      "integrity": "sha512-GYhoyOV0864HFMU1h/JNBXYNmDk2MlbvU7VO/5qliHX6u/6vhSjTJjlyCG4leDEI8ew8IvmkIC5QquQ1U8hAuA==",
-      "dependencies": {
-        "@types/cors": "^2.8.5",
-        "@types/express": "4.17.3",
-        "cors": "^2.8.5",
-        "express": "^4.17.1",
-        "lodash": "^4.17.14",
-        "node-fetch": "^2.6.7"
-      },
-      "bin": {
-        "firebase-functions": "lib/bin/firebase-functions.js"
-      },
-      "engines": {
-        "node": "^8.13.0 || >=10.10.0"
-      },
-      "peerDependencies": {
-        "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
     "node_modules/@google-cloud/bigquery": {

--- a/firestore-bigquery-export/functions/package.json
+++ b/firestore-bigquery-export/functions/package.json
@@ -13,7 +13,7 @@
   "author": "Jan Wyszynski <wyszynski@google.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.31",
+    "@firebaseextensions/firestore-bigquery-change-tracker": "^1.1.32",
     "@google-cloud/bigquery": "^4.7.0",
     "@types/chai": "^4.1.6",
     "@types/express-serve-static-core": "4.17.30",


### PR DESCRIPTION
This PR is to bump the firestore-bigquery-export version ready for a release.