### PR TITLE
docs: clarify service account configuration and verification steps for firestore-bigquery-export

### DIFF
--- a/firestore-bigquery-export/POSTINSTALL.md
+++ b/firestore-bigquery-export/POSTINSTALL.md
@@ -4,30 +4,30 @@ You can test out this extension right away!
 
 1.  Go to your [Cloud Firestore dashboard](https://console.firebase.google.com/project/${param:BIGQUERY_PROJECT_ID}/firestore/data) in the Firebase console.
 
-1.  If it doesn't already exist, create the collection you specified during installation: `${param:COLLECTION_PATH}`
+2.  If it doesn't already exist, create the collection you specified during installation: `${param:COLLECTION_PATH}`
 
-1.  Create a document in the collection called `bigquery-mirror-test` that contains any fields with any values that you'd like.
+3.  Create a document in the collection called `bigquery-mirror-test` that contains any fields with any values that you'd like.
 
-1.  Go to the [BigQuery web UI](https://console.cloud.google.com/bigquery?project=${param:BIGQUERY_PROJECT_ID}&p=${param:BIGQUERY_PROJECT_ID}&d=${param:DATASET_ID}) in the Google Cloud Platform console.
+4.  Go to the [BigQuery web UI](https://console.cloud.google.com/bigquery?project=${param:BIGQUERY_PROJECT_ID}&p=${param:BIGQUERY_PROJECT_ID}&d=${param:DATASET_ID}) in the Google Cloud Platform console.
 
-1.  Query your **raw changelog table**, which should contain a single log of creating the `bigquery-mirror-test` document.
+5.  Query your **raw changelog table**, which should contain a single log of creating the `bigquery-mirror-test` document.
 
     ```
     SELECT *
     FROM `${param:BIGQUERY_PROJECT_ID}.${param:DATASET_ID}.${param:TABLE_ID}_raw_changelog`
     ```
 
-1.  Query your **latest view**, which should return the latest change event for the only document present -- `bigquery-mirror-test`.
+6.  Query your **latest view**, which should return the latest change event for the only document present -- `bigquery-mirror-test`.
 
     ```
     SELECT *
     FROM `${param:BIGQUERY_PROJECT_ID}.${param:DATASET_ID}.${param:TABLE_ID}_raw_latest`
     ```
 
-1.  Delete the `bigquery-mirror-test` document from [Cloud Firestore](https://console.firebase.google.com/project/${param:BIGQUERY_PROJECT_ID}/firestore/data).
+7.  Delete the `bigquery-mirror-test` document from [Cloud Firestore](https://console.firebase.google.com/project/${param:BIGQUERY_PROJECT_ID}/firestore/data).
     The `bigquery-mirror-test` document will disappear from the **latest view** and a `DELETE` event will be added to the **raw changelog table**.
 
-1.  You can check the changelogs of a single document with this query:
+8.  You can check the changelogs of a single document with this query:
 
     ```
     SELECT *
@@ -55,11 +55,19 @@ Enabling wildcard references will provide an additional STRING based column. The
 `Clustering` will not need to create or modify a table when adding clustering options, this will be updated automatically.
 
 
+
 ### Verifying Service Account Name
+
 Before granting permissions, confirm the actual service account name generated during installation.
+
 1. Navigate to **IAM & Admin > IAM** in your Google Cloud Console.
-2. Search for accounts prefixed with `ext-`.
+
+2. Locate the service account starting with `ext-` followed by your extension instance name.
+
 3. Use this name in all subsequent configurations.
+
+
+
 #### Cross-project Streaming
 
 By default, the extension exports data to BigQuery in the same project as your Firebase project. However, you can configure it to export to a BigQuery instance in a different Google Cloud project. To do this:

--- a/firestore-bigquery-export/POSTINSTALL.md
+++ b/firestore-bigquery-export/POSTINSTALL.md
@@ -54,6 +54,12 @@ Enabling wildcard references will provide an additional STRING based column. The
 
 `Clustering` will not need to create or modify a table when adding clustering options, this will be updated automatically.
 
+
+### Verifying Service Account Name
+Before granting permissions, confirm the actual service account name generated during installation.
+1. Navigate to **IAM & Admin > IAM** in your Google Cloud Console.
+2. Search for accounts prefixed with `ext-`.
+3. Use this name in all subsequent configurations.
 #### Cross-project Streaming
 
 By default, the extension exports data to BigQuery in the same project as your Firebase project. However, you can configure it to export to a BigQuery instance in a different Google Cloud project. To do this:

--- a/firestore-bigquery-export/PREINSTALL.md
+++ b/firestore-bigquery-export/PREINSTALL.md
@@ -32,7 +32,7 @@ Note: To enable partitioning for a Big Query database, the following fields are 
 When configuring cross-project setups, the actual service account name may differ from the documented naming format.
 Follow these steps to find and use the correct service account name:
 - Go to **IAM & Admin** in the Google Cloud Console for your Firebase project.
-- Locate the service account starting with `ext-`.
+- Locate the service account starting with `ext-` followed by your extension instance name.
 - Use this name for cross-project permissions, ensuring alignment with the generated account.
 #### Additional setup
 

--- a/firestore-bigquery-export/PREINSTALL.md
+++ b/firestore-bigquery-export/PREINSTALL.md
@@ -27,6 +27,13 @@ Note: To enable partitioning for a Big Query database, the following fields are 
 
 
 
+
+### Service Account Configuration
+When configuring cross-project setups, the actual service account name may differ from the documented naming format.
+Follow these steps to find and use the correct service account name:
+- Go to **IAM & Admin** in the Google Cloud Console for your Firebase project.
+- Locate the service account starting with `ext-`.
+- Use this name for cross-project permissions, ensuring alignment with the generated account.
 #### Additional setup
 
 Before installing this extension, you'll need to:

--- a/firestore-bigquery-export/README.md
+++ b/firestore-bigquery-export/README.md
@@ -35,6 +35,13 @@ Note: To enable partitioning for a Big Query database, the following fields are 
 
 
 
+
+### Service Account Configuration
+When configuring cross-project setups, the actual service account name may differ from the documented naming format.
+Follow these steps to find and use the correct service account name:
+- Go to **IAM & Admin** in the Google Cloud Console for your Firebase project.
+- Locate the service account starting with `ext-`.
+- Use this name for cross-project permissions, ensuring alignment with the generated account.
 #### Additional setup
 
 Before installing this extension, you'll need to:

--- a/firestore-bigquery-export/README.md
+++ b/firestore-bigquery-export/README.md
@@ -40,7 +40,7 @@ Note: To enable partitioning for a Big Query database, the following fields are 
 When configuring cross-project setups, the actual service account name may differ from the documented naming format.
 Follow these steps to find and use the correct service account name:
 - Go to **IAM & Admin** in the Google Cloud Console for your Firebase project.
-- Locate the service account starting with `ext-`.
+- Locate the service account starting with `ext-` followed by your extension instance name.
 - Use this name for cross-project permissions, ensuring alignment with the generated account.
 #### Additional setup
 
@@ -121,24 +121,7 @@ By default, the extension exports data to BigQuery in the same project as your F
 
 1. During installation, set the `BIGQUERY_PROJECT_ID` parameter to your target BigQuery project ID.
 
-2. 
-    After installation, you'll need to grant the extension's service account the necessary BigQuery permissions on the target project.
-
-    ### Service Account Naming Discrepancy
-    Please note that the actual service account generated may differ from the `EXTENSION_INSTANCE_ID` specified during installation. 
-    This discrepancy occurs due to backend constraints such as character limits or unique naming requirements.
-    
-    **Example:**
-    - `EXTENSION_INSTANCE_ID`: `firestore-bigquery-export-y8oz`
-    - Generated Service Account: `ext-firestore-bigquery-ex-5hog@[project-id].iam.gserviceaccount.com`
-    
-    To find the exact service account name:
-    1. Navigate to the **Google Cloud Console**.
-    2. Go to **IAM & Admin > IAM**.
-    3. Search for accounts starting with `ext-`. Use this name for configuring cross-project permissions.
-
-    Update your permission settings to reflect the correct service account name as identified above.
-     You can use our provided scripts:
+2. After installation, you'll need to grant the extension's service account the necessary BigQuery permissions on the target project. You can use our provided scripts:
 
 **For Linux/Mac (Bash):**
 ```bash

--- a/firestore-bigquery-export/README.md
+++ b/firestore-bigquery-export/README.md
@@ -121,7 +121,24 @@ By default, the extension exports data to BigQuery in the same project as your F
 
 1. During installation, set the `BIGQUERY_PROJECT_ID` parameter to your target BigQuery project ID.
 
-2. After installation, you'll need to grant the extension's service account the necessary BigQuery permissions on the target project. You can use our provided scripts:
+2. 
+    After installation, you'll need to grant the extension's service account the necessary BigQuery permissions on the target project.
+
+    ### Service Account Naming Discrepancy
+    Please note that the actual service account generated may differ from the `EXTENSION_INSTANCE_ID` specified during installation. 
+    This discrepancy occurs due to backend constraints such as character limits or unique naming requirements.
+    
+    **Example:**
+    - `EXTENSION_INSTANCE_ID`: `firestore-bigquery-export-y8oz`
+    - Generated Service Account: `ext-firestore-bigquery-ex-5hog@[project-id].iam.gserviceaccount.com`
+    
+    To find the exact service account name:
+    1. Navigate to the **Google Cloud Console**.
+    2. Go to **IAM & Admin > IAM**.
+    3. Search for accounts starting with `ext-`. Use this name for configuring cross-project permissions.
+
+    Update your permission settings to reflect the correct service account name as identified above.
+     You can use our provided scripts:
 
 **For Linux/Mac (Bash):**
 ```bash


### PR DESCRIPTION
## Description

- Clarifies service account naming and configuration in `PREINSTALL.md`.
- Adds steps for verifying the correct service account name in `POSTINSTALL.md`.
- Updates `README.md` to highlight service account naming discrepancies and provide steps for users to locate and use the correct service account.

These updates aim to resolve confusion and ensure smooth setup for cross-project permissions as described in issue #1962.

## Changes

- **PREINSTALL.md**: Added a "Service Account Configuration" section to explain service account name verification and usage.
- **POSTINSTALL.md**: Included "Verifying Service Account Name" steps to ensure users can locate the correct service account.
- **README.md**: Detailed the potential service account naming discrepancies and provided examples with verification steps.

---

Addresses: #1962
