### PR TITLE
fix(firestore-send-email): preparePayload fix

### DIFF
--- a/firestore-send-email/CHANGELOG.md
+++ b/firestore-send-email/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Version 0.2.2
 
+fix: fix validation of payloads
+
 docs: add documentation on how to use dynamic templates with SendGrid
 
 ## Version 0.2.1

--- a/firestore-send-email/functions/__tests__/e2e/sendgrid.test.ts
+++ b/firestore-send-email/functions/__tests__/e2e/sendgrid.test.ts
@@ -1,0 +1,145 @@
+// This test suite assumes local emulator is running the extension, with the following config:
+
+//  AUTH_TYPE=UsernamePassword
+//  DATABASE=(default)
+//  DATABASE_REGION=us-east1
+//  DEFAULT_FROM=<some-email>
+//  MAIL_COLLECTION=emailCollection
+//  OAUTH_PORT=465
+//  SMTP_CONNECTION_URI=smtps://apikey@smtp.sendgrid.net:465
+//  TEMPLATES_COLLECTION=emailTemplates
+//  TTL_EXPIRE_TYPE=never
+//  TTL_EXPIRE_VALUE=1
+
+// set the TEST_EMAIL environment variable to the recipient email address for the test
+const TEST_EMAIL = process.env.TEST_EMAIL || "test@example.com";
+
+//  and that the sendgrid api key is set as a secret for the emulator in a .secret.local file
+
+import * as admin from "firebase-admin";
+
+// Test data constants
+const TEST_TEMPLATE = {
+  name: "test_template",
+  subject: "Test Subject",
+  text: `Hello {{userName}},
+
+Thank you for your order:
+{{orderText}}
+
+Your order will be processed by {{doctorName}}.
+
+Business Hours:
+{{openingHours}}
+
+Address:
+{{address}}
+
+Best regards,
+The Team`,
+  html: `
+<!DOCTYPE html>
+<html>
+<body>
+  <p>Hello {{userName}},</p>
+  <p>Thank you for your order: {{orderText}}</p>
+  <p>Your order will be processed by {{doctorName}}.</p>
+  <p>Business Hours: {{openingHours}}</p>
+  <p>Address: {{address}}</p>
+  <p>Best regards,<br>The Team</p>
+</body>
+</html>`,
+};
+
+const TEST_TEMPLATE_DATA = {
+  address: "123 Test Street, Test City",
+  doctorName: "Dr. Test",
+  openingHours: "Mon-Fri: 9:00-17:00",
+  orderText: "Test order items",
+  userName: "Test User",
+};
+
+const TEST_COLLECTIONS = ["emailCollection", "emailTemplates"] as const;
+
+// Skip the entire suite if E2E_SENDGRID is not set to true
+(process.env.E2E_SENDGRID === "true" ? describe : describe.skip)(
+  "SendGrid E2E Tests",
+  () => {
+    beforeAll(() => {
+      // Initialize with emulator settings
+      admin.initializeApp({
+        projectId: "dev-extensions-testing",
+        databaseURL: "http://localhost:8080?ns=dev-extensions-testing",
+      });
+
+      // Point Firestore to the emulator
+      process.env.FIRESTORE_EMULATOR_HOST = "localhost:8080";
+    });
+
+    beforeEach(async () => {
+      // Clear all data from the emulator
+      const db = admin.firestore();
+
+      for (const collection of TEST_COLLECTIONS) {
+        const snapshot = await db.collection(collection).get();
+        const batch = db.batch();
+
+        snapshot.docs.forEach((doc) => {
+          batch.delete(doc.ref);
+        });
+
+        await batch.commit();
+      }
+
+      // Create the email template
+      await db.collection("emailTemplates").doc(TEST_TEMPLATE.name).set({
+        subject: TEST_TEMPLATE.subject,
+        text: TEST_TEMPLATE.text,
+        html: TEST_TEMPLATE.html,
+      });
+    });
+
+    test("should process a template-based email document", async () => {
+      const db = admin.firestore();
+
+      const testData = {
+        message: {
+          attachments: [],
+          html: null,
+          text: null,
+          subject: TEST_TEMPLATE.subject,
+        },
+        template: {
+          data: TEST_TEMPLATE_DATA,
+          name: TEST_TEMPLATE.name,
+        },
+        to: TEST_EMAIL,
+      };
+
+      // Write the document to the emulator
+      const docRef = db.collection("emailCollection").doc("test-doc");
+      await docRef.set(testData);
+
+      // Wait a bit for the function to process
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
+      // Verify the document was updated
+      const doc = await docRef.get();
+      const updatedData = doc.data();
+
+      // Assert the delivery state was updated to SUCCESS
+      console.log("updatedData", updatedData);
+      expect(updatedData?.delivery.state).toBe("SUCCESS");
+      expect(updatedData?.delivery.attempts).toBe(1);
+      expect(updatedData?.delivery.endTime).toBeDefined();
+      expect(updatedData?.delivery.error).toBeNull();
+
+      // Verify SendGrid specific info
+      expect(updatedData?.delivery.info).toBeDefined();
+      expect(updatedData?.delivery.info?.messageId).toBeDefined();
+      expect(updatedData?.delivery.info?.accepted).toContain(TEST_EMAIL);
+      expect(updatedData?.delivery.info?.rejected).toEqual([]);
+      expect(updatedData?.delivery.info?.pending).toEqual([]);
+    });
+  }
+);

