### PR TITLE
storage-resize-images: prevent double trigger by honoring resizedImage flag (string or boolean)

### DIFF
--- a/storage-resize-images/functions/__tests__/filters.test.ts
+++ b/storage-resize-images/functions/__tests__/filters.test.ts
@@ -99,7 +99,8 @@ describe("shouldResize function", () => {
 
   describe("Metadata Checks", () => {
     test.each([
-      ["already resized", { resizedImage: "true" }, logs.imageAlreadyResized],
+      ["already resized (string)", { resizedImage: "true" }, logs.imageAlreadyResized],
+      ["already resized (boolean)", { resizedImage: true }, logs.imageAlreadyResized],
       [
         "resizing failed previously",
         { resizeFailed: true },

--- a/storage-resize-images/functions/src/filters.ts
+++ b/storage-resize-images/functions/src/filters.ts
@@ -50,7 +50,14 @@ export function shouldResize(object: ObjectMetadata): boolean {
     return false;
   }
 
-  if (object.metadata && object.metadata.resizedImage === "true") {
+  // Skip if this is a resized image we created previously. Some uploads may
+  // store custom metadata as a boolean (true) rather than string "true",
+  // so handle both to ensure idempotence.
+  if (
+    object.metadata &&
+    (object.metadata.resizedImage === "true" ||
+      (object.metadata as any).resizedImage === true)
+  ) {
     logs.imageAlreadyResized();
     return false;
   }

--- a/storage-resize-images/functions/src/resize-image.ts
+++ b/storage-resize-images/functions/src/resize-image.ts
@@ -190,7 +190,9 @@ export const constructMetadata = (
     contentType: imageContentType,
     metadata: objectMetadata.metadata ? { ...objectMetadata.metadata } : {},
   };
-  metadata.metadata.resizedImage = true;
+  // Mark resized images so the function can skip re-processing on finalize.
+  // Use string "true" for consistency with existing checks and metadata conventions.
+  metadata.metadata.resizedImage = "true";
   if (config.cacheControlHeader) {
     metadata.cacheControl = config.cacheControlHeader;
   } else {


### PR DESCRIPTION
The `storage-resize-images` function could run twice for a single upload if the resized outputs re-triggered the function. This happens when `resizedImage` custom metadata is stored as a boolean `true` while the filter only checked for the string "true".

Changes
- filters: treat `metadata.resizedImage === true` or `"true"` as already-resized to short‑circuit early.
- upload: set `resizedImage` metadata to string "true" for consistency with existing expectations.
- tests: add coverage for the boolean variant in metadata checks.

Why
- Cloud Storage custom metadata can arrive as a boolean or a string; handling both ensures idempotence and prevents reprocessing outputs.

Fixes #932.
