### PR TITLE
fix(firestore-send-email): make oauth user optional

### DIFF
--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -158,7 +158,7 @@ params:
     description: >-
       The OAuth2 user email or username for SMTP authentication.
     type: string
-    required: true
+    required: false
 
   - param: MAIL_COLLECTION
     label: Email documents collection


### PR DESCRIPTION
This new param should be optional i think.