### PR TITLE
chore(*): bump all functions to nodejs20 runtime

### DIFF
--- a/delete-user-data/CHANGELOG.md
+++ b/delete-user-data/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.24
+
+feat - move to Node.js 20 runtimes
+
 ## Version 0.1.23
 
 fixed - bump dependencies to fix vulnerabilities

--- a/delete-user-data/extension.yaml
+++ b/delete-user-data/extension.yaml
@@ -64,7 +64,7 @@ resources:
       Authentication's User ID) from Realtime Database, Cloud Firestore, and/or
       Cloud Storage.
     properties:
-      runtime: nodejs18
+      runtime: nodejs20
       eventTrigger:
         eventType: providers/firebase.auth/eventTypes/user.delete
         resource: projects/${param:PROJECT_ID}
@@ -72,7 +72,7 @@ resources:
   - name: handleSearch
     type: firebaseextensions.v1beta.function
     properties:
-      runtime: nodejs18
+      runtime: nodejs20
       eventTrigger:
         eventType: google.pubsub.topic.publish
         resource: projects/${PROJECT_ID}/topics/ext-${EXT_INSTANCE_ID}-discovery
@@ -80,7 +80,7 @@ resources:
   - name: handleDeletion
     type: firebaseextensions.v1beta.function
     properties:
-      runtime: nodejs18
+      runtime: nodejs20
       eventTrigger:
         eventType: google.pubsub.topic.publish
         resource: projects/${PROJECT_ID}/topics/ext-${EXT_INSTANCE_ID}-deletion

--- a/firestore-bigquery-export/CHANGELOG.md
+++ b/firestore-bigquery-export/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.58
+
+feat - move to Node.js 20 runtimes
+
 ## Version 0.1.57
 
 feat - add basic materialized views support, incremental and non-incremental.

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -59,7 +59,7 @@ resources:
       Listens for document changes in your specified Cloud Firestore collection,
       then exports the changes into BigQuery.
     properties:
-      runtime: nodejs18
+      runtime: nodejs20
       eventTrigger:
         eventType: providers/cloud.firestore/eventTypes/document.write
         resource: projects/${param:PROJECT_ID}/databases/(default)/documents/${param:COLLECTION_PATH}/{documentId}
@@ -69,7 +69,7 @@ resources:
     description: >-
       A task-triggered function that gets called on BigQuery sync
     properties:
-      runtime: nodejs18
+      runtime: nodejs20
       taskQueueTrigger:
         rateLimits:
           maxConcurrentDispatches: 500
@@ -83,7 +83,7 @@ resources:
     description: >-
       Runs configuration for sycning with BigQuery
     properties:
-      runtime: nodejs18
+      runtime: nodejs20
       taskQueueTrigger:
         retryConfig:
           maxAttempts: 15
@@ -94,7 +94,7 @@ resources:
     description: >-
       Runs configuration for sycning with BigQuery
     properties:
-      runtime: nodejs18
+      runtime: nodejs20
       taskQueueTrigger:
         retryConfig:
           maxAttempts: 15

--- a/firestore-counter/CHANGELOG.md
+++ b/firestore-counter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.2.12
+
+feat - move to Node.js 20 runtimes
+
 ## Version 0.2.11
 
 fixed - updated vulnerable dependencies

--- a/firestore-counter/extension.yaml
+++ b/firestore-counter/extension.yaml
@@ -53,7 +53,7 @@ resources:
       This scheduled function either aggregates shards itself, or it schedules
       and monitors workers to aggregate shards.
     properties:
-      runtime: nodejs18
+      runtime: nodejs20
       maxInstances: 1
       scheduleTrigger:
         schedule: "every ${param:SCHEDULE_FREQUENCY} minutes"
@@ -64,7 +64,7 @@ resources:
       Listens for changes on counter shards that may need aggregating. This
       function is limited to max 1 instance.
     properties:
-      runtime: nodejs18
+      runtime: nodejs20
       maxInstances: 1
       timeout: 120s
       eventTrigger:
@@ -78,7 +78,7 @@ resources:
       or more worker functions running at any point in time. The controllerCore
       function is responsible for scheduling and monitoring these workers.
     properties:
-      runtime: nodejs18
+      runtime: nodejs20
       eventTrigger:
         eventType: providers/cloud.firestore/eventTypes/document.write
         resource: projects/${param:PROJECT_ID}/databases/(default)/documents/${param:INTERNAL_STATE_PATH}/workers/{workerId}

