### PR TITLE
feat(firestore-bigquery-export): rollback the multi-db feature

### DIFF
--- a/_emulator/extensions/firestore-bigquery-export.env.local
+++ b/_emulator/extensions/firestore-bigquery-export.env.local
@@ -1,5 +1,4 @@
 BIGQUERY_PROJECT_ID=dev-extensions-testing
-DATABASE_ID=(default)
 COLLECTION_PATH=posts
 DATASET_ID=firestore_export
 DATASET_LOCATION=us-central1

--- a/firestore-bigquery-export/CHANGELOG.md
+++ b/firestore-bigquery-export/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## Version 0.1.46
 
-feature - allow firestore database selection
-
 docs - remove mention of bigquery updating on import
 
 ## Version 0.1.45

--- a/firestore-bigquery-export/README.md
+++ b/firestore-bigquery-export/README.md
@@ -124,8 +124,6 @@ To install an extension, your project must be on the [Blaze (pay as you go) plan
 
 * BigQuery Project ID: Override the default project for BigQuery instance. This can allow updates to be directed to to a BigQuery instance on another GCP project.
 
-* Database ID: Override the default project Firestore database. Learn more about managing multiple Firestore databases [here](https://cloud.google.com/firestore/docs/manage-databases).
-
 * Collection path: What is the path of the collection that you would like to export? You may use `{wildcard}` notation to match a subcollection of all documents in a collection (for example: `chatrooms/{chatid}/posts`). Parent Firestore Document IDs from `{wildcards}`  can be returned in `path_params` as a JSON formatted string.
 
 * Enable Wildcard Column field with Parent Firestore Document IDs: If enabled, creates a column containing a JSON object of all wildcard ids from a documents path.

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -58,7 +58,7 @@ resources:
       runtime: nodejs18
       eventTrigger:
         eventType: providers/cloud.firestore/eventTypes/document.write
-        resource: projects/${param:PROJECT_ID}/databases/${param:DATABASE_ID}/documents/${param:COLLECTION_PATH}/{documentId}
+        resource: projects/${param:PROJECT_ID}/databases/(default)/documents/${param:COLLECTION_PATH}/{documentId}
 
   - name: fsimportexistingdocs
     type: firebaseextensions.v1beta.function
@@ -178,16 +178,6 @@ params:
       to be directed to to a BigQuery instance on another GCP project.
     type: string
     default: ${PROJECT_ID}
-    required: true
-
-  - param: DATABASE_ID
-    label: Database ID
-    description: >-
-      Override the default project Firestore database. Learn more about managing
-      multiple Firestore databases
-      [here](https://cloud.google.com/firestore/docs/manage-databases).
-    type: string
-    default: (default)
     required: true
 
   - param: COLLECTION_PATH

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -55,7 +55,6 @@ export interface FirestoreBigQueryEventHistoryTrackerConfig {
   timePartitioningFieldType?: string | undefined;
   timePartitioningFirestoreField?: string | undefined;
   clustering: string[] | null;
-  databaseId?: string | undefined;
   wildcardIds?: boolean;
   bqProjectId?: string | undefined;
   backupTableId?: string | undefined;

--- a/firestore-bigquery-export/functions/__tests__/__snapshots__/config.test.ts.snap
+++ b/firestore-bigquery-export/functions/__tests__/__snapshots__/config.test.ts.snap
@@ -9,7 +9,6 @@ Object {
     "timestamp",
   ],
   "collectionPath": undefined,
-  "databaseId": "(default)",
   "datasetId": "my_dataset",
   "datasetLocation": undefined,
   "doBackfill": false,

--- a/firestore-bigquery-export/functions/__tests__/config.test.ts
+++ b/firestore-bigquery-export/functions/__tests__/config.test.ts
@@ -14,7 +14,6 @@ let extensionParams;
 const environment = {
   LOCATION: "us-central1",
   DATASET_ID: "my_dataset",
-  DATABASE_ID: "(default)",
   TABLE_ID: "my_table",
   TRANSFORM_FUNCTION: "",
   CLUSTERING: "data,timestamp",
@@ -47,7 +46,6 @@ describe("extension config", () => {
     const env = {
       location: environment.LOCATION,
       datasetId: environment.DATASET_ID,
-      databaseId: environment.DATABASE_ID,
       tableId: environment.TABLE_ID,
       clustering: clustering(environment.CLUSTERING),
       kmsKeyName: environment.KMS_KEY_NAME,

--- a/firestore-bigquery-export/functions/src/config.ts
+++ b/firestore-bigquery-export/functions/src/config.ts
@@ -33,7 +33,6 @@ export function clustering(clusters: string | undefined) {
 
 export default {
   bqProjectId: process.env.BIGQUERY_PROJECT_ID,
-  databaseId: process.env.DATABASE_ID || "(default)",
   collectionPath: process.env.COLLECTION_PATH,
   datasetId: process.env.DATASET_ID,
   doBackfill: process.env.DO_BACKFILL === "yes",

--- a/firestore-bigquery-export/functions/src/index.ts
+++ b/firestore-bigquery-export/functions/src/index.ts
@@ -43,7 +43,6 @@ const eventTracker: FirestoreEventHistoryTracker =
     timePartitioningField: config.timePartitioningField,
     timePartitioningFieldType: config.timePartitioningFieldType,
     timePartitioningFirestoreField: config.timePartitioningFirestoreField,
-    databaseId: config.databaseId,
     clustering: config.clustering,
     wildcardIds: config.wildcardIds,
     bqProjectId: config.bqProjectId,
@@ -102,8 +101,7 @@ export const syncBigQuery = functions.tasks
 
 export const fsexportbigquery = functions
   .runWith({ failurePolicy: true })
-  .firestore.database(config.databaseId)
-  .document(config.collectionPath)
+  .firestore.document(config.collectionPath)
   .onWrite(async (change, context) => {
     logs.start();
     try {
@@ -223,12 +221,14 @@ exports.fsimportexistingdocs = functions.tasks
     const docsCount = (data["docsCount"] as number) ?? 0;
 
     const query = config.useCollectionGroupQuery
-      ? getFirestore(config.databaseId).collectionGroup(
-          config.importCollectionPath.split("/")[
-            config.importCollectionPath.split("/").length - 1
-          ]
-        )
-      : getFirestore(config.databaseId).collection(config.importCollectionPath);
+      ? admin
+          .firestore()
+          .collectionGroup(
+            config.importCollectionPath.split("/")[
+              config.importCollectionPath.split("/").length - 1
+            ]
+          )
+      : admin.firestore().collection(config.importCollectionPath);
 
     const snapshot = await query
       .offset(offset)


### PR DESCRIPTION
Rollback the multi-db selection feature due to Extensions currently not supporting v2 Firestore triggers required for the feature to work.