### PR TITLE
chore(dependabot): merge all minor and patch updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "CorieW"
+      - "cabljac"
+      - "HassanBahati"
+    labels:
+      - "dependencies"
+      - "automated"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,16 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/"
+      - "/delete-user-data"
+      - "/firestore-bigquery-export"
+      - "/firestore-counter"
+      - "/firestore-send-email"
+      - "/firestore-shorten-urls-bitly"
+      - "/firestore-translate-text"
+      - "/rtdb-limit-child-nodes"
+      - "/storage-resize-images"
     schedule:
       interval: "weekly"
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    reviewers:
-      - "CorieW"
-      - "cabljac"
-      - "HassanBahati"
     labels:
       - "dependencies"
       - "automated"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/**"
     schedule:
       interval: "weekly"
     labels:


### PR DESCRIPTION
Instead of having a bunch of PRs such as:
- https://github.com/firebase/extensions/pull/2622
- https://github.com/firebase/extensions/pull/2629
- https://github.com/firebase/extensions/pull/2625

It consolidates the updates into a single PR, for example like [this](https://github.com/GoogleCloudPlatform/firebase-extensions/pull/849).