### PR TITLE
fix(firestore-bigquery-export): log data and old data on fail to enqueue

### DIFF
--- a/firestore-bigquery-export/CHANGELOG.md
+++ b/firestore-bigquery-export/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.55
+
+feat - log failed queued tasks
+
 ## Version 0.1.54
 
 fixed - bump changetracker and fix more vulnerabilities

--- a/firestore-bigquery-export/README.md
+++ b/firestore-bigquery-export/README.md
@@ -126,6 +126,8 @@ To install an extension, your project must be on the [Blaze (pay as you go) plan
 
 * Collection path: What is the path of the collection that you would like to export? You may use `{wildcard}` notation to match a subcollection of all documents in a collection (for example: `chatrooms/{chatid}/posts`). Parent Firestore Document IDs from `{wildcards}`  can be returned in `path_params` as a JSON formatted string.
 
+* Enable logging failed exports: If enabled, the extension will exports that failed to enqueue to the Firebase console, to prevent data loss.
+
 * Enable Wildcard Column field with Parent Firestore Document IDs: If enabled, creates a column containing a JSON object of all wildcard ids from a documents path.
 
 * Dataset ID: What ID would you like to use for your BigQuery dataset? This extension will create the dataset, if it doesn't already exist.

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-bigquery-export
-version: 0.1.54
+version: 0.1.55
 specVersion: v1beta
 
 displayName: Stream Firestore to BigQuery
@@ -204,6 +204,19 @@ params:
       Firestore collection paths must be an odd number of segments separated by
       slashes, e.g. "path/to/collection".
     default: posts
+    required: true
+
+  - param: LOG_FAILED_EXPORTS
+    label: Enable logging failed exports
+    description: >-
+      If enabled, the extension will exports that failed to enqueue to the
+      Firebase console, to prevent data loss.
+    type: select
+    options:
+      - label: Yes
+        value: yes
+      - label: No
+        value: no
     required: true
 
   - param: WILDCARD_IDS

--- a/firestore-bigquery-export/functions/__tests__/__snapshots__/config.test.ts.snap
+++ b/firestore-bigquery-export/functions/__tests__/__snapshots__/config.test.ts.snap
@@ -20,6 +20,7 @@ Object {
   "instanceId": undefined,
   "kmsKeyName": "test",
   "location": "us-central1",
+  "logFailedExportData": false,
   "maxDispatchesPerSecond": 10,
   "tableId": "my_table",
   "timePartitioning": null,

--- a/firestore-bigquery-export/functions/src/config.ts
+++ b/firestore-bigquery-export/functions/src/config.ts
@@ -32,6 +32,7 @@ export function clustering(clusters: string | undefined) {
 }
 
 export default {
+  logFailedExportData: process.env.LOG_FAILED_EXPORTS === "yes",
   bqProjectId: process.env.BIGQUERY_PROJECT_ID,
   databaseId: "(default)",
   collectionPath: process.env.COLLECTION_PATH,

--- a/firestore-bigquery-export/functions/src/logs.ts
+++ b/firestore-bigquery-export/functions/src/logs.ts
@@ -149,8 +149,24 @@ export const dataTypeInvalid = (
   );
 };
 
-export const error = (err: Error) => {
-  logger.error("Error when mirroring data to BigQuery", err);
+export const error = (
+  includeEvent: boolean,
+  message: string,
+  err: Error,
+  event: any,
+  eventTrackerConfig: any
+) => {
+  if (includeEvent) {
+    logger.error(`Error when mirroring data to BigQuery: ${message}`, {
+      error: err,
+      event,
+      eventTrackerConfig,
+    });
+  } else {
+    logger.error(`Error when mirroring data to BigQuery: ${message}`, {
+      error: err,
+    });
+  }
 };
 
 export const init = () => {


### PR DESCRIPTION
This PR adds logging of data on failure to enqueue in BQ extension