### PR TITLE
docs: Remove documentation section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,3 @@ You can also browse official Firebase extensions from the following sources:
 * [Firebase Extensions product page](https://firebase.google.com/products/extensions)
 * [Firebase Extensions dashboard](https://console.firebase.google.com/project/_/extensions/) in the Firebase console
 You can also browse official Firebase extensions on the [Extensions Marketplace](https://extensions.dev).
-
-## Documentation
-
-Documentation for the [Extensions by Firebase](https://firebase.google.com/docs/extensions) section are now stored in this repository.
-
-They can be found under [Docs](https://github.com/firebase/extensions/tree/master/docs)


### PR DESCRIPTION
Removed documentation section from README. These docs are very old, no sense pointing to them right now.

This should also re-trigger the release pipeline