### PR TITLE
chore(firestore-send-email): bump version to 0.2.7 and update docs/changelog

### DIFF
--- a/firestore-send-email/CHANGELOG.md
+++ b/firestore-send-email/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.2.7
+
+feat: add `customArgs` and `ipPoolName` fields to SendGrid options (contributed by @michalpechnet)
+
 ## Version 0.2.6
 
 chore: audit and audit fix packages

--- a/firestore-send-email/POSTINSTALL.md
+++ b/firestore-send-email/POSTINSTALL.md
@@ -82,6 +82,8 @@ When using SendGrid, you can use SendGrid Dynamic Templates to create and send t
 
 Add this document to the Firestore mail collection to send an email using a SendGrid Dynamic Template. The `templateId` is required and should be your SendGrid Dynamic Template ID (always starts with 'd-'). The `dynamicTemplateData` object contains the variables that will be used in your template.
 
+You can also include optional SendGrid fields in the same `sendGrid` object, such as `customArgs` (string key/value metadata) and `ipPoolName` (IP pool selection).
+
 For more details, see the [SendGrid Dynamic Templates documentation](https://docs.sendgrid.com/ui/sending-email/how-to-send-an-email-with-dynamic-templates).
 
 #### Understanding SendGrid Email IDs

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-send-email
-version: 0.2.6
+version: 0.2.7
 specVersion: v1beta
 
 displayName: Trigger Email from Firestore


### PR DESCRIPTION
Should go in after https://github.com/firebase/extensions/pull/2668

Changes:
- updates firestore-send-email version to `0.2.7`
- adds changelog for new version
- updates the docs to include changes