### PR TITLE
fix(firestore-send-email): SendGrid v3 issues

### DIFF
--- a/firestore-send-email/functions/__tests__/helpers.test.ts
+++ b/firestore-send-email/functions/__tests__/helpers.test.ts
@@ -216,6 +216,7 @@ describe("set server credentials helper function", () => {
     expect(regex.test(config.smtpConnectionUri)).toBe(false);
   });
 
+  /* Test removed due to the new SendGrid transporter logic - see setSendGridTransport()
   test("return a SendGrid transporter if the host is smtp.sendgrid.net", () => {
     const config: Config = {
       smtpConnectionUri: "smtps://apikey@smtp.sendgrid.net:465",
@@ -227,4 +228,5 @@ describe("set server credentials helper function", () => {
     const credentials = setSmtpCredentials(config);
     expect(credentials.transporter.name === "nodemailer-sendgrid").toBe(true);
   });
+  */
 });

--- a/firestore-send-email/functions/src/helpers.ts
+++ b/firestore-send-email/functions/src/helpers.ts
@@ -91,7 +91,7 @@ export function setSendGridTransport(config: Config) {
   const { smtpPassword } = config;
 
   const options: sg.SendgridOptions = {
-    apiKey: decodeURIComponent(smtpPassword),
+    apiKey: smtpPassword,
   };
 
   return createTransport(sg(options));

--- a/firestore-send-email/functions/src/helpers.ts
+++ b/firestore-send-email/functions/src/helpers.ts
@@ -71,14 +71,6 @@ export function setSmtpCredentials(config: Config) {
       },
     });
   } else {
-    /* Replaced with `setSendGridTransport()`
-  else if (checkSendGrid(url.hostname)) {
-    const options: sg.SendgridOptions = {
-      apiKey: decodeURIComponent(url.password),
-    };
-
-    transport = createTransport(sg(options));
-  } */
     transport = createTransport(url.href, {
       tls: parseTlsOptions(config.tls),
     });

--- a/firestore-send-email/functions/src/helpers.ts
+++ b/firestore-send-email/functions/src/helpers.ts
@@ -70,17 +70,29 @@ export function setSmtpCredentials(config: Config) {
         pass: decodeURIComponent(url.password),
       },
     });
-  } else if (checkSendGrid(url.hostname)) {
+  } else {
+    /* Replaced with `setSendGridTransport()`
+  else if (checkSendGrid(url.hostname)) {
     const options: sg.SendgridOptions = {
       apiKey: decodeURIComponent(url.password),
     };
 
     transport = createTransport(sg(options));
-  } else {
+  } */
     transport = createTransport(url.href, {
       tls: parseTlsOptions(config.tls),
     });
   }
 
   return transport;
+}
+
+export function setSendGridTransport(config: Config) {
+  const { smtpPassword } = config;
+
+  const options: sg.SendgridOptions = {
+    apiKey: decodeURIComponent(smtpPassword),
+  };
+
+  return createTransport(sg(options));
 }

--- a/firestore-send-email/functions/src/index.ts
+++ b/firestore-send-email/functions/src/index.ts
@@ -286,7 +286,6 @@ async function deliver(
   }
 
   logs.attemptingDelivery(ref);
-  functions.logger.warn("here 0");
   const update = {
     "delivery.attempts": FieldValue.increment(1),
     "delivery.endTime": FieldValue.serverTimestamp(),
@@ -295,7 +294,6 @@ async function deliver(
   };
 
   try {
-    functions.logger.warn("here 1");
     payload = await preparePayload(payload);
 
     if (!payload.to.length && !payload.cc.length && !payload.bcc.length) {
@@ -304,11 +302,8 @@ async function deliver(
       );
     }
 
-    functions.logger.warn("here 2");
-
-    // Switch to SendGrid transport if SendGrid config is provided
+    // Switch to SendGrid transport if SendGrid config is provided.
     if (payload.sendGrid) {
-      functions.logger.warn("here 3");
       transport = setSendGridTransport(config);
 
       // Convert text and html to undefined if they are null
@@ -339,7 +334,7 @@ async function deliver(
         mail_settings: payload.sendGrid?.mailSettings || {},
       }),
     });
-    functions.logger.warn("here 6");
+
     const info = {
       messageId: result.messageId || null,
       accepted: result.accepted || [],
@@ -350,15 +345,12 @@ async function deliver(
 
     update["delivery.state"] = "SUCCESS";
     update["delivery.info"] = info;
-    functions.logger.warn("here 7");
+
     logs.delivered(ref, info);
-    functions.logger.warn("here 8");
   } catch (e) {
-    functions.logger.warn("here 9");
     update["delivery.state"] = "ERROR";
     update["delivery.error"] = e.toString();
     logs.deliveryError(ref, e);
-    functions.logger.warn("here 10");
   }
 
   // Wrapping in transaction to allow for automatic retries (#48)
@@ -367,7 +359,6 @@ async function deliver(
     // since the email sending will have been attempted regardless of what the
     // delivery state was at that point, so we just update the state to reflect
     // the result of the last attempt so as to not potentially cause duplicate sends.
-    functions.logger.warn("here 11");
     transaction.update(ref, update);
     return Promise.resolve();
   });

--- a/firestore-send-email/functions/src/index.ts
+++ b/firestore-send-email/functions/src/index.ts
@@ -23,7 +23,7 @@ import * as logs from "./logs";
 import config from "./config";
 import Templates from "./templates";
 import { QueuePayload } from "./types";
-import { parseTlsOptions, setSmtpCredentials } from "./helpers";
+import { setSendGridTransport, setSmtpCredentials } from "./helpers";
 import * as events from "./events";
 
 logs.init();
@@ -300,6 +300,19 @@ async function deliver(
       throw new Error(
         "Failed to deliver email. Expected at least 1 recipient."
       );
+    }
+
+    // Switch to SendGrid transport if SendGrid config is provided
+    if (payload.sendGrid) {
+      transport = setSendGridTransport(config);
+    }
+
+    if (payload.message?.text == null) {
+      delete payload.message.text;
+    }
+
+    if (payload.message?.html == null) {
+      delete payload.message.html;
     }
 
     const result = await transport.sendMail({


### PR DESCRIPTION
- Use new SendGrid (v3) transport only when payload body contains `sendGrid` field
-  Fix an issue where `text` or `html` fields were `null` and not `undefined` which was resulting in an error.

Resolves #2004.