### PR TITLE
chore(firestore-bigquery-export): bump runtime to Node.js 22 for v1 functions

### DIFF
--- a/firestore-bigquery-export/CHANGELOG.md
+++ b/firestore-bigquery-export/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.61
+
+chore: bump Cloud Functions runtime to Node.js 22
+
 ## Version 0.1.60
 
 feat - configure a log level to control the verbosity of logs.

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-bigquery-export
-version: 0.1.60
+version: 0.1.61
 specVersion: v1beta
 
 displayName: Stream Firestore to BigQuery
@@ -59,7 +59,7 @@ resources:
       Listens for document changes in your specified Cloud Firestore collection,
       then exports the changes into BigQuery.
     properties:
-      runtime: nodejs20
+      runtime: nodejs22
       eventTrigger:
         eventType: providers/cloud.firestore/eventTypes/document.write
         resource: projects/${param:PROJECT_ID}/databases/(default)/documents/${param:COLLECTION_PATH}/{documentId}
@@ -69,7 +69,7 @@ resources:
     description: >-
       A task-triggered function that gets called on BigQuery sync
     properties:
-      runtime: nodejs20
+      runtime: nodejs22
       taskQueueTrigger:
         rateLimits:
           maxConcurrentDispatches: 500
@@ -83,7 +83,7 @@ resources:
     description: >-
       Runs configuration for sycning with BigQuery
     properties:
-      runtime: nodejs20
+      runtime: nodejs22
       taskQueueTrigger:
         retryConfig:
           maxAttempts: 15
@@ -94,7 +94,7 @@ resources:
     description: >-
       Runs configuration for sycning with BigQuery
     properties:
-      runtime: nodejs20
+      runtime: nodejs22
       taskQueueTrigger:
         retryConfig:
           maxAttempts: 15


### PR DESCRIPTION
Bumps the Cloud Functions runtime from nodejs20 to nodejs22 on the v1 functions branch, so users affected by the root wildcard regression (#2396) can continue using v1 triggers on a supported runtime.