### PR TITLE
fix(workflows): update from actions/cache v2 to v4

### DIFF
--- a/.github/workflows/readmes-updated.yml
+++ b/.github/workflows/readmes-updated.yml
@@ -44,7 +44,7 @@ jobs:
           echo "::set-output name=dir::$(npm config get prefix)"
 
       - name: Cache global dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.global-deps-setup.outputs.dir }}
           key:


### PR DESCRIPTION
[Soon to be deprecated](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down)