### PR TITLE
docs(firestore-bigquery-export): clarify meaning of "exclude old data"

### DIFF
--- a/firestore-bigquery-export/README.md
+++ b/firestore-bigquery-export/README.md
@@ -156,7 +156,7 @@ essential for the script to insert data into an already partitioned table.)
 
 * Use new query syntax for snapshots: If enabled, snapshots will be generated with the new query syntax, which should be more performant, and avoid potential resource limitations.
 
-* Exclude old data payloads: If enabled, table rows will never contain old data (document snapshot before update), which should be more performant, and avoid potential resource limitations.
+* Exclude old data payloads: If enabled, table rows will never contain old data (document snapshot before the update), which should be more performant, and avoid potential resource limitations.
 
 * Use Collection Group query: Do you want to use a [collection group](https://firebase.google.com/docs/firestore/query-data/queries#collection-group-query) query for importing existing documents? You have to enable collectionGroup query if your import path contains subcollections. Warning: A collectionGroup query will target every collection in your Firestore project that matches the 'Existing documents collection'. For example, if you have 10,000 documents with a subcollection named: landmarks, this will query every document in 10,000 landmarks collections.
 

--- a/firestore-bigquery-export/README.md
+++ b/firestore-bigquery-export/README.md
@@ -156,7 +156,7 @@ essential for the script to insert data into an already partitioned table.)
 
 * Use new query syntax for snapshots: If enabled, snapshots will be generated with the new query syntax, which should be more performant, and avoid potential resource limitations.
 
-* Exclude old data payloads: If enabled, table rows will never contain old data (document snapshot before the Firestore onDocumentUpdate event: `change.before.data()`). The reduction in data should be more performant, and avoid potential resource limitations.
+* Exclude old data payloads: If enabled, table rows will never contain old data (document snapshot before update), which should be more performant, and avoid potential resource limitations.
 
 * Use Collection Group query: Do you want to use a [collection group](https://firebase.google.com/docs/firestore/query-data/queries#collection-group-query) query for importing existing documents? You have to enable collectionGroup query if your import path contains subcollections. Warning: A collectionGroup query will target every collection in your Firestore project that matches the 'Existing documents collection'. For example, if you have 10,000 documents with a subcollection named: landmarks, this will query every document in 10,000 landmarks collections.
 

--- a/firestore-bigquery-export/README.md
+++ b/firestore-bigquery-export/README.md
@@ -156,7 +156,7 @@ essential for the script to insert data into an already partitioned table.)
 
 * Use new query syntax for snapshots: If enabled, snapshots will be generated with the new query syntax, which should be more performant, and avoid potential resource limitations.
 
-* Exclude old data payloads: If enabled, table rows will never contain old data (document snapshot before the update), which should be more performant, and avoid potential resource limitations.
+* Exclude old data payloads: If enabled, table rows will never contain old data (document snapshot before the Firestore onDocumentUpdate event: `change.before.data()`). The reduction in data should be more performant, and avoid potential resource limitations.
 
 * Use Collection Group query: Do you want to use a [collection group](https://firebase.google.com/docs/firestore/query-data/queries#collection-group-query) query for importing existing documents? You have to enable collectionGroup query if your import path contains subcollections. Warning: A collectionGroup query will target every collection in your Firestore project that matches the 'Existing documents collection'. For example, if you have 10,000 documents with a subcollection named: landmarks, this will query every document in 10,000 landmarks collections.
 

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -394,8 +394,9 @@ params:
     label: Exclude old data payloads
     description: >-
       If enabled, table rows will never contain old data (document snapshot
-      before the update), which should be more performant, and avoid potential
-      resource limitations.
+      before the Firestore onDocumentUpdate event: `change.before.data()`). The
+      reduction in data should be more performant, and avoid potential resource
+      limitations.
     type: select
     required: false
     default: no


### PR DESCRIPTION
Replaces https://github.com/firebase/extensions/pull/2024 as CI was failing (we need to update that CI so it'll run from forks I think)