### PR TITLE
docs(firestore-send-email): add docs on dynamic SendGrid templates

### DIFF
--- a/firestore-send-email/CHANGELOG.md
+++ b/firestore-send-email/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.2.2
+
+docs: add documentation on how to use dynamic templates with SendGrid
+
 ## Version 0.2.1
 
 fix: return info on sendgrid messages

--- a/firestore-send-email/POSTINSTALL.md
+++ b/firestore-send-email/POSTINSTALL.md
@@ -61,6 +61,29 @@ Add this document to the Firestore mail collection to send categorized emails.
 
 For more details, see the [SendGrid Categories documentation](https://docs.sendgrid.com/ui/sending-email/categories).
 
+#### Firestore-Send-Email: SendGrid Dynamic Templates
+
+When using SendGrid, you can use SendGrid Dynamic Templates to create and send templated emails.
+
+## Example JSON representation of Firestore document for a Dynamic Template:
+```json
+{
+  "to": ["example@example.com"],
+  "sendGrid": {
+    "templateId": "d-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "dynamicTemplateData": {
+      "name": "John Doe",
+      "company": "Example Corp",
+      "position": "Developer"
+    }
+  }
+}
+```
+
+Add this document to the Firestore mail collection to send an email using a SendGrid Dynamic Template. The `templateId` is required and should be your SendGrid Dynamic Template ID (always starts with 'd-'). The `dynamicTemplateData` object contains the variables that will be used in your template.
+
+For more details, see the [SendGrid Dynamic Templates documentation](https://docs.sendgrid.com/ui/sending-email/how-to-send-an-email-with-dynamic-templates).
+
 #### Understanding SendGrid Email IDs
 
 When an email is sent successfully, the extension tracks two different IDs in the delivery information:

--- a/firestore-send-email/PREINSTALL.md
+++ b/firestore-send-email/PREINSTALL.md
@@ -39,6 +39,29 @@ Add this document to the Firestore mail collection to send categorized emails.
 
 For more details, see the [SendGrid Categories documentation](https://docs.sendgrid.com/ui/sending-email/categories).
 
+#### Firestore-Send-Email: SendGrid Dynamic Templates
+
+When using SendGrid, you can use SendGrid Dynamic Templates to create and send templated emails.
+
+## Example JSON representation of Firestore document for a Dynamic Template:
+```json
+{
+  "to": ["example@example.com"],
+  "sendGrid": {
+    "templateId": "d-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",  // SendGrid Dynamic Template ID always starts with 'd-'
+    "dynamicTemplateData": {
+      "name": "John Doe",
+      "company": "Example Corp",
+      "position": "Developer"
+    }
+  }
+}
+```
+
+Add this document to the Firestore mail collection to send an email using a SendGrid Dynamic Template. The `templateId` is required and should be your SendGrid Dynamic Template ID (always starts with 'd-'). The `dynamicTemplateData` object contains the variables that will be used in your template.
+
+For more details, see the [SendGrid Dynamic Templates documentation](https://docs.sendgrid.com/ui/sending-email/how-to-send-an-email-with-dynamic-templates).
+
 #### Setting Up OAuth2 Authentication
 
 This section will help you set up OAuth2 authentication for the extension, using GCP (Gmail) as an example.
@@ -195,7 +218,7 @@ Detailed instructions for creating a TTL field can be found in the [Firestore TT
 #### Billing
 To install an extension, your project must be on the [Blaze (pay as you go) plan](https://firebase.google.com/pricing)
 
-- This extension uses other Firebase and Google Cloud Platform services, which have associated charges if you exceed the service’s no-cost tier:
+- This extension uses other Firebase and Google Cloud Platform services, which have associated charges if you exceed the service's no-cost tier:
   - Cloud Firestore
   - Cloud Functions (Node.js 10+ runtime. [See FAQs](https://firebase.google.com/support/faq#extensions-pricing))
 

--- a/firestore-send-email/README.md
+++ b/firestore-send-email/README.md
@@ -47,6 +47,29 @@ Add this document to the Firestore mail collection to send categorized emails.
 
 For more details, see the [SendGrid Categories documentation](https://docs.sendgrid.com/ui/sending-email/categories).
 
+#### Firestore-Send-Email: SendGrid Dynamic Templates
+
+When using SendGrid, you can use SendGrid Dynamic Templates to create and send templated emails.
+
+## Example JSON representation of Firestore document for a Dynamic Template:
+```json
+{
+  "to": ["example@example.com"],
+  "sendGrid": {
+    "templateId": "d-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",  // SendGrid Dynamic Template ID always starts with 'd-'
+    "dynamicTemplateData": {
+      "name": "John Doe",
+      "company": "Example Corp",
+      "position": "Developer"
+    }
+  }
+}
+```
+
+Add this document to the Firestore mail collection to send an email using a SendGrid Dynamic Template. The `templateId` is required and should be your SendGrid Dynamic Template ID (always starts with 'd-'). The `dynamicTemplateData` object contains the variables that will be used in your template.
+
+For more details, see the [SendGrid Dynamic Templates documentation](https://docs.sendgrid.com/ui/sending-email/how-to-send-an-email-with-dynamic-templates).
+
 #### Setting Up OAuth2 Authentication
 
 This section will help you set up OAuth2 authentication for the extension, using GCP (Gmail) as an example.
@@ -203,7 +226,7 @@ Detailed instructions for creating a TTL field can be found in the [Firestore TT
 #### Billing
 To install an extension, your project must be on the [Blaze (pay as you go) plan](https://firebase.google.com/pricing)
 
-- This extension uses other Firebase and Google Cloud Platform services, which have associated charges if you exceed the service’s no-cost tier:
+- This extension uses other Firebase and Google Cloud Platform services, which have associated charges if you exceed the service's no-cost tier:
   - Cloud Firestore
   - Cloud Functions (Node.js 10+ runtime. [See FAQs](https://firebase.google.com/support/faq#extensions-pricing))
 

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-send-email
-version: 0.2.1
+version: 0.2.2
 specVersion: v1beta
 
 displayName: Trigger Email from Firestore


### PR DESCRIPTION
This PR adds docs for using dynamic templates with SendGrid in firestore-send-email.

fixes https://github.com/firebase/extensions/issues/2363