### PR TITLE
fix(firestore-send-email): add types and attempt to extract message ID

### DIFF
--- a/firestore-send-email/CHANGELOG.md
+++ b/firestore-send-email/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 0.2.1
+
+fix: return info on sendgrid messages
+
+feat: include sendgrid queueId
+
 ## Version 0.2.0
 
 feat: use v2 firestore trigger

--- a/firestore-send-email/CHANGELOG.md
+++ b/firestore-send-email/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 fix: return info on sendgrid messages
 
-feat: include sendgrid queueId
+feat: include sendgridQueueId if using that provider
 
 ## Version 0.2.0
 

--- a/firestore-send-email/POSTINSTALL.md
+++ b/firestore-send-email/POSTINSTALL.md
@@ -44,7 +44,7 @@ See the [official documentation](https://firebase.google.com/docs/extensions/off
 
 When using SendGrid (`SMTP_CONNECTION_URI` includes `sendgrid.net`), you can assign categories to your emails.
 
-## Example JSON with Categories:
+##### Example JSON with Categories:
 ```json
 {
   "to": ["example@example.com"],
@@ -60,6 +60,30 @@ When using SendGrid (`SMTP_CONNECTION_URI` includes `sendgrid.net`), you can ass
 Add this document to the Firestore mail collection to send categorized emails.
 
 For more details, see the [SendGrid Categories documentation](https://docs.sendgrid.com/ui/sending-email/categories).
+
+#### Understanding SendGrid Email IDs
+
+When an email is sent successfully, the extension tracks two different IDs in the delivery information:
+
+- **Queue ID**: This is SendGrid's internal queue identifier (from the `x-message-id` header). It's useful for tracking the email within SendGrid's system.
+- **Message ID**: This is the RFC-2822 Message-ID header, which is a standard email identifier used across email systems.
+
+You can find both IDs in the `delivery.info` field of your email document after successful delivery:
+
+```json
+{
+  "delivery": {
+    "info": {
+      "messageId": "<unique-message-id@your-domain.com>",
+      "sendgridQueueId": "sendgrid-queue-id",
+      "accepted": ["recipient@example.com"],
+      "rejected": [],
+      "pending": [],
+      "response": "status=202"
+    }
+  }
+}
+```
 
 ### Automatic Deletion of Email Documents
 

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-send-email
-version: 0.2.0
+version: 0.2.1
 specVersion: v1beta
 
 displayName: Trigger Email from Firestore

--- a/firestore-send-email/functions/__tests__/nodemailer-sendgrid/index.test.ts
+++ b/firestore-send-email/functions/__tests__/nodemailer-sendgrid/index.test.ts
@@ -1,9 +1,13 @@
-// __tests__/SendGridTransport.test.ts
-
 import * as sgMail from "@sendgrid/mail";
-import { SendGridTransport } from "../../src/nodemailer-sendgrid";
+import {
+  SendGridTransport,
+  SendGridTransportOptions,
+  MailSource,
+  Address,
+  AttachmentEntry,
+  IcalEvent,
+} from "../../src/nodemailer-sendgrid";
 
-// 1) Mock out setApiKey/send before importing our transport
 jest.mock("@sendgrid/mail", () => ({
   setApiKey: jest.fn(),
   send: jest.fn(),
@@ -14,42 +18,230 @@ describe("SendGridTransport", () => {
     jest.clearAllMocks();
   });
 
-  test("sets API key when provided", () => {
-    new SendGridTransport({ apiKey: "test-key" });
-    expect(sgMail.setApiKey).toHaveBeenCalledWith("test-key");
+  test("constructor: sets API key when provided", () => {
+    new SendGridTransport({ apiKey: "API-KEY-123" });
+    expect(sgMail.setApiKey as jest.Mock).toHaveBeenCalledWith("API-KEY-123");
   });
 
-  test("normalizes the mail and calls sgMail.send + callback", async () => {
-    const transport = new SendGridTransport({ apiKey: "ignored" });
+  test("constructor: does not call setApiKey when no apiKey option", () => {
+    new SendGridTransport({});
+    expect(sgMail.setApiKey as jest.Mock).not.toHaveBeenCalled();
+  });
 
-    // 2) Prepare a fake MailSource that calls back with our `source`
-    const source = {
-      subject: "Hello",
-      text: "World",
-      from: { name: "Alice", address: "alice@example.com" },
-      to: [{ name: "Bob", address: "bob@example.com" }],
-    };
-    const fakeMail: any = {
-      normalize: jest.fn((cb: any) => cb(null, source)),
+  test("send: callback with error if normalize errors", async () => {
+    const transport = new SendGridTransport({ apiKey: "X" });
+    const fakeErr = new Error("normalize failed");
+    const fakeMail: Partial<MailSource> = {
+      normalize: (cb) => cb(fakeErr, {} as any),
     };
 
-    // 3) Stub sgMail.send to resolve with a fake response
-    (sgMail.send as jest.Mock).mockResolvedValueOnce(["SENT", {}]);
+    const cb = jest.fn();
+    transport.send(fakeMail as MailSource, cb);
 
-    const callback = jest.fn();
+    // allow normalize→callback to run
+    await new Promise((r) => setImmediate(r));
 
-    // 4) Call send() and wait for the microtask queue to flush
-    transport.send(fakeMail, callback);
-    await new Promise((resolve) => setImmediate(resolve));
+    expect(cb).toHaveBeenCalledWith(fakeErr);
+    expect(sgMail.send as jest.Mock).not.toHaveBeenCalled();
+  });
 
-    // 5) Assertions
-    expect(fakeMail.normalize).toHaveBeenCalled();
+  test("send: basic subject/text/html mapping", async () => {
+    const transport = new SendGridTransport();
+    const source = { subject: "S", text: "T", html: "<p>H</p>" };
+    const fakeMail: any = { normalize: (cb: any) => cb(null, source) };
+
+    (sgMail.send as jest.Mock).mockResolvedValueOnce(["OK", {}]);
+    const cb = jest.fn();
+
+    transport.send(fakeMail, cb);
+    await new Promise((r) => setImmediate(r));
+
     expect(sgMail.send).toHaveBeenCalledWith({
-      subject: "Hello",
-      text: "World",
-      from: { name: "Alice", email: "alice@example.com" },
-      to: [{ name: "Bob", email: "bob@example.com" }],
+      subject: "S",
+      text: "T",
+      html: "<p>H</p>",
     });
-    expect(callback).toHaveBeenCalledWith(null, ["SENT", {}]);
+    expect(cb).toHaveBeenCalledWith(null, ["OK", {}]);
+  });
+
+  test("send: maps from and replyTo", async () => {
+    const transport = new SendGridTransport();
+    const addr: Address = { name: "Alice", address: "a@x.com" };
+    const source = { from: addr, replyTo: [addr] };
+    const fakeMail: any = { normalize: (cb) => cb(null, source) };
+    (sgMail.send as jest.Mock).mockResolvedValueOnce([{}, {}]);
+
+    const cb = jest.fn();
+    transport.send(fakeMail, cb);
+    await new Promise((r) => setImmediate(r));
+
+    const sentMsg = (sgMail.send as jest.Mock).mock.calls[0][0];
+    expect(sentMsg.from).toEqual({ name: "Alice", email: "a@x.com" });
+    expect(sentMsg.replyTo).toEqual({ name: "Alice", email: "a@x.com" });
+    expect(cb).toHaveBeenCalledWith(null, [{}, {}]);
+  });
+
+  test("send: maps to, cc, bcc arrays", async () => {
+    const transport = new SendGridTransport();
+    const a1: Address = { name: "B", address: "b@x" };
+    const a2: Address = { name: "C", address: "c@x" };
+    const source = { to: [a1], cc: a2, bcc: [a1, a2] };
+    const fakeMail: any = { normalize: (cb) => cb(null, source) };
+    (sgMail.send as jest.Mock).mockResolvedValueOnce([{}, {}]);
+
+    const cb = jest.fn();
+    transport.send(fakeMail, cb);
+    await new Promise((r) => setImmediate(r));
+
+    const sent = (sgMail.send as jest.Mock).mock.calls[0][0];
+    expect(sent.to).toEqual([{ name: "B", email: "b@x" }]);
+    expect(sent.cc).toEqual([{ name: "C", email: "c@x" }]);
+    expect(sent.bcc).toEqual([
+      { name: "B", email: "b@x" },
+      { name: "C", email: "c@x" },
+    ]);
+  });
+
+  test("send: attachments with inline and normal dispositions", async () => {
+    const transport = new SendGridTransport();
+    const atchs: AttachmentEntry[] = [
+      { content: "foo", filename: "f.txt", contentType: "text/plain" },
+      {
+        content: "img",
+        filename: "i.png",
+        contentType: "image/png",
+        cid: "cid123",
+      },
+    ];
+    const source = { attachments: atchs };
+    const fakeMail: any = { normalize: (cb) => cb(null, source) };
+    (sgMail.send as jest.Mock).mockResolvedValueOnce([{}, {}]);
+
+    const cb = jest.fn();
+    transport.send(fakeMail, cb);
+    await new Promise((r) => setImmediate(r));
+
+    const sentAtt = (sgMail.send as jest.Mock).mock.calls[0][0].attachments;
+    expect(sentAtt).toHaveLength(2);
+    // first: normal
+    expect(sentAtt[0]).toMatchObject({
+      content: "foo",
+      filename: "f.txt",
+      type: "text/plain",
+      disposition: "attachment",
+    });
+    // second: inline
+    expect(sentAtt[1]).toMatchObject({
+      content: "img",
+      filename: "i.png",
+      type: "image/png",
+      disposition: "inline",
+      content_id: "cid123",
+    });
+  });
+
+  test("send: alternatives → content", async () => {
+    const transport = new SendGridTransport();
+    const alts = [{ content: "alt", contentType: "text/alt" }];
+    const source = { alternatives: alts };
+    const fakeMail: any = { normalize: (cb) => cb(null, source) };
+    (sgMail.send as jest.Mock).mockResolvedValueOnce([{}, {}]);
+
+    const cb = jest.fn();
+    transport.send(fakeMail, cb);
+    await new Promise((r) => setImmediate(r));
+
+    const sentContent = (sgMail.send as jest.Mock).mock.calls[0][0].content;
+    expect(sentContent).toEqual([{ content: "alt", type: "text/alt" }]);
+  });
+
+  test("send: icalEvent as attachment", async () => {
+    const transport = new SendGridTransport();
+    const ev: IcalEvent = { content: "ics", filename: "evt.ics" };
+    const source = { icalEvent: ev };
+    const fakeMail: any = { normalize: (cb) => cb(null, source) };
+    (sgMail.send as jest.Mock).mockResolvedValueOnce([{}, {}]);
+
+    const cb = jest.fn();
+    transport.send(fakeMail, cb);
+    await new Promise((r) => setImmediate(r));
+
+    const sentAtt = (sgMail.send as jest.Mock).mock.calls[0][0].attachments![0];
+    expect(sentAtt).toMatchObject({
+      content: "ics",
+      filename: "evt.ics",
+      type: "application/ics",
+      disposition: "attachment",
+    });
+  });
+
+  test("send: watchHtml → content", async () => {
+    const transport = new SendGridTransport();
+    const source = { watchHtml: "<watch>" };
+    const fakeMail: any = { normalize: (cb) => cb(null, source) };
+    (sgMail.send as jest.Mock).mockResolvedValueOnce([{}, {}]);
+
+    const cb = jest.fn();
+    transport.send(fakeMail, cb);
+    await new Promise((r) => setImmediate(r));
+
+    const content = (sgMail.send as jest.Mock).mock.calls[0][0].content;
+    expect(content).toEqual([{ content: "<watch>", type: "text/watch-html" }]);
+  });
+
+  test("send: normalizedHeaders & messageId → headers", async () => {
+    const transport = new SendGridTransport();
+    const source = {
+      normalizedHeaders: { "X-Custom": "val" },
+      messageId: "msg-123",
+    };
+    const fakeMail: any = { normalize: (cb) => cb(null, source) };
+    (sgMail.send as jest.Mock).mockResolvedValueOnce([{}, {}]);
+
+    const cb = jest.fn();
+    transport.send(fakeMail, cb);
+    await new Promise((r) => setImmediate(r));
+
+    const headers = (sgMail.send as jest.Mock).mock.calls[0][0].headers;
+    expect(headers).toMatchObject({
+      "X-Custom": "val",
+      "message-id": "msg-123",
+    });
+  });
+
+  test("send: merges text/html into content array when alternatives present", async () => {
+    const transport = new SendGridTransport();
+    const source = {
+      text: "TXT",
+      html: "<H>",
+      alternatives: [{ content: "alt1", contentType: "type1" }],
+    };
+    const fakeMail: any = { normalize: (cb) => cb(null, source) };
+    (sgMail.send as jest.Mock).mockResolvedValueOnce([{}, {}]);
+
+    const cb = jest.fn();
+    transport.send(fakeMail, cb);
+    await new Promise((r) => setImmediate(r));
+
+    const content = (sgMail.send as jest.Mock).mock.calls[0][0].content;
+    expect(content).toEqual([
+      { type: "text/html", content: "<H>" },
+      { type: "text/plain", content: "TXT" },
+      { type: "type1", content: "alt1" },
+    ]);
+  });
+
+  test("send: callback with error if sgMail.send rejects", async () => {
+    const transport = new SendGridTransport();
+    const source = { subject: "Hi" };
+    const fakeMail: any = { normalize: (cb) => cb(null, source) };
+    const sendErr = new Error("send failed");
+    (sgMail.send as jest.Mock).mockRejectedValueOnce(sendErr);
+
+    const cb = jest.fn();
+    transport.send(fakeMail, cb);
+    await new Promise((r) => setImmediate(r));
+
+    expect(cb).toHaveBeenCalledWith(sendErr);
   });
 });

--- a/firestore-send-email/functions/__tests__/nodemailer-sendgrid/index.test.ts
+++ b/firestore-send-email/functions/__tests__/nodemailer-sendgrid/index.test.ts
@@ -1,0 +1,55 @@
+// __tests__/SendGridTransport.test.ts
+
+import * as sgMail from "@sendgrid/mail";
+import { SendGridTransport } from "../../src/nodemailer-sendgrid";
+
+// 1) Mock out setApiKey/send before importing our transport
+jest.mock("@sendgrid/mail", () => ({
+  setApiKey: jest.fn(),
+  send: jest.fn(),
+}));
+
+describe("SendGridTransport", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("sets API key when provided", () => {
+    new SendGridTransport({ apiKey: "test-key" });
+    expect(sgMail.setApiKey).toHaveBeenCalledWith("test-key");
+  });
+
+  test("normalizes the mail and calls sgMail.send + callback", async () => {
+    const transport = new SendGridTransport({ apiKey: "ignored" });
+
+    // 2) Prepare a fake MailSource that calls back with our `source`
+    const source = {
+      subject: "Hello",
+      text: "World",
+      from: { name: "Alice", address: "alice@example.com" },
+      to: [{ name: "Bob", address: "bob@example.com" }],
+    };
+    const fakeMail: any = {
+      normalize: jest.fn((cb: any) => cb(null, source)),
+    };
+
+    // 3) Stub sgMail.send to resolve with a fake response
+    (sgMail.send as jest.Mock).mockResolvedValueOnce(["SENT", {}]);
+
+    const callback = jest.fn();
+
+    // 4) Call send() and wait for the microtask queue to flush
+    transport.send(fakeMail, callback);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // 5) Assertions
+    expect(fakeMail.normalize).toHaveBeenCalled();
+    expect(sgMail.send).toHaveBeenCalledWith({
+      subject: "Hello",
+      text: "World",
+      from: { name: "Alice", email: "alice@example.com" },
+      to: [{ name: "Bob", email: "bob@example.com" }],
+    });
+    expect(callback).toHaveBeenCalledWith(null, ["SENT", {}]);
+  });
+});

--- a/firestore-send-email/functions/__tests__/nodemailer-sendgrid/index.test.ts
+++ b/firestore-send-email/functions/__tests__/nodemailer-sendgrid/index.test.ts
@@ -225,9 +225,9 @@ describe("SendGridTransport", () => {
 
     const content = (sgMail.send as jest.Mock).mock.calls[0][0].content;
     expect(content).toEqual([
-      { type: "text/html", content: "<H>" },
-      { type: "text/plain", content: "TXT" },
-      { type: "type1", content: "alt1" },
+      { type: "text/html", value: "<H>" },
+      { type: "text/plain", value: "TXT" },
+      { type: "type1", value: "alt1" },
     ]);
   });
 

--- a/firestore-send-email/functions/jest.config.js
+++ b/firestore-send-email/functions/jest.config.js
@@ -15,7 +15,7 @@ module.exports = {
     printBasicPrototype: true,
   },
   setupFiles: ["<rootDir>/__tests__/jest.setup.ts"],
-  testMatch: ["**/__tests__/*.test.ts"],
+  testMatch: ["**/__tests__/**/*.test.ts"],
   testEnvironment: "node",
   moduleNameMapper: {
     "firebase-admin/app": "<rootDir>/node_modules/firebase-admin/lib/app",

--- a/firestore-send-email/functions/src/index.ts
+++ b/firestore-send-email/functions/src/index.ts
@@ -31,7 +31,7 @@ import * as nodemailer from "nodemailer";
 import * as logs from "./logs";
 import config from "./config";
 import Templates from "./templates";
-import { QueuePayload, SendGridAttachment } from "./types";
+import { QueuePayload } from "./types";
 import { isSendGrid, setSmtpCredentials } from "./helpers";
 import * as events from "./events";
 import { SendGridTransport } from "./nodemailer-sendgrid";

--- a/firestore-send-email/functions/src/index.ts
+++ b/firestore-send-email/functions/src/index.ts
@@ -324,6 +324,7 @@ async function sendWithSendGrid(
   const messageId =
     ((response.headers["x-message-id"] ||
       response.headers["X-Message-Id"]) as string) || null;
+
   const acceptedList = payload.to.map((r) =>
     typeof r === "string" ? r : (r as any).email
   );

--- a/firestore-send-email/functions/src/index.ts
+++ b/firestore-send-email/functions/src/index.ts
@@ -31,7 +31,7 @@ import * as nodemailer from "nodemailer";
 import * as logs from "./logs";
 import config from "./config";
 import Templates from "./templates";
-import { QueuePayload } from "./types";
+import { Delivery, QueuePayload } from "./types";
 import { isSendGrid, setSmtpCredentials } from "./helpers";
 import * as events from "./events";
 import { SendGridTransport } from "./nodemailer-sendgrid";
@@ -408,7 +408,7 @@ async function processWrite(
       // initialize the delivery state.
       if (!payload.delivery) {
         const startTime = Timestamp.fromDate(new Date());
-        const delivery: any = {
+        const delivery: Partial<Delivery> = {
           startTime: startTime,
           state: "PENDING",
           attempts: 0,

--- a/firestore-send-email/functions/src/index.ts
+++ b/firestore-send-email/functions/src/index.ts
@@ -31,7 +31,7 @@ import * as nodemailer from "nodemailer";
 import * as logs from "./logs";
 import config from "./config";
 import Templates from "./templates";
-import { Delivery, QueuePayload } from "./types";
+import { Delivery, QueuePayload, ExtendedSendMailOptions } from "./types";
 import { isSendGrid, setSmtpCredentials } from "./helpers";
 import * as events from "./events";
 import { SendGridTransport } from "./nodemailer-sendgrid";
@@ -299,7 +299,7 @@ async function deliver(ref: DocumentReference): Promise<void> {
       );
     }
 
-    const mailOptions: nodemailer.SendMailOptions = {
+    const mailOptions: ExtendedSendMailOptions = {
       from: payload.from || config.defaultFrom,
       replyTo: payload.replyTo || config.defaultReplyTo,
       to: payload.to,
@@ -309,7 +309,6 @@ async function deliver(ref: DocumentReference): Promise<void> {
       text: payload.message?.text,
       html: payload.message?.html,
       attachments: payload.message?.attachments,
-      // @ts-ignore - TODO: fix types here
       categories: payload.categories,
       templateId: payload.sendGrid?.templateId,
       dynamicTemplateData: payload.sendGrid?.dynamicTemplateData,

--- a/firestore-send-email/functions/src/nodemailer-sendgrid/index.ts
+++ b/firestore-send-email/functions/src/nodemailer-sendgrid/index.ts
@@ -43,6 +43,10 @@ export interface MailSource {
   messageId?: string;
   [key: string]: any;
   normalize(cb: (err: Error | null, source: MailSource) => void): void;
+  categories?: string[];
+  templateId?: string;
+  dynamicTemplateData?: Record<string, unknown>;
+  mailSettings?: Record<string, unknown>;
 }
 
 export class SendGridTransport {
@@ -162,6 +166,13 @@ export class SendGridTransport {
               ...(msg.headers ?? {}),
               "message-id": source.messageId,
             };
+            break;
+
+          case "categories":
+          case "templateId":
+          case "dynamicTemplateData":
+          case "mailSettings":
+            msg[key] = source[key];
             break;
 
           default:

--- a/firestore-send-email/functions/src/nodemailer-sendgrid/index.ts
+++ b/firestore-send-email/functions/src/nodemailer-sendgrid/index.ts
@@ -87,7 +87,6 @@ export class SendGridTransport {
 
       const msg: any = {};
 
-      // Map all MailSource properties into the @sendgrid/mail message shape
       for (const key of Object.keys(source)) {
         switch (key) {
           case "subject":
@@ -202,22 +201,20 @@ export class SendGridTransport {
         }
       }
 
-      // Send via SendGrid's HTTP API
       sgMail
         .send(msg)
         .then(([response]) => {
-          // 1) Internal SendGrid queue-ID from HTTP header
+          // Internal SendGrid queue-ID from HTTP header
           const rawQueue = (response.headers["x-message-id"] ||
             response.headers["X-Message-Id"]) as string | undefined;
           const queueId = rawQueue ? String(rawQueue) : null;
 
-          // 2) Your RFC-2822 Message-ID header
+          // RFC-2822 Message-ID header
           const headerMsgId = (msg.headers && msg.headers["message-id"]) as
             | string
             | undefined;
           const messageId = headerMsgId || null;
 
-          // 3) Build accepted list from msg.to
           const toList = ([] as any[]).concat(msg.to || []);
           const accepted = toList.map((r) =>
             typeof r === "string" ? r : r.email

--- a/firestore-send-email/functions/src/nodemailer-sendgrid/index.ts
+++ b/firestore-send-email/functions/src/nodemailer-sendgrid/index.ts
@@ -9,11 +9,24 @@ import {
   SendGridMessage,
 } from "./types";
 
+/**
+ * A Nodemailer transport implementation for SendGrid.
+ * This class handles the conversion of Nodemailer mail objects to SendGrid's format
+ * and sends emails using the SendGrid API.
+ */
 export class SendGridTransport {
+  /** The name of the transport */
   public readonly name = "firebase-extensions-nodemailer-sendgrid";
+  /** The version of the transport */
   public readonly version = "0.0.1";
+  /** The SendGrid transport options */
   private readonly options: SendGridTransportOptions;
 
+  /**
+   * Creates a new SendGridTransport instance.
+   * @param options - Configuration options for the SendGrid transport
+   * @param options.apiKey - SendGrid API key for authentication
+   */
   constructor(options: SendGridTransportOptions = {}) {
     this.options = options;
     if (options.apiKey) {
@@ -21,6 +34,13 @@ export class SendGridTransport {
     }
   }
 
+  /**
+   * Sends an email using SendGrid.
+   * @param mail - The mail object containing email details (from, to, subject, etc.)
+   * @param callback - Callback function to handle the result of the send operation
+   * @param callback.err - Error object if the send operation failed
+   * @param callback.info - Information about the sent email if successful
+   */
   public send(
     mail: MailSource,
     callback: (err: Error | null, info?: SendGridInfo) => void

--- a/firestore-send-email/functions/src/nodemailer-sendgrid/index.ts
+++ b/firestore-send-email/functions/src/nodemailer-sendgrid/index.ts
@@ -1,0 +1,194 @@
+import * as sgMail from "@sendgrid/mail";
+
+export interface SendGridTransportOptions {
+  apiKey?: string;
+  [key: string]: unknown;
+}
+
+export interface Address {
+  name?: string;
+  address: string;
+}
+
+export interface AttachmentEntry {
+  content: string | Buffer;
+  filename: string;
+  contentType: string;
+  cid?: string;
+}
+
+export interface IcalEvent {
+  content: string;
+  filename?: string;
+}
+
+export interface NormalizedHeaders {
+  [header: string]: string;
+}
+
+export interface MailSource {
+  subject?: string;
+  text?: string;
+  html?: string;
+  from?: Address | Address[];
+  replyTo?: Address | Address[];
+  to?: Address | Address[];
+  cc?: Address | Address[];
+  bcc?: Address | Address[];
+  attachments?: AttachmentEntry[];
+  alternatives?: { content: string; contentType: string }[];
+  icalEvent?: IcalEvent;
+  watchHtml?: string;
+  normalizedHeaders?: NormalizedHeaders;
+  messageId?: string;
+  [key: string]: any;
+  normalize(cb: (err: Error | null, source: MailSource) => void): void;
+}
+
+export class SendGridTransport {
+  public readonly name: string;
+  public readonly version: string;
+  private readonly options: SendGridTransportOptions;
+
+  constructor(options: SendGridTransportOptions = {}) {
+    this.options = options;
+    this.name = "firebase-extensions-nodemailer-sendgrid";
+    this.version = "0.0.1";
+    if (options.apiKey) {
+      sgMail.setApiKey(options.apiKey);
+    }
+  }
+
+  public send(
+    mail: MailSource,
+    callback: (err: Error | null, result?: unknown) => void
+  ): void {
+    mail.normalize((err, source) => {
+      if (err) {
+        return callback(err);
+      }
+
+      const msg: any = {};
+
+      for (const key of Object.keys(source || {})) {
+        switch (key) {
+          case "subject":
+          case "text":
+          case "html":
+            msg[key] = source[key];
+            break;
+
+          case "from":
+          case "replyTo":
+            msg[key] = []
+              .concat(source[key] ?? [])
+              .map((entry: Address) => ({
+                name: entry.name,
+                email: entry.address,
+              }))
+              .shift();
+            break;
+
+          case "to":
+          case "cc":
+          case "bcc":
+            msg[key] = [].concat(source[key] ?? []).map((entry: Address) => ({
+              name: entry.name,
+              email: entry.address,
+            }));
+            break;
+
+          case "attachments": {
+            const attachments = (source.attachments ?? []).map((entry) => {
+              const attachment: any = {
+                content: entry.content,
+                filename: entry.filename,
+                type: entry.contentType,
+                disposition: "attachment",
+              };
+              if (entry.cid) {
+                attachment.content_id = entry.cid;
+                attachment.disposition = "inline";
+              }
+              return attachment;
+            });
+            msg.attachments = []
+              .concat(msg.attachments ?? [])
+              .concat(attachments);
+            break;
+          }
+
+          case "alternatives": {
+            const alternatives = (source.alternatives ?? []).map((entry) => ({
+              content: entry.content,
+              type: entry.contentType,
+            }));
+            msg.content = [].concat(msg.content ?? []).concat(alternatives);
+            break;
+          }
+
+          case "icalEvent": {
+            const ev = source.icalEvent!;
+            const attachment = {
+              content: ev.content,
+              filename: ev.filename ?? "invite.ics",
+              type: "application/ics",
+              disposition: "attachment",
+            };
+            msg.attachments = []
+              .concat(msg.attachments ?? [])
+              .concat(attachment);
+            break;
+          }
+
+          case "watchHtml": {
+            const alternative = {
+              content: source.watchHtml!,
+              type: "text/watch-html",
+            };
+            msg.content = [].concat(msg.content ?? []).concat(alternative);
+            break;
+          }
+
+          case "normalizedHeaders":
+            msg.headers = {
+              ...(msg.headers ?? {}),
+              ...source.normalizedHeaders,
+            };
+            break;
+
+          case "messageId":
+            msg.headers = {
+              ...(msg.headers ?? {}),
+              "message-id": source.messageId,
+            };
+            break;
+
+          default:
+            msg[key] = source[key];
+        }
+      }
+
+      // If we've built a `content` array, merge in text/html
+      if (Array.isArray(msg.content) && msg.content.length) {
+        if (msg.text) {
+          msg.content.unshift({ type: "text/plain", content: msg.text });
+          delete msg.text;
+        }
+        if (msg.html) {
+          msg.content.unshift({ type: "text/html", content: msg.html });
+          delete msg.html;
+        }
+      }
+
+      sgMail
+        .send(msg)
+        .then((response) => {
+          callback(null, response);
+        })
+        .catch((err: Error) => {
+          callback(err);
+        });
+    });
+  }
+}

--- a/firestore-send-email/functions/src/nodemailer-sendgrid/types.ts
+++ b/firestore-send-email/functions/src/nodemailer-sendgrid/types.ts
@@ -1,0 +1,95 @@
+export interface SendGridTransportOptions {
+  apiKey?: string;
+  [key: string]: unknown;
+}
+
+export interface Address {
+  name?: string;
+  address: string;
+}
+
+export interface AttachmentEntry {
+  content: string | Buffer;
+  filename: string;
+  contentType: string;
+  cid?: string;
+}
+
+export interface IcalEvent {
+  content: string;
+  filename?: string;
+}
+
+export interface NormalizedHeaders {
+  [header: string]: string;
+}
+
+export interface MailSource {
+  normalize(cb: (err: Error | null, source: MailSource) => void): void;
+
+  from?: Address | Address[];
+  replyTo?: Address | Address[];
+  to?: Address | Address[];
+  cc?: Address | Address[];
+  bcc?: Address | Address[];
+  subject?: string;
+  text?: string;
+  html?: string;
+  attachments?: AttachmentEntry[];
+  alternatives?: { content: string; contentType: string }[];
+  icalEvent?: IcalEvent;
+  watchHtml?: string;
+  normalizedHeaders?: NormalizedHeaders;
+  messageId?: string;
+
+  categories?: string[];
+  templateId?: string;
+  dynamicTemplateData?: Record<string, unknown>;
+  mailSettings?: Record<string, unknown>;
+
+  [key: string]: unknown;
+}
+
+export interface SendGridInfo {
+  /** The RFC-2822 Message-ID header (what you set or SendGrid generated) */
+  messageId: string | null;
+  /** SendGrid's internal queue token (the X-Message-Id HTTP header) */
+  queueId: string | null;
+  accepted: string[];
+  rejected: string[];
+  pending: string[];
+  /** HTTP status line, e.g. "status=202" */
+  response: string;
+}
+
+export interface SendGridAttachment {
+  content: string;
+  filename: string;
+  type: string;
+  disposition: string;
+  content_id?: string;
+}
+
+export interface SendGridContent {
+  type: string;
+  value: string;
+}
+
+export interface SendGridMessage {
+  subject?: string;
+  text?: string;
+  html?: string;
+  from?: { name?: string; email: string };
+  replyTo?: { name?: string; email: string };
+  to?: Array<{ name?: string; email: string }>;
+  cc?: Array<{ name?: string; email: string }>;
+  bcc?: Array<{ name?: string; email: string }>;
+  attachments?: SendGridAttachment[];
+  content?: SendGridContent[];
+  headers?: Record<string, string>;
+  categories?: string[];
+  templateId?: string;
+  dynamicTemplateData?: Record<string, unknown>;
+  mailSettings?: Record<string, unknown>;
+  [key: string]: unknown;
+}

--- a/firestore-send-email/functions/src/types.ts
+++ b/firestore-send-email/functions/src/types.ts
@@ -59,21 +59,24 @@ export interface TemplateData {
   attachments?: Attachment[];
 }
 
-export interface QueuePayload {
-  delivery?: {
-    startTime: admin.firestore.Timestamp;
-    endTime: admin.firestore.Timestamp;
-    leaseExpireTime: admin.firestore.Timestamp;
-    state: "PENDING" | "PROCESSING" | "RETRY" | "SUCCESS" | "ERROR";
-    attempts: number;
-    error?: string;
-    info?: {
-      messageId: string;
-      accepted: string[];
-      rejected: string[];
-      pending: string[];
-    };
+export interface Delivery {
+  startTime: admin.firestore.Timestamp;
+  endTime: admin.firestore.Timestamp;
+  leaseExpireTime: admin.firestore.Timestamp;
+  state: "PENDING" | "PROCESSING" | "RETRY" | "SUCCESS" | "ERROR";
+  attempts: number;
+  error?: string;
+  expireAt?: admin.firestore.Timestamp;
+  info?: {
+    messageId: string;
+    accepted: string[];
+    rejected: string[];
+    pending: string[];
   };
+}
+
+export interface QueuePayload {
+  delivery?: Delivery;
   message?: nodemailer.SendMailOptions;
   template?: {
     name: string;
@@ -98,13 +101,13 @@ export interface QueuePayload {
 }
 
 // Define the expected format for SendGrid attachments
-export type SendGridAttachment = {
+export interface SendGridAttachment {
   content: string; // Base64-encoded string
   filename: string;
   type?: string;
   disposition?: string;
   contentId?: string;
-};
+}
 
 export enum AuthenticatonType {
   OAuth2 = "OAuth2",

--- a/firestore-send-email/functions/src/types.ts
+++ b/firestore-send-email/functions/src/types.ts
@@ -121,3 +121,10 @@ export enum Hosts {
   Outlook = "smtp-mail.outlook.com",
   Hotmail = "smtp.live.com",
 }
+
+export interface ExtendedSendMailOptions extends nodemailer.SendMailOptions {
+  categories?: string[];
+  templateId?: string;
+  dynamicTemplateData?: Record<string, any>;
+  mailSettings?: Record<string, any>;
+}


### PR DESCRIPTION
Resolves https://github.com/firebase/extensions/issues/2375

This PR includes the sendgrid queue ID as well as the message ID when writing back to firestore

We have refactored to wrap the HTTP SDK for sendgrid in a custom transport

TODO:

- [x] update tests
- [ ] regression test dynamic templates and categories
- [ ] regression test other providers (gmail)

