### PR TITLE
Update extension.yaml

### DIFF
--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -69,7 +69,7 @@ resources:
           - attribute: database
             value: ${DATABASE}
           - attribute: document
-            value: ${COLLECTION_PATH}/{documentId}
+            value: "${COLLECTION_PATH}/{documentId}"
             operator: match-path-pattern
 
   - name: syncBigQuery


### PR DESCRIPTION
Fix for {wildcard}:
- When COLLECTION_PATH is {wildcard}, it renders as: value: {wildcard}/{documentId}
- YAML interprets {wildcard} as a flow mapping (like a dictionary). The fix is literally just adding quotes: value: "${COLLECTION_PATH}/{documentId}"