### PR TITLE
fix(firestore-shorten-urls-bitly): make database param required

### DIFF
--- a/firestore-shorten-urls-bitly/extension.yaml
+++ b/firestore-shorten-urls-bitly/extension.yaml
@@ -117,7 +117,7 @@ params:
       The Firestore database to use. Use "(default)" for the default database.
     example: (default)
     default: (default)
-    required: false
+    required: true
 
 events:
   - type: firebase.extensions.firestore-shorten-urls-bitly.v1.onStart


### PR DESCRIPTION
This needs to be required (a default is provided)