### PR TITLE
fix(firestore-send-email): support attachments in sendgrid

### DIFF
--- a/firestore-send-email/CHANGELOG.md
+++ b/firestore-send-email/CHANGELOG.md
@@ -4,6 +4,8 @@ feat: add support for OAuth2 authentication
 
 fix: default replyTo issue introduced in 0.1.35
 
+fix: sendgrid attachment bug introduced in 0.1.35
+
 ## Version 0.1.36
 
 feat - move to Node.js 20 runtimes

--- a/firestore-send-email/functions/src/index.ts
+++ b/firestore-send-email/functions/src/index.ts
@@ -258,10 +258,10 @@ async function sendWithSendGrid(payload: QueuePayload) {
 
   // Transform attachments to match SendGrid's expected format
   const formatAttachments = (
-    attachments: Attachment[] = []
+    attachments: QueuePayload["message"]["attachments"] = []
   ): SendGridAttachment[] => {
     return attachments.map((attachment) => ({
-      content: attachment.content || "", // Base64-encoded string
+      content: (attachment.content as string | undefined) || "", // Base64-encoded string
       filename: attachment.filename || "attachment",
       type: attachment.contentType,
       disposition: attachment.contentDisposition,
@@ -270,6 +270,8 @@ async function sendWithSendGrid(payload: QueuePayload) {
   };
 
   const replyTo = { email: payload.replyTo || config.defaultReplyTo };
+
+  const attachments = payload.message.attachments;
 
   // Build the message object for SendGrid
   const msg: sgMail.MailDataRequired = {
@@ -289,7 +291,7 @@ async function sendWithSendGrid(payload: QueuePayload) {
         : undefined,
     categories: payload.categories, // SendGrid-specific field
     headers: payload.headers,
-    attachments: formatAttachments(payload.attachments), // Transform attachments to SendGrid format
+    attachments: formatAttachments(attachments), // Transform attachments to SendGrid format
     mailSettings: payload.sendGrid?.mailSettings || {}, // SendGrid-specific mail settings
   };
 


### PR DESCRIPTION
fixes https://github.com/firebase/extensions/issues/2306