### PR TITLE
fix(firestore-bigquery-export): fix tests

### DIFF
--- a/firestore-bigquery-export/functions/__tests__/functions.test.ts
+++ b/firestore-bigquery-export/functions/__tests__/functions.test.ts
@@ -74,11 +74,12 @@ const defaultEnvironment = {
 let restoreEnv;
 let functionsTest;
 
-/** Helper to Mock Export */
-const mockExport = (document, data) => {
+/** Helper to Mock Export - v2 onDocumentWritten expects event with .data = Change (before/after) */
+const mockExport = (documentChange, context) => {
   const ref = require("../src/index").fsexportbigquery;
   const wrapped = functionsTest.wrap(ref);
-  return wrapped(document, data);
+  const event = { data: documentChange, ...context };
+  return wrapped(event);
 };
 
 describe("extension", () => {
@@ -121,7 +122,8 @@ describe("extension", () => {
       );
 
       const callResult = await mockExport(documentChange, {
-        resource: { name: "example/doc1" },
+        document: "example/doc1",
+        id: "test-event-id-create",
       });
 
       expect(callResult).toBeUndefined();
@@ -155,7 +157,8 @@ describe("extension", () => {
       );
 
       const callResult = await mockExport(documentChange, {
-        resource: { name: "example/doc1" },
+        document: "example/doc1",
+        id: "test-event-id-delete",
       });
 
       expect(callResult).toBeUndefined();


### PR DESCRIPTION
## Description
Fixes the functions.test.ts suite for the Firestore BigQuery export extension. The tests were failing because they used the v1 trigger calling convention: the handler was invoked with (documentChange, context) while the actual code uses the v2 onDocumentWritten API, which receives a single event object whose data property is the change (with before/after). The test helper and event payload were updated to match this v2 event shape so getChangeType(change) receives a proper Change and no longer hits change.after being undefined.

## Related Issues
Fixes failing tests on https://github.com/firebase/extensions/pull/2654


## Changes Made
- firestore-bigquery-export/functions/__tests__/functions.test.ts
     - mockExport: Build a single v2-style event { data: documentChange, ...context } and call wrapped(event) instead of wrapped(document, data).
     - CREATE test: Pass context as { document: "example/doc1", id: "test-event-id-create" } (replacing resource: { name: "example/doc1" }).
     - DELETE test: Same context shape with id: "test-event-id-delete".