--- a/firestore-send-email/CHANGELOG.md
+++ b/firestore-send-email/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.36
+
+feat - move to Node.js 20 runtimes
+
 ## Version 0.1.35
 
 feat - add SendGrid category support

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -53,7 +53,7 @@ resources:
       delivers emails, and updates the document with delivery status
       information.
     properties:
-      runtime: nodejs18
+      runtime: nodejs20
       eventTrigger:
         eventType: providers/cloud.firestore/eventTypes/document.write
         resource: projects/${param:PROJECT_ID}/databases/(default)/documents/${param:MAIL_COLLECTION}/{id}

--- a/firestore-shorten-urls-bitly/CHANGELOG.md
+++ b/firestore-shorten-urls-bitly/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.18
+
+feat - move to Node.js 20 runtimes
+
 ## Version 0.1.17
 
 fixed - bump dependencies, fix vulnerabilities

--- a/firestore-shorten-urls-bitly/extension.yaml
+++ b/firestore-shorten-urls-bitly/extension.yaml
@@ -54,7 +54,7 @@ resources:
       collection, shortens the URLs, then writes the shortened form back to the
       same document.
     properties:
-      runtime: nodejs18
+      runtime: nodejs20
       eventTrigger:
         eventType: providers/cloud.firestore/eventTypes/document.write
         resource: projects/${param:PROJECT_ID}/databases/(default)/documents/${param:COLLECTION_PATH}/{documentId}

--- a/firestore-translate-text/CHANGELOG.md
+++ b/firestore-translate-text/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.22
+
+feat - move to Node.js 20 runtimes
+
 ## Version 0.1.21
 
 feat - update docs and config setup for AI Translations with Gemini

--- a/firestore-translate-text/extension.yaml
+++ b/firestore-translate-text/extension.yaml
@@ -60,7 +60,7 @@ resources:
       collection, translates the strings, then writes the translated strings
       back to the same document.
     properties:
-      runtime: nodejs18
+      runtime: nodejs20
       eventTrigger:
         eventType: providers/cloud.firestore/eventTypes/document.write
         resource: projects/${param:PROJECT_ID}/databases/(default)/documents/${param:COLLECTION_PATH}/{messageId}
@@ -72,7 +72,7 @@ resources:
       translates the strings into any missing languages, then writes the
       translated strings back to the same document.
     properties:
-      runtime: nodejs18
+      runtime: nodejs20
       availableMemoryMb: 1024
       timeout: 540s
       taskQueueTrigger: {}

--- a/rtdb-limit-child-nodes/CHANGELOG.md
+++ b/rtdb-limit-child-nodes/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.15
+
+feat - move to Node.js 20 runtimes
+
 ## Version 0.1.14
 
 fixed - bump dependencies to fix vulnerabilities

--- a/rtdb-limit-child-nodes/extension.yaml
+++ b/rtdb-limit-child-nodes/extension.yaml
@@ -53,7 +53,7 @@ resources:
       checks if the max count has been exceeded, then deletes the oldest nodes
       first, as needed to maintain the max count.
     properties:
-      runtime: nodejs18
+      runtime: nodejs20
       eventTrigger:
         eventType: providers/google.firebase.database/eventTypes/ref.create
         resource: projects/_/instances/${param:SELECTED_DATABASE_INSTANCE}/refs/${param:NODE_PATH}/{messageid}

--- a/storage-resize-images/CHANGELOG.md
+++ b/storage-resize-images/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.2.7
+
+feat - move to Node.js 20 runtimes
+
 ## Version 0.2.6
 
 fixed - bump dependencies, fix vulnerabilities

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -58,7 +58,7 @@ resources:
       resizes the images, then stores the resized images in the same bucket.
       Optionally keeps or deletes the original images.
     properties:
-      runtime: nodejs18
+      runtime: nodejs20
       availableMemoryMb: ${param:FUNCTION_MEMORY}
       eventTrigger:
         eventType: google.storage.object.finalize
@@ -68,7 +68,7 @@ resources:
     description: >-
       Handles tasks from startBackfill to resize existing images.
     properties:
-      runtime: nodejs18
+      runtime: nodejs20
       availableMemoryMb: ${param:FUNCTION_MEMORY}
       taskQueueTrigger: {}
 


### PR DESCRIPTION
This PR should resolve the following:

fixes: https://github.com/firebase/extensions/issues/2277

fixes: https://github.com/firebase/extensions/issues/2252