--- a/firestore-send-email/functions/__tests__/prepare-payload.test.ts
+++ b/firestore-send-email/functions/__tests__/prepare-payload.test.ts
@@ -1,0 +1,229 @@
+import { preparePayload, setDependencies } from "../src/prepare-payload";
+
+class MockTemplates {
+  async render(name: string, data: any) {
+    switch (name) {
+      case "html-only-template":
+        return {
+          html: "<h1>Template HTML</h1>",
+          subject: "Template Subject",
+        };
+      case "text-only-template":
+        return {
+          text: "Template text content",
+          subject: "Template Subject",
+        };
+      case "both-html-text-template":
+        return {
+          html: "<h1>Template HTML</h1>",
+          text: "Template text content",
+          subject: "Template Subject",
+        };
+      case "template-with-attachments":
+        return {
+          html: "<h1>Template HTML</h1>",
+          subject: "Template Subject",
+          attachments: [{ filename: "template.pdf" }],
+        };
+      case "template-with-data":
+        return {
+          html: `<h1>Hello ${data.name}</h1>`,
+          subject: `Subject for ${data.name}`,
+        };
+      default:
+        return {};
+    }
+  }
+}
+
+describe("preparePayload Template Merging", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // We stub db.getAll here but it won't be called unless toUids/ccUids/bccUids are used
+    setDependencies({ getAll: jest.fn() }, new MockTemplates());
+  });
+
+  it("should throw error when there is no message and no template", async () => {
+    const payload = {
+      to: "test@example.com",
+    };
+
+    await expect(preparePayload(payload)).rejects.toThrow(
+      "Invalid email configuration: Email configuration must include either a 'message', 'template', or 'sendGrid' object"
+    );
+  });
+
+  it("should preserve existing HTML content when template only provides text", async () => {
+    const payload = {
+      to: "test@example.com",
+      template: {
+        name: "text-only-template",
+        data: {},
+      },
+      message: {
+        html: "<p>Original HTML content</p>",
+        subject: "Original Subject",
+      },
+    };
+
+    const result = await preparePayload(payload);
+
+    expect(result.message.html).toBe("<p>Original HTML content</p>");
+    expect(result.message.text).toBe("Template text content");
+    expect(result.message.subject).toBe("Template Subject");
+  });
+
+  it("should prioritize template HTML over message text when both exist", async () => {
+    const payload = {
+      to: "test@example.com",
+      template: {
+        name: "both-html-text-template",
+        data: {},
+      },
+      message: {
+        text: "Original text content",
+      },
+    };
+
+    const result = await preparePayload(payload);
+
+    expect(result.message.html).toBe("<h1>Template HTML</h1>");
+    expect(result.message.text).toBe("Template text content");
+  });
+
+  it("should handle attachment merging correctly", async () => {
+    const payload = {
+      to: "test@example.com",
+      template: {
+        name: "template-with-attachments",
+        data: {},
+      },
+      message: {
+        attachments: [{ filename: "original.doc" }],
+      },
+    };
+
+    const result = await preparePayload(payload);
+
+    expect(result.message.attachments).toEqual([{ filename: "template.pdf" }]);
+  });
+
+  it("should gracefully handle template with no content", async () => {
+    const payload = {
+      to: "test@example.com",
+      template: {
+        name: "empty-template",
+        data: {},
+      },
+      message: {
+        html: "<p>Original HTML content</p>",
+        subject: "Original Subject",
+      },
+    };
+
+    const result = await preparePayload(payload);
+
+    expect(result.message.html).toBe("<p>Original HTML content</p>");
+    expect(result.message.subject).toBe("Original Subject");
+    expect(result.message.attachments).toEqual([]);
+  });
+
+  it("should merge template and message content correctly", async () => {
+    const payload = {
+      to: "test@example.com",
+      template: {
+        name: "html-only-template",
+        data: {},
+      },
+      message: {
+        text: "Original text content",
+        subject: "Original Subject",
+        attachments: [{ filename: "original.doc" }],
+      },
+    };
+
+    const result = await preparePayload(payload);
+
+    expect(result.message.html).toBe("<h1>Template HTML</h1>");
+    expect(result.message.text).toBe("Original text content");
+    expect(result.message.subject).toBe("Template Subject");
+    expect(result.message.attachments).toEqual([{ filename: "original.doc" }]);
+  });
+
+  it("should handle template data correctly", async () => {
+    const payload = {
+      to: "test@example.com",
+      template: {
+        name: "template-with-data",
+        data: { name: "John" },
+      },
+    };
+
+    const result = await preparePayload(payload);
+
+    expect(result.message.html).toBe("<h1>Hello John</h1>");
+    expect(result.message.subject).toBe("Subject for John");
+  });
+
+  it("should handle string recipient addresses", async () => {
+    const payload = {
+      to: "test@example.com",
+      cc: "cc@example.com",
+      bcc: "bcc@example.com",
+      message: {
+        subject: "Test Subject",
+        html: "<p>Test HTML content</p>",
+      },
+    };
+
+    const result = await preparePayload(payload);
+
+    expect(result.to).toEqual(["test@example.com"]);
+    expect(result.cc).toEqual(["cc@example.com"]);
+    expect(result.bcc).toEqual(["bcc@example.com"]);
+  });
+
+  it("should handle array recipient addresses", async () => {
+    const payload = {
+      to: ["test1@example.com", "test2@example.com"],
+      cc: ["cc1@example.com", "cc2@example.com"],
+      bcc: ["bcc1@example.com", "bcc2@example.com"],
+      message: {
+        subject: "Test Subject",
+        html: "<p>Test HTML content</p>",
+      },
+    };
+
+    const result = await preparePayload(payload);
+
+    expect(result.to).toEqual(["test1@example.com", "test2@example.com"]);
+    expect(result.cc).toEqual(["cc1@example.com", "cc2@example.com"]);
+    expect(result.bcc).toEqual(["bcc1@example.com", "bcc2@example.com"]);
+  });
+
+  it("should handle message without template", async () => {
+    const payload = {
+      to: "test@example.com",
+      message: {
+        html: "<p>Direct HTML content</p>",
+        subject: "Direct Subject",
+      },
+    };
+
+    const result = await preparePayload(payload);
+
+    expect(result.message.html).toBe("<p>Direct HTML content</p>");
+    expect(result.message.subject).toBe("Direct Subject");
+  });
+
+  it("should handle empty message object", async () => {
+    const payload = {
+      to: "test@example.com",
+      message: {},
+    };
+
+    const result = await preparePayload(payload);
+
+    expect(result.message).toEqual({});
+  });
+});

