### PR TITLE
fix(firestore-send-email): fix issue with empty message property causing error when using SendGrid

### DIFF
--- a/firestore-send-email/CHANGELOG.md
+++ b/firestore-send-email/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.38
+
+fix: empty message property causing error when using SendGrid
+
 ## Version 0.1.37
 
 feat: add support for OAuth2 authentication

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-send-email
-version: 0.1.37
+version: 0.1.38
 specVersion: v1beta
 
 displayName: Trigger Email from Firestore

--- a/firestore-send-email/functions/src/index.ts
+++ b/firestore-send-email/functions/src/index.ts
@@ -271,7 +271,7 @@ async function sendWithSendGrid(payload: QueuePayload) {
 
   const replyTo = { email: payload.replyTo || config.defaultReplyTo };
 
-  const attachments = payload.message.attachments;
+  const attachments = payload.message?.attachments;
 
   // Build the message object for SendGrid
   const msg: sgMail.MailDataRequired = {


### PR DESCRIPTION
Resolves https://github.com/firebase/extensions/issues/2372

Tested