### PR TITLE
feat(firestore-bigquery-exports) add an option to skip BigQuery init steps

### DIFF
--- a/firestore-bigquery-export/scripts/import/src/config.ts
+++ b/firestore-bigquery-export/scripts/import/src/config.ts
@@ -197,6 +197,12 @@ const questions = [
     name: "failedBatchOutput",
     type: "input",
   },
+  {
+    message: "Would you like to skip BigQuery init steps?",
+    name: "skipInit",
+    type: "confirm",
+    default: false,
+  },
 ];
 
 export async function parseConfig(): Promise<CliConfig | CliConfigError> {
@@ -270,6 +276,7 @@ export async function parseConfig(): Promise<CliConfig | CliConfigError> {
       rawChangeLogName,
       cursorPositionFile,
       failedBatchOutput: program.failedBatchOutput,
+      skipInit: program.skipInit,
     };
   }
   const {
@@ -285,6 +292,7 @@ export async function parseConfig(): Promise<CliConfig | CliConfigError> {
     useNewSnapshotQuerySyntax,
     useEmulator,
     failedBatchOutput,
+    skipInit,
   } = await inquirer.prompt(questions);
 
   const rawChangeLogName = `${table}_raw_changelog`;
@@ -311,6 +319,7 @@ export async function parseConfig(): Promise<CliConfig | CliConfigError> {
     rawChangeLogName,
     cursorPositionFile,
     failedBatchOutput,
+    skipInit,
   };
 }
 

--- a/firestore-bigquery-export/scripts/import/src/index.ts
+++ b/firestore-bigquery-export/scripts/import/src/index.ts
@@ -82,9 +82,12 @@ const run = async (): Promise<number> => {
     useNewSnapshotQuerySyntax,
     bqProjectId: bigQueryProjectId,
     transformFunction: config.transformFunctionUrl,
+    skipInit: config.skipInit,
   });
 
-  await initializeDataSink(dataSink, config);
+  if (!config.skipInit) {
+    await initializeDataSink(dataSink, config);
+  }
 
   logs.importingData(config);
   if (multiThreaded && queryCollectionGroup) {

--- a/firestore-bigquery-export/scripts/import/src/program.ts
+++ b/firestore-bigquery-export/scripts/import/src/program.ts
@@ -65,5 +65,9 @@ export const getCLIOptions = () => {
     .option(
       "-f, --failed-batch-output <file>",
       "Path to the JSON file where failed batches will be recorded."
+    )
+    .option(
+      "--skip-init [true|false]",
+      "Whether to skip BigQuery init steps."
     );
 };

--- a/firestore-bigquery-export/scripts/import/src/types.ts
+++ b/firestore-bigquery-export/scripts/import/src/types.ts
@@ -17,6 +17,7 @@ export interface CliConfig {
   cursorPositionFile: string;
   failedBatchOutput?: string;
   transformFunctionUrl?: string;
+  skipInit: boolean;
 }
 
 export interface CliConfigError {


### PR DESCRIPTION
This feature would solve this issue: https://github.com/firebase/extensions/issues/2468

When running backfill command with `@firebaseextensions/fs-bq-import-collection`, there is no reason to alter existing BigQuery table or view, when everything is working fine.

This MR adds an option `--skip-init` to skip those steps (alterning clustering / partitionning of the raw_changelog, creating the latest view).