--- a/firestore-send-email/functions/__tests__/validation.test.ts
+++ b/firestore-send-email/functions/__tests__/validation.test.ts
@@ -187,6 +187,17 @@ describe("validatePayload", () => {
       };
       expect(() => validatePayload(validPayload)).not.toThrow();
     });
+
+    it("should validate template without message object", () => {
+      const validPayload = {
+        to: "test@example.com",
+        template: {
+          name: "EGFMB64MzmVz0Or75ctL",
+          data: { userName: "cabljac", name: "jacob" },
+        },
+      };
+      expect(() => validatePayload(validPayload)).not.toThrow();
+    });
   });
 
   it("should validate a SendGrid payload with only mailSettings", () => {

--- a/firestore-send-email/functions/__tests__/validation.test.ts
+++ b/firestore-send-email/functions/__tests__/validation.test.ts
@@ -346,4 +346,266 @@ describe("validatePayload", () => {
       );
     });
   });
+
+  describe("attachment validation", () => {
+    describe("valid attachments", () => {
+      it("should validate plain text attachment", () => {
+        const validPayload = {
+          to: "test@example.com",
+          message: {
+            subject: "Test Subject",
+            text: "Test message",
+            attachments: [
+              {
+                filename: "hello.txt",
+                content: "Hello world!",
+              },
+            ],
+          },
+        };
+        expect(() => validatePayload(validPayload)).not.toThrow();
+      });
+
+      it("should validate binary buffer attachment", () => {
+        const validPayload = {
+          to: "test@example.com",
+          message: {
+            subject: "Test Subject",
+            text: "Test message",
+            attachments: [
+              {
+                filename: "buffer.txt",
+                content: Buffer.from("Hello world!", "utf8"),
+              },
+            ],
+          },
+        };
+        expect(() => validatePayload(validPayload)).not.toThrow();
+      });
+
+      it("should validate local file attachment", () => {
+        const validPayload = {
+          to: "test@example.com",
+          message: {
+            subject: "Test Subject",
+            text: "Test message",
+            attachments: [
+              {
+                filename: "report.pdf",
+                path: "/absolute/path/to/report.pdf",
+              },
+            ],
+          },
+        };
+        expect(() => validatePayload(validPayload)).not.toThrow();
+      });
+
+      it("should validate attachment with implicit filename", () => {
+        const validPayload = {
+          to: "test@example.com",
+          message: {
+            subject: "Test Subject",
+            text: "Test message",
+            attachments: [
+              {
+                path: "/absolute/path/to/image.png",
+              },
+            ],
+          },
+        };
+        expect(() => validatePayload(validPayload)).not.toThrow();
+      });
+
+      it("should validate attachment with custom content type", () => {
+        const validPayload = {
+          to: "test@example.com",
+          message: {
+            subject: "Test Subject",
+            text: "Test message",
+            attachments: [
+              {
+                filename: "data.bin",
+                content: Buffer.from("deadbeef", "hex"),
+                contentType: "application/octet-stream",
+              },
+            ],
+          },
+        };
+        expect(() => validatePayload(validPayload)).not.toThrow();
+      });
+
+      it("should validate remote file attachment", () => {
+        const validPayload = {
+          to: "test@example.com",
+          message: {
+            subject: "Test Subject",
+            text: "Test message",
+            attachments: [
+              {
+                filename: "license.txt",
+                href: "https://raw.githubusercontent.com/nodemailer/nodemailer/master/LICENSE",
+              },
+            ],
+          },
+        };
+        expect(() => validatePayload(validPayload)).not.toThrow();
+      });
+
+      it("should validate base64 encoded attachment", () => {
+        const validPayload = {
+          to: "test@example.com",
+          message: {
+            subject: "Test Subject",
+            text: "Test message",
+            attachments: [
+              {
+                filename: "photo.jpg",
+                content: "/9j/4AAQSkZJRgABAQAAAQABAAD…",
+                encoding: "base64",
+              },
+            ],
+          },
+        };
+        expect(() => validatePayload(validPayload)).not.toThrow();
+      });
+
+      it("should validate data URI attachment", () => {
+        const validPayload = {
+          to: "test@example.com",
+          message: {
+            subject: "Test Subject",
+            text: "Test message",
+            attachments: [
+              {
+                path: "data:text/plain;base64,SGVsbG8gd29ybGQ=",
+              },
+            ],
+          },
+        };
+        expect(() => validatePayload(validPayload)).not.toThrow();
+      });
+
+      it("should validate pre-built MIME node attachment", () => {
+        const validPayload = {
+          to: "test@example.com",
+          message: {
+            subject: "Test Subject",
+            text: "Test message",
+            attachments: [
+              {
+                raw: [
+                  "Content-Type: text/plain; charset=utf-8",
+                  'Content-Disposition: attachment; filename="greeting.txt"',
+                  "",
+                  "Hello world!",
+                ].join("\r\n"),
+              },
+            ],
+          },
+        };
+        expect(() => validatePayload(validPayload)).not.toThrow();
+      });
+
+      it("should validate embedded image attachment", () => {
+        const validPayload = {
+          to: "test@example.com",
+          message: {
+            subject: "Test Subject",
+            html: '<p><img src="cid:logo@nodemailer" alt="Nodemailer logo"></p>',
+            attachments: [
+              {
+                filename: "logo.png",
+                path: "./assets/logo.png",
+                cid: "logo@nodemailer",
+              },
+            ],
+          },
+        };
+        expect(() => validatePayload(validPayload)).not.toThrow();
+      });
+
+      it("should validate multiple attachments", () => {
+        const validPayload = {
+          to: "test@example.com",
+          message: {
+            subject: "Test Subject",
+            text: "Test message",
+            attachments: [
+              {
+                filename: "file1.txt",
+                content: "Content 1",
+              },
+              {
+                filename: "file2.txt",
+                content: "Content 2",
+              },
+            ],
+          },
+        };
+        expect(() => validatePayload(validPayload)).not.toThrow();
+      });
+    });
+
+    describe("invalid attachments", () => {
+      it("should throw error for invalid httpHeaders type", () => {
+        const invalidPayload = {
+          to: "test@example.com",
+          message: {
+            subject: "Test Subject",
+            text: "Test message",
+            attachments: [
+              {
+                filename: "test.txt",
+                href: "https://example.com",
+                httpHeaders: "not-an-object",
+              },
+            ],
+          },
+        };
+        expect(() => validatePayload(invalidPayload)).toThrow(ValidationError);
+        expect(() => validatePayload(invalidPayload)).toThrow(
+          "Invalid message configuration: Field 'message.attachments.0.httpHeaders' must be a map"
+        );
+      });
+
+      it("should throw error for invalid headers type", () => {
+        const invalidPayload = {
+          to: "test@example.com",
+          message: {
+            subject: "Test Subject",
+            text: "Test message",
+            attachments: [
+              {
+                filename: "test.txt",
+                content: "test",
+                headers: "not-an-object",
+              },
+            ],
+          },
+        };
+        expect(() => validatePayload(invalidPayload)).toThrow(ValidationError);
+        expect(() => validatePayload(invalidPayload)).toThrow(
+          "Invalid message configuration: Field 'message.attachments.0.headers' must be a map"
+        );
+      });
+
+      it("should throw error for non-array attachments", () => {
+        const invalidPayload = {
+          to: "test@example.com",
+          message: {
+            subject: "Test Subject",
+            text: "Test message",
+            attachments: {
+              filename: "test.txt",
+              content: "test",
+            },
+          },
+        };
+        expect(() => validatePayload(invalidPayload)).toThrow(ValidationError);
+        expect(() => validatePayload(invalidPayload)).toThrow(
+          "Invalid message configuration: Field 'message.attachments' must be an array"
+        );
+      });
+    });
+  });
 });

