### PR TITLE
feat(*): remove default database region on v2 triggers

### DIFF
--- a/firestore-bigquery-export/CHANGELOG.md
+++ b/firestore-bigquery-export/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.2.2
+
+fix: remove default value on DATABASE_REGION
+
 ## Versions 0.2.1
 
 fix: correct database region params and make mutable

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-bigquery-export
-version: 0.2.1
+version: 0.2.2
 specVersion: v1beta
 
 displayName: Stream Firestore to BigQuery
@@ -310,7 +310,6 @@ params:
       # Africa
       - label: Johannesburg (africa-south1)
         value: africa-south1
-    default: us
     required: true
     immutable: false
 

--- a/firestore-shorten-urls-bitly/CHANGELOG.md
+++ b/firestore-shorten-urls-bitly/CHANGELOG.md
@@ -1,4 +1,8 @@
-## Versions 0.2.1
+## Version 0.2.2
+
+fix: remove default value on DATABASE_REGION
+
+## Version 0.2.1
 
 fix: correct database region params and make mutable
 

--- a/firestore-shorten-urls-bitly/extension.yaml
+++ b/firestore-shorten-urls-bitly/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-shorten-urls-bitly
-version: 0.2.1
+version: 0.2.2
 specVersion: v1beta
 
 displayName: Shorten URLs in Firestore
@@ -234,7 +234,6 @@ params:
       # Africa
       - label: Johannesburg (africa-south1)
         value: africa-south1
-    default: us
     required: true
     immutable: false
 


### PR DESCRIPTION
This PR removes the incorrect default: us value for database region on firestore v2 triggers