### PR TITLE
docs(firestore-translate-text): fix extension.yaml description

### DIFF
--- a/firestore-translate-text/README.md
+++ b/firestore-translate-text/README.md
@@ -94,7 +94,7 @@ To install an extension, your project must be on the [Blaze (pay as you go) plan
 * Genkit Gemini provider: If you selected to use Genkit to perform translations, please provide the name of the Gemini API you want to use.
 
 
-* Google AI API key: If you selected to use Genkit with Google AI to perform translations, please provide a Google AI API key
+* Google AI API key: If you selected to use Genkit with Google AI to perform translations, please provide a Google AI API key.
 
 
 

--- a/firestore-translate-text/extension.yaml
+++ b/firestore-translate-text/extension.yaml
@@ -170,7 +170,7 @@ params:
     label: Google AI API key
     description: >
       If you selected to use Genkit with Google AI to perform translations,
-      please provide a Google AI API key
+      please provide a Google AI API key.
     type: secret
     required: false
 


### PR DESCRIPTION
This PR is to retrigger the release process, and fix a small grammar typo.