--- a/firestore-send-email/functions/jest.config.js
+++ b/firestore-send-email/functions/jest.config.js
@@ -17,6 +17,13 @@ module.exports = {
   setupFiles: ["<rootDir>/__tests__/jest.setup.ts"],
   testMatch: ["**/__tests__/**/*.test.ts"],
   testEnvironment: "node",
+  collectCoverageFrom: [
+    "src/**/*.{js,ts}",
+    "!src/**/*.d.ts",
+    "!**/__tests__/**",
+  ],
+  coverageDirectory: "coverage",
+  coverageReporters: ["text", "lcov", "html"],
   moduleNameMapper: {
     "firebase-admin/app": "<rootDir>/node_modules/firebase-admin/lib/app",
     "firebase-admin/eventarc":

--- a/firestore-send-email/functions/package.json
+++ b/firestore-send-email/functions/package.json
@@ -14,6 +14,7 @@
     "test:local": "concurrently --kill-others \"npm run local:emulator\" \"npm run testIfEmulatorRunning\"",
     "test:watch": "concurrently \"npm run local:emulator\" \"jest --watch\"",
     "test:coverage": "concurrently --kill-others \"npm run local:emulator\" \"wait-on tcp:4001 && jest --coverage\"",
+    "test:e2e:sendgrid": "E2E_SENDGRID=true jest __tests__/e2e/sendgrid.test.ts",
     "generate-readme": "firebase ext:info .. --markdown > ../README.md"
   },
   "keywords": [],

--- a/firestore-send-email/functions/package.json
+++ b/firestore-send-email/functions/package.json
@@ -13,6 +13,7 @@
     "testIfEmulatorRunning": "wait-on tcp:4001 && jest",
     "test:local": "concurrently --kill-others \"npm run local:emulator\" \"npm run testIfEmulatorRunning\"",
     "test:watch": "concurrently \"npm run local:emulator\" \"jest --watch\"",
+    "test:coverage": "concurrently --kill-others \"npm run local:emulator\" \"wait-on tcp:4001 && jest --coverage\"",
     "generate-readme": "firebase ext:info .. --markdown > ../README.md"
   },
   "keywords": [],

