### PR TITLE
fix!(storage-resize-images): disable backfill

### DIFF
--- a/storage-resize-images/CHANGELOG.md
+++ b/storage-resize-images/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.3.0
+
+fix! - remove backfill feature
+
 ## Version 0.2.10
 
 feat - added param for adjusting backfill max batch size

--- a/storage-resize-images/README.md
+++ b/storage-resize-images/README.md
@@ -182,13 +182,6 @@ Leave this field empty if you do not want to store failed images in a separate d
 
 * Cloud Function memory: Memory of the function responsible of resizing images.  Choose how much memory to give to the function that resize images. (For animated GIF => GIF we recommend using a minimum of 2GB).
 
-* Backfill existing images: Should existing, unresized images in the Storage bucket be resized as well?
-
-
-* Backfill batch size: The maximum number of images to resize in a single batch. By default, the function is configured to resize 3 images at a time. This is a conservative default to work with smallest memory option (512 MB).
-WARNING: Ensure your function has enough memory to handle the batch size.
-
-
 * Assign new access token: Should resized images have a new access token assigned to them,  different from the original image?
 
 
@@ -206,8 +199,6 @@ WARNING: Ensure your function has enough memory to handle the batch size.
 **Cloud Functions:**
 
 * **generateResizedImage:** Listens for new images uploaded to your specified Cloud Storage bucket, resizes the images, then stores the resized images in the same bucket. Optionally keeps or deletes the original images.
-
-* **backfillResizedImages:** Handles tasks from startBackfill to resize existing images.
 
 
 

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: storage-resize-images
-version: 0.2.10
+version: 0.3.10
 specVersion: v1beta
 
 displayName: Resize Images
@@ -65,14 +65,15 @@ resources:
       eventTrigger:
         eventType: google.storage.object.finalize
         resource: projects/_/buckets/${param:IMG_BUCKET}
-  - name: backfillResizedImages
-    type: firebaseextensions.v1beta.function
-    description: >-
-      Handles tasks from startBackfill to resize existing images.
-    properties:
-      runtime: nodejs20
-      availableMemoryMb: ${param:FUNCTION_MEMORY}
-      taskQueueTrigger: {}
+  # Backfill feature disabled - commented out to preserve code
+  # - name: backfillResizedImages
+  #   type: firebaseextensions.v1beta.function
+  #   description: >-
+  #     Handles tasks from startBackfill to resize existing images.
+  #   properties:
+  #     runtime: nodejs20
+  #     availableMemoryMb: ${param:FUNCTION_MEMORY}
+  #     taskQueueTrigger: {}
 
 params:
   - param: IMG_BUCKET
@@ -316,32 +317,33 @@ params:
     required: true
     immutable: false
 
-  - param: DO_BACKFILL
-    label: Backfill existing images
-    description: >
-      Should existing, unresized images in the Storage bucket be resized as
-      well?
-    type: select
-    required: true
-    options:
-      - label: Yes
-        value: true
-      - label: No
-        value: false
+  # Backfill parameters disabled - commented out to preserve code
+  # - param: DO_BACKFILL
+  #   label: Backfill existing images
+  #   description: >
+  #     Should existing, unresized images in the Storage bucket be resized as
+  #     well?
+  #   type: select
+  #   required: true
+  #   options:
+  #     - label: Yes
+  #       value: true
+  #     - label: No
+  #       value: false
 
-  - param: BACKFILL_BATCH_SIZE
-    label: Backfill batch size
-    description: >
-      The maximum number of images to resize in a single batch. By default, the
-      function is configured to resize 3 images at a time. This is a
-      conservative default to work with smallest memory option (512 MB).
-
-      WARNING: Ensure your function has enough memory to handle the batch size.
-    type: string
-    default: 3
-    validationRegex: ^[1-9][0-9]*$
-    validationErrorMessage: Please provide a valid number.
-    required: false
+  # - param: BACKFILL_BATCH_SIZE
+  #   label: Backfill batch size
+  #   description: >
+  #     The maximum number of images to resize in a single batch. By default, the
+  #     function is configured to resize 3 images at a time. This is a
+  #     conservative default to work with smallest memory option (512 MB).
+  #
+  #     WARNING: Ensure your function has enough memory to handle the batch size.
+  #   type: string
+  #   default: 3
+  #   validationRegex: ^[1-9][0-9]*$
+  #   validationErrorMessage: Please provide a valid number.
+  #   required: false
 
   - param: REGENERATE_TOKEN
     label: Assign new access token
@@ -426,14 +428,14 @@ events:
     description:
       Occurs when the function is settled. Provides no customized data other
       than the context.
-
-lifecycleEvents:
-  onInstall:
-    function: backfillResizedImages
-    processingMessage: Resizing existing images in ${param:IMG_BUCKET}
-  onUpdate:
-    function: backfillResizedImages
-    processingMessage: Resizing existing images in ${param:IMG_BUCKET}
-  onConfigure:
-    function: backfillResizedImages
-    processingMessage: Resizing existing images in ${param:IMG_BUCKET}
+# Lifecycle events disabled - backfill feature commented out
+# lifecycleEvents:
+#   onInstall:
+#     function: backfillResizedImages
+#     processingMessage: Resizing existing images in ${param:IMG_BUCKET}
+#   onUpdate:
+#     function: backfillResizedImages
+#     processingMessage: Resizing existing images in ${param:IMG_BUCKET}
+#   onConfigure:
+#     function: backfillResizedImages
+#     processingMessage: Resizing existing images in ${param:IMG_BUCKET}

--- a/storage-resize-images/functions/src/config.ts
+++ b/storage-resize-images/functions/src/config.ts
@@ -68,7 +68,8 @@ export const convertHarmBlockThreshold: (
 export const config = {
   bucket: process.env.IMG_BUCKET,
   cacheControlHeader: process.env.CACHE_CONTROL_HEADER,
-  doBackfill: process.env.DO_BACKFILL === "true",
+  // Backfill feature disabled - commented out to preserve code
+  // doBackfill: process.env.DO_BACKFILL === "true",
   imageSizes: process.env.IMG_SIZES.split(","),
   regenerateToken: process.env.REGENERATE_TOKEN == "true",
   makePublic: process.env.MAKE_PUBLIC === "true",
@@ -88,7 +89,7 @@ export const config = {
   ),
   customFilterPrompt: process.env.CUSTOM_FILTER_PROMPT || null,
   placeholderImagePath: process.env.PLACEHOLDER_IMAGE_PATH || null,
-  backfillBatchSize: Number(process.env.BACKFILL_BATCH_SIZE) || 3,
+  // backfillBatchSize: Number(process.env.BACKFILL_BATCH_SIZE) || 3,
 };
 
 export type Config = typeof config;


### PR DESCRIPTION
This PR disables the backfill feature of storage-resize-images, to prevent issues like https://github.com/firebase/extensions/issues/2506

After investigation, we believe the created thread of Cloud Tasks could be branching, leading to non-linear growth of the queue, and the extension functions attempting to process images that have already been resized.

We have not been able to reproduce this directly, but this draft PR is a preventative step.