### PR TITLE
fix(firestore-bigquery-export): do not cluster invalid types

### DIFF
--- a/firestore-bigquery-export/CHANGELOG.md
+++ b/firestore-bigquery-export/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 feat - add basic materialized views support
 
+fix - do not add/update clustering if an invalid clustering field is present.
+
 ## Version 0.1.56
 
 feat - improve sync strategy by immediately writing to BQ, and using cloud tasks only as a last resort

--- a/firestore-bigquery-export/README.md
+++ b/firestore-bigquery-export/README.md
@@ -258,7 +258,9 @@ essential for the script to insert data into an already partitioned table.)
 
 * BigQuery SQL Time Partitioning table schema field(column) type: Parameter for BigQuery SQL schema field type for the selected Time Partitioning Firestore Document field option. Cannot be changed if Table is already partitioned.
 
-* BigQuery SQL table clustering: This parameter will allow you to set up Clustering for the BigQuery Table created by the extension. (for example: `data,document_id,timestamp`- no whitespaces). You can select up to 4 comma separated fields. The order of the specified columns determines the sort order of the data. Available schema extensions table fields for clustering: `document_id, document_name, timestamp, event_id, operation, data`.
+* BigQuery SQL table clustering: This parameter allows you to set up clustering for the BigQuery table created by the extension. Specify up to 4 comma-separated fields (for example:  `data,document_id,timestamp` - no whitespaces). The order of the specified  columns determines the sort order of the data. 
+Note: Cluster columns must be top-level, non-repeated columns of one of the  following types: BIGNUMERIC, BOOL, DATE, DATETIME, GEOGRAPHY, INT64, NUMERIC,  RANGE, STRING, TIMESTAMP. Clustering will not be added if a field with an invalid type is present in this parameter.
+Available schema extensions table fields for clustering include: `document_id, document_name, timestamp, event_id,  operation, data`.
 
 * Maximum number of synced documents per second: This parameter will set the maximum number of syncronised documents per second with BQ. Please note, any other external updates to a Big Query table will be included within this quota. Ensure that you have a set a low enough number to compensate. Defaults to 10.
 

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -310,12 +310,18 @@ params:
   - param: CLUSTERING
     label: BigQuery SQL table clustering
     description: >-
-      This parameter will allow you to set up Clustering for the BigQuery Table
-      created by the extension. (for example: `data,document_id,timestamp`- no
-      whitespaces). You can select up to 4 comma separated fields. The order of
-      the specified columns determines the sort order of the data. Available
-      schema extensions table fields for clustering: `document_id,
-      document_name, timestamp, event_id, operation, data`.
+      This parameter allows you to set up clustering for the BigQuery table
+      created by the extension. Specify up to 4 comma-separated fields (for
+      example:  `data,document_id,timestamp` - no whitespaces). The order of the
+      specified  columns determines the sort order of the data. 
+
+      Note: Cluster columns must be top-level, non-repeated columns of one of
+      the  following types: BIGNUMERIC, BOOL, DATE, DATETIME, GEOGRAPHY, INT64,
+      NUMERIC,  RANGE, STRING, TIMESTAMP. Clustering will not be added if a
+      field with an invalid type is present in this parameter.
+
+      Available schema extensions table fields for clustering include:
+      `document_id, document_name, timestamp, event_id,  operation, data`.
     type: string
     validationRegex: ^[^,\s]+(?:,[^,\s]+){0,3}$
     validationErrorMessage:

--- a/firestore-bigquery-export/functions/__tests__/__snapshots__/config.test.ts.snap
+++ b/firestore-bigquery-export/functions/__tests__/__snapshots__/config.test.ts.snap
@@ -39,7 +39,9 @@ Object {
 
 exports[`extension config config.clustering param exists 1`] = `
 Object {
-  "description": "This parameter will allow you to set up Clustering for the BigQuery Table created by the extension. (for example: \`data,document_id,timestamp\`- no whitespaces). You can select up to 4 comma separated fields. The order of the specified columns determines the sort order of the data. Available schema extensions table fields for clustering: \`document_id, document_name, timestamp, event_id, operation, data\`.",
+  "description": "This parameter allows you to set up clustering for the BigQuery table created by the extension. Specify up to 4 comma-separated fields (for example:  \`data,document_id,timestamp\` - no whitespaces). The order of the specified  columns determines the sort order of the data. 
+Note: Cluster columns must be top-level, non-repeated columns of one of the  following types: BIGNUMERIC, BOOL, DATE, DATETIME, GEOGRAPHY, INT64, NUMERIC,  RANGE, STRING, TIMESTAMP. Clustering will not be added if a field with an invalid type is present in this parameter.
+Available schema extensions table fields for clustering include: \`document_id, document_name, timestamp, event_id,  operation, data\`.",
   "example": "data,document_id,timestamp",
   "label": "BigQuery SQL table clustering",
   "param": "CLUSTERING",


### PR DESCRIPTION
wait for https://github.com/firebase/extensions/pull/2255

part of fix for https://github.com/firebase/extensions/issues/2134