--- a/firestore-send-email/functions/src/prepare-payload.ts
+++ b/firestore-send-email/functions/src/prepare-payload.ts
@@ -1,7 +1,12 @@
 import { DocumentData } from "firebase-admin/firestore";
-import { validatePayload } from "./validation";
+import {
+  validatePayload,
+  attachmentSchema,
+  attachmentsSchema,
+} from "./validation";
 import * as logs from "./logs";
 import config from "./config";
+import { z } from "zod";
 
 let db: any;
 let templates: any;
@@ -36,9 +41,11 @@ export async function preparePayload(
     const templateRender = await templates.render(template.name, template.data);
     const mergeMessage = payload.message || {};
 
-    const attachments = templateRender.attachments
-      ? templateRender.attachments
-      : mergeMessage.attachments;
+    let attachments = attachmentsSchema.parse(
+      templateRender.attachments
+        ? templateRender.attachments
+        : mergeMessage.attachments
+    );
 
     const handleTemplateValue = (value: any) => {
       if (value === null) {

--- a/firestore-send-email/functions/src/prepare-payload.ts
+++ b/firestore-send-email/functions/src/prepare-payload.ts
@@ -1,0 +1,167 @@
+import { DocumentData } from "firebase-admin/firestore";
+import { validatePayload } from "./validation";
+import * as logs from "./logs";
+import config from "./config";
+
+let db: any;
+let templates: any;
+
+export function setDependencies(database: any, templatesInstance: any) {
+  db = database;
+  templates = templatesInstance;
+}
+
+function validateFieldArray(field: string, array?: string[]) {
+  if (!Array.isArray(array)) {
+    throw new Error(`Invalid field "${field}". Expected an array of strings.`);
+  }
+
+  if (array.find((item) => typeof item !== "string")) {
+    throw new Error(`Invalid field "${field}". Expected an array of strings.`);
+  }
+}
+
+export async function preparePayload(
+  payload: DocumentData
+): Promise<DocumentData> {
+  // Validate the payload before processing
+  validatePayload(payload);
+
+  const { template } = payload;
+
+  if (templates && template) {
+    if (!template.name) {
+      throw new Error(`Template object is missing a 'name' parameter.`);
+    }
+
+    const templateRender = await templates.render(template.name, template.data);
+
+    const mergeMessage = payload.message || {};
+
+    const attachments = templateRender.attachments
+      ? templateRender.attachments
+      : mergeMessage.attachments;
+
+    payload.message = Object.assign(mergeMessage, templateRender, {
+      attachments: attachments || [],
+    });
+  }
+
+  let to: string[] = [];
+  let cc: string[] = [];
+  let bcc: string[] = [];
+
+  if (typeof payload.to === "string") {
+    to = [payload.to];
+  } else if (payload.to) {
+    validateFieldArray("to", payload.to);
+    to = to.concat(payload.to);
+  }
+
+  if (typeof payload.cc === "string") {
+    cc = [payload.cc];
+  } else if (payload.cc) {
+    validateFieldArray("cc", payload.cc);
+    cc = cc.concat(payload.cc);
+  }
+
+  if (typeof payload.bcc === "string") {
+    bcc = [payload.bcc];
+  } else if (payload.bcc) {
+    validateFieldArray("bcc", payload.bcc);
+    bcc = bcc.concat(payload.bcc);
+  }
+
+  if (!payload.toUids && !payload.ccUids && !payload.bccUids) {
+    payload.to = to;
+    payload.cc = cc;
+    payload.bcc = bcc;
+    return payload;
+  }
+
+  if (!config.usersCollection) {
+    throw new Error("Must specify a users collection to send using uids.");
+  }
+
+  let uids: string[] = [];
+
+  if (payload.toUids) {
+    validateFieldArray("toUids", payload.toUids);
+    uids = uids.concat(payload.toUids);
+  }
+
+  if (payload.ccUids) {
+    validateFieldArray("ccUids", payload.ccUids);
+    uids = uids.concat(payload.ccUids);
+  }
+
+  if (payload.bccUids) {
+    validateFieldArray("bccUids", payload.bccUids);
+    uids = uids.concat(payload.bccUids);
+  }
+
+  const toFetch: Record<string, string | null> = {};
+  uids.forEach((uid) => (toFetch[uid] = null));
+
+  const documents = await db.getAll(
+    ...Object.keys(toFetch).map((uid) =>
+      db.collection(config.usersCollection).doc(uid)
+    ),
+    {
+      fieldMask: ["email"],
+    }
+  );
+
+  const missingUids: string[] = [];
+
+  documents.forEach((documentSnapshot) => {
+    if (documentSnapshot.exists) {
+      const email = documentSnapshot.get("email");
+
+      if (email) {
+        toFetch[documentSnapshot.id] = email;
+      } else {
+        missingUids.push(documentSnapshot.id);
+      }
+    } else {
+      missingUids.push(documentSnapshot.id);
+    }
+  });
+
+  logs.missingUids(missingUids);
+
+  if (payload.toUids) {
+    payload.toUids.forEach((uid) => {
+      const email = toFetch[uid];
+      if (email) {
+        to.push(email);
+      }
+    });
+  }
+
+  payload.to = to;
+
+  if (payload.ccUids) {
+    payload.ccUids.forEach((uid) => {
+      const email = toFetch[uid];
+      if (email) {
+        cc.push(email);
+      }
+    });
+  }
+
+  payload.cc = cc;
+
+  if (payload.bccUids) {
+    payload.bccUids.forEach((uid) => {
+      const email = toFetch[uid];
+      if (email) {
+        bcc.push(email);
+      }
+    });
+  }
+
+  payload.bcc = bcc;
+
+  return payload;
+}

--- a/firestore-send-email/functions/src/prepare-payload.ts
+++ b/firestore-send-email/functions/src/prepare-payload.ts
@@ -24,33 +24,73 @@ function validateFieldArray(field: string, array?: string[]) {
 export async function preparePayload(
   payload: DocumentData
 ): Promise<DocumentData> {
+  console.log("Step 1: Starting preparePayload with payload:", payload);
+
   // Validate the payload before processing
+  console.log("Step 2: Validating payload");
   validatePayload(payload);
 
   const { template } = payload;
+  console.log("Step 3: Template from payload:", template);
+  console.log("Step 4: Templates instance exists:", !!templates);
 
   if (templates && template) {
+    console.log("Step 5: Processing template");
+
     if (!template.name) {
       throw new Error(`Template object is missing a 'name' parameter.`);
     }
 
+    console.log("Step 6: Rendering template:", template.name);
     const templateRender = await templates.render(template.name, template.data);
+    console.log("Step 7: Template render result:", templateRender);
 
     const mergeMessage = payload.message || {};
+    console.log("Step 8: Message to merge with:", mergeMessage);
 
     const attachments = templateRender.attachments
       ? templateRender.attachments
       : mergeMessage.attachments;
 
-    payload.message = Object.assign(mergeMessage, templateRender, {
+    // Helper function to handle null/empty string logic
+    const handleTemplateValue = (value: any) => {
+      if (value === null) {
+        return undefined; // null means don't include the property
+      }
+      if (value === "") {
+        return ""; // Empty string is preserved
+      }
+      if (value === undefined) {
+        return undefined; // undefined means don't overwrite
+      }
+      return value || undefined; // For other falsy values, convert to undefined
+    };
+
+    // Only include values that should be applied from templateRender
+    const templateContent = {
+      subject: handleTemplateValue(templateRender.subject),
+      html: handleTemplateValue(templateRender.html),
+      text: handleTemplateValue(templateRender.text),
+      amp: handleTemplateValue(templateRender.amp),
       attachments: attachments || [],
+    };
+
+    // Remove undefined values to prevent Object.assign from overwriting
+    Object.keys(templateContent).forEach((key) => {
+      if (templateContent[key] === undefined) {
+        delete templateContent[key];
+      }
     });
+
+    payload.message = Object.assign(mergeMessage, templateContent);
+    console.log("Step 9: Merged message result:", payload.message);
   }
 
   let to: string[] = [];
   let cc: string[] = [];
   let bcc: string[] = [];
 
+  console.log("Step 10: Processing recipient addresses");
   if (typeof payload.to === "string") {
     to = [payload.to];
   } else if (payload.to) {
@@ -72,7 +112,10 @@ export async function preparePayload(
     bcc = bcc.concat(payload.bcc);
   }
 
+  console.log("Step 11: Processed recipients:", { to, cc, bcc });
+
   if (!payload.toUids && !payload.ccUids && !payload.bccUids) {
+    console.log("Step 12: No UIDs to process, returning with direct addresses");
     payload.to = to;
     payload.cc = cc;
     payload.bcc = bcc;
@@ -100,9 +143,12 @@ export async function preparePayload(
     uids = uids.concat(payload.bccUids);
   }
 
+  console.log("Step 13: Processing UIDs:", uids);
+
   const toFetch: Record<string, string | null> = {};
   uids.forEach((uid) => (toFetch[uid] = null));
 
+  console.log("Step 14: Fetching user documents");
   const documents = await db.getAll(
     ...Object.keys(toFetch).map((uid) =>
       db.collection(config.usersCollection).doc(uid)
@@ -128,6 +174,10 @@ export async function preparePayload(
     }
   });
 
+  console.log("Step 15: User document fetch results:", {
+    toFetch,
+    missingUids,
+  });
   logs.missingUids(missingUids);
 
   if (payload.toUids) {
@@ -162,6 +212,8 @@ export async function preparePayload(
   }
 
   payload.bcc = bcc;
+
+  console.log("Step 16: Final payload:", payload);
 
   return payload;
 }

--- a/firestore-send-email/functions/src/validation.ts
+++ b/firestore-send-email/functions/src/validation.ts
@@ -66,8 +66,8 @@ export const attachmentsSchema = z
  */
 const baseMessageSchema = z.object({
   subject: z.string().optional(),
-  text: z.string().optional(),
-  html: z.string().optional(),
+  text: z.string().nullable().optional(),
+  html: z.string().nullable().optional(),
   attachments: attachmentsSchema,
 });
 

--- a/firestore-send-email/functions/src/validation.ts
+++ b/firestore-send-email/functions/src/validation.ts
@@ -12,13 +12,63 @@ export class ValidationError extends Error {
 }
 
 /**
+ * Schema for email attachments
+ */
+export const attachmentSchema = z
+  .object({
+    filename: z.string().nullable().optional(),
+    content: z
+      .union([z.string(), z.instanceof(Buffer), z.any()])
+      .nullable()
+      .optional(), // Stream type is handled as any
+    path: z.string().nullable().optional(),
+    href: z.string().nullable().optional(),
+    httpHeaders: z.record(z.string()).nullable().optional(),
+    contentType: z.string().nullable().optional(),
+    contentDisposition: z.string().nullable().optional(),
+    cid: z.string().nullable().optional(),
+    encoding: z.string().nullable().optional(),
+    headers: z.record(z.string()).nullable().optional(),
+    raw: z.string().nullable().optional(),
+  })
+  .passthrough()
+  .transform((data) => {
+    // Only keep properties that are defined in the schema
+    const validKeys = [
+      "filename",
+      "content",
+      "path",
+      "href",
+      "httpHeaders",
+      "contentType",
+      "contentDisposition",
+      "cid",
+      "encoding",
+      "headers",
+      "raw",
+    ];
+    return Object.fromEntries(
+      Object.entries(data).filter(([key]) => validKeys.includes(key))
+    );
+  });
+
+export const attachmentsSchema = z
+  .array(attachmentSchema)
+  .optional()
+  .transform((attachments) =>
+    attachments
+      ? attachments.filter((attachment) => Object.keys(attachment).length > 0)
+      : undefined
+  );
+
+/**
  * Base schema for email message content.
  */
 const baseMessageSchema = z.object({
   subject: z.string().optional(),
   text: z.string().optional(),
   html: z.string().optional(),
-  attachments: z.array(z.any()).optional(),
+  attachments: attachmentsSchema,
 });
 
 /**


### PR DESCRIPTION
This PR is to actually fix https://github.com/firebase/extensions/issues/2419

We extract preparePayload into a dependency injection pattern, and cover it with unit tests, and ensure template/message merging is being done correctly