### PR TITLE
fix(storage-resize-images): maintain aspect ratio of resized images

### DIFF
--- a/storage-resize-images/functions/src/resize-image.ts
+++ b/storage-resize-images/functions/src/resize-image.ts
@@ -47,6 +47,7 @@ export function resize(file, size) {
   return sharp(file, ops)
     .rotate()
     .resize(parseInt(width, 10), parseInt(height, 10), {
+      fit: "inside",
       withoutEnlargement: true,
       ...sharpOptions,
     })


### PR DESCRIPTION
The extension documentation says

> This extension keeps the aspect ratio of uploaded images constant and shrinks the image until the resized image’s dimensions are at or under your specified max width and height.

However, it doesn't currently do that: this pull request fixes it.

Fixes #2106 