### PR TITLE
fix(firestore-send-email): 'replyTo' no longer required

### DIFF
--- a/firestore-send-email/CHANGELOG.md
+++ b/firestore-send-email/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 feat: add support for OAuth2 authentication
 
+fix: default replyTo issue introduced in 0.1.35
+
 ## Version 0.1.36
 
 feat - move to Node.js 20 runtimes

--- a/firestore-send-email/functions/src/index.ts
+++ b/firestore-send-email/functions/src/index.ts
@@ -269,13 +269,15 @@ async function sendWithSendGrid(payload: QueuePayload) {
     }));
   };
 
+  const replyTo = { email: payload.replyTo || config.defaultReplyTo };
+
   // Build the message object for SendGrid
   const msg: sgMail.MailDataRequired = {
     to: formatEmails(payload.to),
     cc: formatEmails(payload.cc),
     bcc: formatEmails(payload.bcc),
     from: { email: payload.from || config.defaultFrom },
-    replyTo: { email: payload.replyTo || config.defaultReplyTo },
+    replyTo: replyTo.email ? replyTo : undefined,
     subject: payload.message?.subject,
     text:
       typeof payload.message?.text === "string"


### PR DESCRIPTION
Resolves #2284

**Checklist:**
- [x] Has been tested