### PR TITLE
fix(firestore-translate-text): remove deprecated gemini-2.0-flash model options

### DIFF
--- a/.agents/skills/public-skill/SKILL.md
+++ b/.agents/skills/public-skill/SKILL.md
@@ -1,0 +1,1 @@
+public guidance for contributing

--- a/.agents/skills/public-skill/SKILL.md
+++ b/.agents/skills/public-skill/SKILL.md
@@ -1,1 +1,0 @@
-public guidance for contributing

--- a/firestore-translate-text/CHANGELOG.md
+++ b/firestore-translate-text/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.28
+
+fix - remove deprecated gemini-2.0-flash and gemini-2.0-flash-lite model options
+
 ## Version 0.1.27
 
 chore: update Cloud Functions runtime to Node.js 22

--- a/firestore-translate-text/extension.yaml
+++ b/firestore-translate-text/extension.yaml
@@ -172,10 +172,6 @@ params:
       - label:
           Gemini 2.5 Flash Lite (cheap, good quality, large max output size)
         value: gemini-2.5-flash-lite
-      - label: Gemini 2.0 Flash (cheap, good quality)
-        value: gemini-2.0-flash
-      - label: Gemini 2.0 Flash Lite (cheapest, lowest quality)
-        value: gemini-2.0-flash-lite
     default: gemini-2.5-flash
 
   - param: GOOGLE_AI_API_KEY

--- a/firestore-translate-text/extension.yaml
+++ b/firestore-translate-text/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-translate-text
-version: 0.1.27
+version: 0.1.28
 specVersion: v1beta
 
 tags: [ai]


### PR DESCRIPTION
gemini-2.0-flash and gemini-2.0-flash-lite are being discontinued on June 1st, 2026. Remove them from the GEMINI_MODEL dropdown options. The default (gemini-2.5-flash) is unchanged.

Fixes #2607