### PR TITLE
feat(firestore-shorten-urls-bitly): use v2 functions

### DIFF
--- a/firestore-shorten-urls-bitly/CHANGELOG.md
+++ b/firestore-shorten-urls-bitly/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 0.2.0
+
+feat: use v2 firestore trigger
+
+feat: allow non-(default) firestore instances
+
 ## Version 0.1.18
 
 feat - move to Node.js 20 runtimes

--- a/firestore-shorten-urls-bitly/README.md
+++ b/firestore-shorten-urls-bitly/README.md
@@ -49,11 +49,14 @@ To install an extension, your project must be on the [Blaze (pay as you go) plan
 * Short URL field name: What is the name of the field where you want to store your shortened URLs?
 
 
+* Firestore Database: The Firestore database to use. Use "(default)" for the default database.
 
 
-**Cloud Functions:**
 
-* **fsurlshortener:** Listens for writes of new URLs to your specified Cloud Firestore collection, shortens the URLs, then writes the shortened form back to the same document.
+
+**Other Resources**:
+
+* fsurlshortener (firebaseextensions.v1beta.v2function)
 
 
 

--- a/firestore-shorten-urls-bitly/extension.yaml
+++ b/firestore-shorten-urls-bitly/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-shorten-urls-bitly
-version: 0.1.18
+version: 0.2.0
 specVersion: v1beta
 
 displayName: Shorten URLs in Firestore
@@ -48,16 +48,26 @@ roles:
 
 resources:
   - name: fsurlshortener
-    type: firebaseextensions.v1beta.function
+    type: firebaseextensions.v1beta.v2function
     description:
       Listens for writes of new URLs to your specified Cloud Firestore
       collection, shortens the URLs, then writes the shortened form back to the
       same document.
     properties:
-      runtime: nodejs20
+      sourceDirectory: functions
+      buildConfig:
+        runtime: nodejs22
+      serviceConfig:
+        timeoutSeconds: 120
       eventTrigger:
-        eventType: providers/cloud.firestore/eventTypes/document.write
-        resource: projects/${param:PROJECT_ID}/databases/(default)/documents/${param:COLLECTION_PATH}/{documentId}
+        eventType: google.cloud.firestore.document.v1.written
+        triggerRegion: ${LOCATION}
+        eventFilters:
+          - attribute: database
+            value: ${DATABASE}
+          - attribute: document
+            value: ${COLLECTION_PATH}/{documentId}
+            operator: match-path-pattern
 
 externalServices:
   - name: Bitly
@@ -101,6 +111,14 @@ params:
     default: shortUrl
     required: true
 
+  - param: DATABASE
+    label: Firestore Database
+    description: >
+      The Firestore database to use. Use "(default)" for the default database.
+    example: (default)
+    default: (default)
+    required: false
+
 events:
   - type: firebase.extensions.firestore-shorten-urls-bitly.v1.onStart
     description:
@@ -108,9 +126,7 @@ events:
       include data such as the context of the trigger request.
 
   - type: firebase.extensions.firestore-shorten-urls-bitly.v1.onSuccess
-    description:
-      Occurs when image resizing completes successfully. The event will contain
-      further details about specific formats and sizes.
+    description: Occurs when URL shortening completes successfully.
 
   - type: firebase.extensions.firestore-shorten-urls-bitly.v1.onError
     description:

--- a/firestore-shorten-urls-bitly/functions/src/abstract-shortener.ts
+++ b/firestore-shorten-urls-bitly/functions/src/abstract-shortener.ts
@@ -14,11 +14,18 @@
  * limitations under the License.
  */
 
-import * as admin from "firebase-admin";
-import * as functions from "firebase-functions";
+import { initializeApp } from "firebase-admin/app";
+import {
+  getFirestore,
+  DocumentSnapshot,
+  FieldValue,
+} from "firebase-admin/firestore";
+import { Change } from "firebase-functions/v2/firestore";
+import { logger } from "firebase-functions/v2";
 
 import * as logs from "./logs";
 import * as events from "./events";
+import config from "./config";
 
 enum ChangeType {
   CREATE,
@@ -35,14 +42,10 @@ export abstract class FirestoreUrlShortener {
   ) {
     this.urlFieldName = urlFieldName;
     this.shortUrlFieldName = shortUrlFieldName;
-
-    // Initialize the Firebase Admin SDK
-    admin.initializeApp();
+    initializeApp();
   }
 
-  public async onDocumentWrite(
-    change: functions.Change<admin.firestore.DocumentSnapshot>
-  ) {
+  public async onDocumentWrite(change: Change<DocumentSnapshot>) {
     this.logs.start();
 
     if (this.urlFieldName === this.shortUrlFieldName) {
@@ -52,33 +55,40 @@ export abstract class FirestoreUrlShortener {
 
     const changeType = this.getChangeType(change);
 
-    switch (changeType) {
-      case ChangeType.CREATE:
-        await this.handleCreateDocument(change.after);
-        break;
-      case ChangeType.DELETE:
-        this.handleDeleteDocument();
-        break;
-      case ChangeType.UPDATE:
-        await this.handleUpdateDocument(change.before, change.after);
-        break;
-      default: {
-        const err = new Error(`Invalid change type: ${changeType}`);
-        await events.recordErrorEvent(err);
-        throw err;
+    try {
+      switch (changeType) {
+        case ChangeType.CREATE:
+          await this.handleCreateDocument(change.after);
+          break;
+        case ChangeType.DELETE:
+          this.handleDeleteDocument();
+          break;
+        case ChangeType.UPDATE:
+          await this.handleUpdateDocument(change.before, change.after);
+          break;
+        default: {
+          const err = new Error(`Invalid change type: ${changeType}`);
+          await events.recordErrorEvent(err);
+          throw err;
+        }
       }
+
+      this.logs.complete();
+    } catch (err) {
+      logger.error("Error in extension execution", err);
+      await events.recordErrorEvent(
+        err instanceof Error ? err : new Error(String(err))
+      );
+      throw err;
     }
-
-    this.logs.complete();
   }
 
-  protected extractUrl(snapshot: admin.firestore.DocumentSnapshot) {
-    return snapshot.get(this.urlFieldName);
+  protected extractUrl(snapshot: DocumentSnapshot) {
+    const data = snapshot.data();
+    return data ? data[this.urlFieldName] : undefined;
   }
 
-  private getChangeType(
-    change: functions.Change<admin.firestore.DocumentSnapshot>
-  ) {
+  private getChangeType(change: Change<DocumentSnapshot>) {
     if (!change.after.exists) {
       return ChangeType.DELETE;
     }
@@ -88,9 +98,7 @@ export abstract class FirestoreUrlShortener {
     return ChangeType.UPDATE;
   }
 
-  private async handleCreateDocument(
-    snapshot: admin.firestore.DocumentSnapshot
-  ) {
+  private async handleCreateDocument(snapshot: DocumentSnapshot) {
     const url = this.extractUrl(snapshot);
     if (url) {
       this.logs.documentCreatedWithUrl();
@@ -105,8 +113,8 @@ export abstract class FirestoreUrlShortener {
   }
 
   private async handleUpdateDocument(
-    before: admin.firestore.DocumentSnapshot,
-    after: admin.firestore.DocumentSnapshot
+    before: DocumentSnapshot,
+    after: DocumentSnapshot
   ) {
     const urlAfter = this.extractUrl(after);
     const urlBefore = this.extractUrl(before);
@@ -118,27 +126,27 @@ export abstract class FirestoreUrlShortener {
       await this.shortenUrl(after);
     } else if (urlBefore) {
       this.logs.documentUpdatedDeletedUrl();
-      await this.updateShortUrl(after, admin.firestore.FieldValue.delete());
+      await this.updateShortUrl(after, FieldValue.delete());
     } else {
       this.logs.documentUpdatedNoUrl();
     }
   }
 
-  protected abstract shortenUrl(
-    snapshot: admin.firestore.DocumentSnapshot
-  ): Promise<void>;
+  protected abstract shortenUrl(snapshot: DocumentSnapshot): Promise<void>;
 
   protected async updateShortUrl(
-    snapshot: admin.firestore.DocumentSnapshot,
+    snapshot: DocumentSnapshot,
     url: any
   ): Promise<void> {
     this.logs.updateDocument(snapshot.ref.path);
 
-    // Wrapping in transaction to allow for automatic retries (#48)
-    await admin.firestore().runTransaction((transaction) => {
+    // Wrapping in transaction to allow for automatic retries
+    const firestore = getFirestore(config.database);
+    await firestore.runTransaction((transaction) => {
       transaction.update(snapshot.ref, this.shortUrlFieldName, url);
       return Promise.resolve();
     });
+
     this.logs.updateDocumentComplete(snapshot.ref.path);
     await events.recordSuccessEvent({
       subject: snapshot.ref.path,

--- a/firestore-shorten-urls-bitly/functions/src/config.ts
+++ b/firestore-shorten-urls-bitly/functions/src/config.ts
@@ -20,4 +20,5 @@ export default {
   location: process.env.LOCATION,
   shortUrlFieldName: process.env.SHORT_URL_FIELD_NAME,
   urlFieldName: process.env.URL_FIELD_NAME,
+  database: process.env.DATABASE,
 };


### PR DESCRIPTION
This PR  migrates the extension to v2 firestore triggers, and adds a database param