### PR TITLE
fix(firestore-send-email) restore headers support

### DIFF
--- a/firestore-send-email/CHANGELOG.md
+++ b/firestore-send-email/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Version 0.2.5
+
+fix: add missing 'headers' field to the mailOptions interface
+
+docs: update documentation to include 'headers' field
+
 ## Version 0.2.4
 
 fix: TTL expire type "week" fixed (#2455)

--- a/firestore-send-email/PREINSTALL.md
+++ b/firestore-send-email/PREINSTALL.md
@@ -18,6 +18,29 @@ You can also optionally configure this extension to render emails using [Handleb
 
 When you configure this extension, you'll need to supply your **SMTP credentials for mail delivery**. Note that this extension is for use with bulk email service providers, like SendGrid, Mailgun, etc.
 
+#### Using custom headers
+
+You can add custom headers to your emails by including a `headers` field in the document you add to the Firestore collection. The `headers` field should be an object where each key is the header name and the value is the header value.
+
+## Example JSON with Custom Headers:
+```json
+{
+  "to": ["example@example.com"],
+  "message": {
+    "subject": "Test Email with Custom Headers",
+    "text": "This is a test email to see if custom headers work.",
+    "html": "<strong>This is a test email to see if custom headers work.</strong>"
+  },
+  "headers": {
+    "X-Custom-Header": "CustomValue",
+    "X-Another-Header": "AnotherValue",
+  }
+}
+```
+
+Add this document to the Firestore mail collection to send an email with custom headers.
+You can even include headers like 'List-Unsubscribe' to allow recipients to unsubscribe from your emails.
+
 #### Firestore-Send-Email: SendGrid Categories
 
 When using SendGrid (`SMTP_CONNECTION_URI` includes `sendgrid.net`), you can assign categories to your emails.

--- a/firestore-send-email/README.md
+++ b/firestore-send-email/README.md
@@ -49,7 +49,6 @@ You can add custom headers to your emails by including a `headers` field in the 
 Add this document to the Firestore mail collection to send an email with custom headers.
 You can even include headers like 'List-Unsubscribe' to allow recipients to unsubscribe from your emails.
 
-
 #### Firestore-Send-Email: SendGrid Categories
 
 When using SendGrid (`SMTP_CONNECTION_URI` includes `sendgrid.net`), you can assign categories to your emails.

--- a/firestore-send-email/README.md
+++ b/firestore-send-email/README.md
@@ -26,6 +26,30 @@ You can also optionally configure this extension to render emails using [Handleb
 
 When you configure this extension, you'll need to supply your **SMTP credentials for mail delivery**. Note that this extension is for use with bulk email service providers, like SendGrid, Mailgun, etc.
 
+#### Using custom headers
+
+You can add custom headers to your emails by including a `headers` field in the document you add to the Firestore collection. The `headers` field should be an object where each key is the header name and the value is the header value.
+
+## Example JSON with Custom Headers:
+```json
+{
+  "to": ["example@example.com"],
+  "message": {
+    "subject": "Test Email with Custom Headers",
+    "text": "This is a test email to see if custom headers work.",
+    "html": "<strong>This is a test email to see if custom headers work.</strong>"
+  },
+  "headers": {
+    "X-Custom-Header": "CustomValue",
+    "X-Another-Header": "AnotherValue",
+  }
+}
+```
+
+Add this document to the Firestore mail collection to send an email with custom headers.
+You can even include headers like 'List-Unsubscribe' to allow recipients to unsubscribe from your emails.
+
+
 #### Firestore-Send-Email: SendGrid Categories
 
 When using SendGrid (`SMTP_CONNECTION_URI` includes `sendgrid.net`), you can assign categories to your emails.

--- a/firestore-send-email/functions/src/index.ts
+++ b/firestore-send-email/functions/src/index.ts
@@ -173,6 +173,7 @@ async function deliver(ref: DocumentReference): Promise<void> {
       subject: payload.message?.subject,
       text: payload.message?.text,
       html: payload.message?.html,
+      headers: payload?.headers,
       attachments: payload.message?.attachments,
       categories: payload.categories,
       templateId: payload.sendGrid?.templateId,


### PR DESCRIPTION
I just noticed that this feature was removed, and wanted to contribute a quick fix.