### PR TITLE
chore(firestore-translate-text): fully remove backfill resources

### DIFF
--- a/firestore-translate-text/README.md
+++ b/firestore-translate-text/README.md
@@ -95,8 +95,6 @@ To install an extension, your project must be on the [Blaze (pay as you go) plan
 
 * **fstranslate:** Listens for writes of new strings to your specified Cloud Firestore collection, translates the strings, then writes the translated strings back to the same document.
 
-* **fstranslatebackfill:** Searches your specified Cloud Firestore collection for existing documents, translates the strings into any missing languages, then writes the translated strings back to the same document.
-
 
 
 **APIs Used**:

--- a/firestore-translate-text/extension.yaml
+++ b/firestore-translate-text/extension.yaml
@@ -65,17 +65,18 @@ resources:
         eventType: providers/cloud.firestore/eventTypes/document.write
         resource: projects/${param:PROJECT_ID}/databases/(default)/documents/${param:COLLECTION_PATH}/{messageId}
 
-  - name: fstranslatebackfill
-    type: firebaseextensions.v1beta.function
-    description:
-      Searches your specified Cloud Firestore collection for existing documents,
-      translates the strings into any missing languages, then writes the
-      translated strings back to the same document.
-    properties:
-      runtime: nodejs20
-      availableMemoryMb: 1024
-      timeout: 540s
-      taskQueueTrigger: {}
+  # ! DO NOT UNCOMMENT THIS PARAMETER, IT IS CURRENTLY PROBLEMATIC
+  # - name: fstranslatebackfill
+  #   type: firebaseextensions.v1beta.function
+  #   description:
+  #     Searches your specified Cloud Firestore collection for existing documents,
+  #     translates the strings into any missing languages, then writes the
+  #     translated strings back to the same document.
+  #   properties:
+  #     runtime: nodejs20
+  #     availableMemoryMb: 1024
+  #     timeout: 540s
+  #     taskQueueTrigger: {}
 
 params:
   - param: LANGUAGES

--- a/firestore-translate-text/functions/src/config.ts
+++ b/firestore-translate-text/functions/src/config.ts
@@ -15,7 +15,7 @@
  */
 
 export default {
-  doBackfill: process.env.DO_BACKFILL === "true",
+  doBackfill: false,
   languages: Array.from(new Set(process.env.LANGUAGES.split(","))),
   location: process.env.LOCATION,
   inputFieldName: process.env.INPUT_FIELD_NAME,


### PR DESCRIPTION
This PR removes leftover resources in the extension for the removed backfill feature.