### PR TITLE
perf(gen-schema-view): update schema view query to eliminate unnecessary window function calls, enhancing efficiency

### DIFF
--- a/firestore-bigquery-export/scripts/gen-schema-view/package.json
+++ b/firestore-bigquery-export/scripts/gen-schema-view/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@firebaseextensions/fs-bq-schema-views",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Generate strongly-typed BigQuery Views based on raw JSON",
   "main": "./lib/index.js",
   "repository": {

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/emptySchemaLatest.sql
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/emptySchemaLatest.sql
@@ -15,23 +15,15 @@ FROM
     SELECT
       document_name,
       document_id,
-      FIRST_VALUE(timestamp) OVER(
-        PARTITION BY document_name
-        ORDER BY
-          timestamp DESC
-      ) AS timestamp,
-      FIRST_VALUE(operation) OVER(
-        PARTITION BY document_name
-        ORDER BY
-          timestamp DESC
-      ) AS operation,
-      FIRST_VALUE(operation) OVER(
-        PARTITION BY document_name
-        ORDER BY
-          timestamp DESC
-      ) = "DELETE" AS is_deleted
+      timestamp,
+      operation,
+      operation = "DELETE" AS is_deleted
     FROM
-      `test.test_dataset.test_table`
+      `test.test_dataset.test_table` QUALIFY RANK() OVER(
+        PARTITION BY document_name
+        ORDER BY
+          timestamp DESC
+      ) = 1
   )
 WHERE
   NOT is_deleted

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaLatest.sql
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/fullSchemaLatest.sql
@@ -28,68 +28,26 @@ FROM
         SELECT
           document_name,
           document_id,
-          FIRST_VALUE(timestamp) OVER(
-            PARTITION BY document_name
-            ORDER BY
-              timestamp DESC
-          ) AS timestamp,
-          FIRST_VALUE(operation) OVER(
-            PARTITION BY document_name
-            ORDER BY
-              timestamp DESC
-          ) AS operation,
-          FIRST_VALUE(operation) OVER(
-            PARTITION BY document_name
-            ORDER BY
-              timestamp DESC
-          ) = "DELETE" AS is_deleted,
-          FIRST_VALUE(JSON_EXTRACT_SCALAR(data, '$.name')) OVER(
-            PARTITION BY document_name
-            ORDER BY
-              timestamp DESC
-          ) AS name,
-          `test.test_dataset.firestoreArray`(
-            FIRST_VALUE(JSON_EXTRACT(data, '$.favorite_numbers')) OVER(
-              PARTITION BY document_name
-              ORDER BY
-                timestamp DESC
-            )
-          ) AS favorite_numbers,
-          `test.test_dataset.firestoreTimestamp`(
-            FIRST_VALUE(JSON_EXTRACT(data, '$.last_login')) OVER(
-              PARTITION BY document_name
-              ORDER BY
-                timestamp DESC
-            )
-          ) AS last_login,
-          `test.test_dataset.firestoreGeopoint`(
-            FIRST_VALUE(JSON_EXTRACT(data, '$.last_location')) OVER(
-              PARTITION BY document_name
-              ORDER BY
-                timestamp DESC
-            )
-          ) AS last_location,
+          timestamp,
+          operation,
+          operation = "DELETE" AS is_deleted,
+          JSON_EXTRACT_SCALAR(data, '$.name') AS name,
+          `test.test_dataset.firestoreArray`(JSON_EXTRACT(data, '$.favorite_numbers')) AS favorite_numbers,
+          `test.test_dataset.firestoreTimestamp`(JSON_EXTRACT(data, '$.last_login')) AS last_login,
+          `test.test_dataset.firestoreGeopoint`(JSON_EXTRACT(data, '$.last_location')) AS last_location,
           SAFE_CAST(
-            FIRST_VALUE(JSON_EXTRACT_SCALAR(data, '$.last_location._latitude')) OVER(
-              PARTITION BY document_name
-              ORDER BY
-                timestamp DESC
-            ) AS NUMERIC
+            JSON_EXTRACT_SCALAR(data, '$.last_location._latitude') AS NUMERIC
           ) AS last_location_latitude,
           SAFE_CAST(
-            FIRST_VALUE(JSON_EXTRACT_SCALAR(data, '$.last_location._longitude')) OVER(
-              PARTITION BY document_name
-              ORDER BY
-                timestamp DESC
-            ) AS NUMERIC
+            JSON_EXTRACT_SCALAR(data, '$.last_location._longitude') AS NUMERIC
           ) AS last_location_longitude,
-          FIRST_VALUE(JSON_EXTRACT_SCALAR(data, '$.friends.name')) OVER(
+          JSON_EXTRACT_SCALAR(data, '$.friends.name') AS friends_name
+        FROM
+          `test.test_dataset.test_table` QUALIFY RANK() OVER(
             PARTITION BY document_name
             ORDER BY
               timestamp DESC
-          ) AS friends_name
-        FROM
-          `test.test_dataset.test_table`
+          ) = 1
       )
     WHERE
       NOT is_deleted

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/viewColumnRenameSchema.sql
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/__tests__/fixtures/sql/viewColumnRenameSchema.sql
@@ -44,145 +44,41 @@ FROM
         SELECT
           document_name,
           document_id,
-          FIRST_VALUE(timestamp) OVER(
-            PARTITION BY document_name
-            ORDER BY
-              timestamp DESC
-          ) AS timestamp,
-          FIRST_VALUE(operation) OVER(
-            PARTITION BY document_name
-            ORDER BY
-              timestamp DESC
-          ) AS operation,
-          FIRST_VALUE(operation) OVER(
-            PARTITION BY document_name
-            ORDER BY
-              timestamp DESC
-          ) = "DELETE" AS is_deleted,
-          `test.test_dataset.firestoreArray`(
-            FIRST_VALUE(JSON_EXTRACT(data, '$.order')) OVER(
-              PARTITION BY document_name
-              ORDER BY
-                timestamp DESC
-            )
-          ) AS newArray,
-          FIRST_VALUE(JSON_EXTRACT_SCALAR(data, '$.limit')) OVER(
-            PARTITION BY document_name
-            ORDER BY
-              timestamp DESC
-          ) AS newString,
-          `test.test_dataset.firestoreNumber`(
-            FIRST_VALUE(JSON_EXTRACT_SCALAR(data, '$.from')) OVER(
-              PARTITION BY document_name
-              ORDER BY
-                timestamp DESC
-            )
-          ) AS newNumber,
-          `test.test_dataset.firestoreBoolean`(
-            FIRST_VALUE(JSON_EXTRACT_SCALAR(data, '$.select')) OVER(
-              PARTITION BY document_name
-              ORDER BY
-                timestamp DESC
-            )
-          ) AS newBoolean,
-          `test.test_dataset.firestoreGeopoint`(
-            FIRST_VALUE(JSON_EXTRACT(data, '$.where')) OVER(
-              PARTITION BY document_name
-              ORDER BY
-                timestamp DESC
-            )
-          ) AS newGeopoint,
+          timestamp,
+          operation,
+          operation = "DELETE" AS is_deleted,
+          `test.test_dataset.firestoreArray`(JSON_EXTRACT(data, '$.order')) AS newArray,
+          JSON_EXTRACT_SCALAR(data, '$.limit') AS newString,
+          `test.test_dataset.firestoreNumber`(JSON_EXTRACT_SCALAR(data, '$.from')) AS newNumber,
+          `test.test_dataset.firestoreBoolean`(JSON_EXTRACT_SCALAR(data, '$.select')) AS newBoolean,
+          `test.test_dataset.firestoreGeopoint`(JSON_EXTRACT(data, '$.where')) AS newGeopoint,
           SAFE_CAST(
-            FIRST_VALUE(JSON_EXTRACT_SCALAR(data, '$.where._latitude')) OVER(
-              PARTITION BY document_name
-              ORDER BY
-                timestamp DESC
-            ) AS NUMERIC
+            JSON_EXTRACT_SCALAR(data, '$.where._latitude') AS NUMERIC
           ) AS newGeopoint_latitude,
           SAFE_CAST(
-            FIRST_VALUE(JSON_EXTRACT_SCALAR(data, '$.where._longitude')) OVER(
-              PARTITION BY document_name
-              ORDER BY
-                timestamp DESC
-            ) AS NUMERIC
+            JSON_EXTRACT_SCALAR(data, '$.where._longitude') AS NUMERIC
           ) AS newGeopoint_longitude,
-          `test.test_dataset.firestoreTimestamp`(
-            FIRST_VALUE(JSON_EXTRACT(data, '$.between')) OVER(
-              PARTITION BY document_name
-              ORDER BY
-                timestamp DESC
-            )
-          ) AS newTimestamp,
-          FIRST_VALUE(JSON_EXTRACT_SCALAR(data, '$.like')) OVER(
-            PARTITION BY document_name
-            ORDER BY
-              timestamp DESC
-          ) AS newReference,
-          FIRST_VALUE(JSON_EXTRACT_SCALAR(data, '$.and.like')) OVER(
-            PARTITION BY document_name
-            ORDER BY
-              timestamp DESC
-          ) AS newMapColumnName_referenceMap,
-          `test.test_dataset.firestoreArray`(
-            FIRST_VALUE(JSON_EXTRACT(data, '$.and.order')) OVER(
-              PARTITION BY document_name
-              ORDER BY
-                timestamp DESC
-            )
-          ) AS newMapColumnName_arrayMap,
-          FIRST_VALUE(JSON_EXTRACT_SCALAR(data, '$.and.limit')) OVER(
-            PARTITION BY document_name
-            ORDER BY
-              timestamp DESC
-          ) AS newMapColumnName_stringMap,
-          `test.test_dataset.firestoreNumber`(
-            FIRST_VALUE(JSON_EXTRACT_SCALAR(data, '$.and.from')) OVER(
-              PARTITION BY document_name
-              ORDER BY
-                timestamp DESC
-            )
-          ) AS newMapColumnName_numberMap,
-          `test.test_dataset.firestoreBoolean`(
-            FIRST_VALUE(JSON_EXTRACT_SCALAR(data, '$.and.select')) OVER(
-              PARTITION BY document_name
-              ORDER BY
-                timestamp DESC
-            )
-          ) AS newMapColumnName_booleanMap,
-          `test.test_dataset.firestoreGeopoint`(
-            FIRST_VALUE(JSON_EXTRACT(data, '$.and.where')) OVER(
-              PARTITION BY document_name
-              ORDER BY
-                timestamp DESC
-            )
-          ) AS newMapColumnName_geopointMap,
+          `test.test_dataset.firestoreTimestamp`(JSON_EXTRACT(data, '$.between')) AS newTimestamp,
+          JSON_EXTRACT_SCALAR(data, '$.like') AS newReference,
+          JSON_EXTRACT_SCALAR(data, '$.and.like') AS newMapColumnName_referenceMap,
+          `test.test_dataset.firestoreArray`(JSON_EXTRACT(data, '$.and.order')) AS newMapColumnName_arrayMap,
+          JSON_EXTRACT_SCALAR(data, '$.and.limit') AS newMapColumnName_stringMap,
+          `test.test_dataset.firestoreNumber`(JSON_EXTRACT_SCALAR(data, '$.and.from')) AS newMapColumnName_numberMap,
+          `test.test_dataset.firestoreBoolean`(JSON_EXTRACT_SCALAR(data, '$.and.select')) AS newMapColumnName_booleanMap,
+          `test.test_dataset.firestoreGeopoint`(JSON_EXTRACT(data, '$.and.where')) AS newMapColumnName_geopointMap,
           SAFE_CAST(
-            FIRST_VALUE(
-              JSON_EXTRACT_SCALAR(data, '$.and.where._latitude')
-            ) OVER(
-              PARTITION BY document_name
-              ORDER BY
-                timestamp DESC
-            ) AS NUMERIC
+            JSON_EXTRACT_SCALAR(data, '$.and.where._latitude') AS NUMERIC
           ) AS newMapColumnName_geopointMap_latitude,
           SAFE_CAST(
-            FIRST_VALUE(
-              JSON_EXTRACT_SCALAR(data, '$.and.where._longitude')
-            ) OVER(
-              PARTITION BY document_name
-              ORDER BY
-                timestamp DESC
-            ) AS NUMERIC
+            JSON_EXTRACT_SCALAR(data, '$.and.where._longitude') AS NUMERIC
           ) AS newMapColumnName_geopointMap_longitude,
-          `test.test_dataset.firestoreTimestamp`(
-            FIRST_VALUE(JSON_EXTRACT(data, '$.and.between')) OVER(
-              PARTITION BY document_name
-              ORDER BY
-                timestamp DESC
-            )
-          ) AS newMapColumnName_timestampMap
+          `test.test_dataset.firestoreTimestamp`(JSON_EXTRACT(data, '$.and.between')) AS newMapColumnName_timestampMap
         FROM
-          `test.test_dataset.test_table`
+          `test.test_dataset.test_table` QUALIFY RANK() OVER(
+            PARTITION BY document_name
+            ORDER BY
+              timestamp DESC
+          ) = 1
       )
     WHERE
       NOT is_deleted

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
@@ -67,9 +67,8 @@ export const buildLatestSchemaSnapshotViewQuery = (
   useNewSqlSyntax = false
 ): any => {
   // Use identity transformer - no FIRST_VALUE wrapping needed
-  // We'll use QUALIFY ROW_NUMBER() = 1 instead to filter to latest row
-  const identitySelector = (selector: string, _isArrayType?: boolean) =>
-    selector;
+  // We'll use QUALIFY RANK() = 1 instead to filter to latest row
+  const identitySelector = (selector: string) => selector;
 
   // We need to pass the dataset id into the parser so that we can call the
   // fully qualified json2array persistent user-defined function in the proper
@@ -140,7 +139,7 @@ export const buildLatestSchemaSnapshotViewQuery = (
     })
     .join(" ");
 
-  // Use QUALIFY with single ROW_NUMBER() instead of multiple FIRST_VALUE() calls
+  // Use QUALIFY with single RANK() instead of multiple FIRST_VALUE() calls
   // This dramatically improves performance for wide schemas (200+ columns)
   // by using only ONE window function regardless of field count
   let query = `

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
@@ -66,15 +66,20 @@ export const buildLatestSchemaSnapshotViewQuery = (
   schema: FirestoreSchema,
   useNewSqlSyntax = false
 ): any => {
-  const firstValue = (selector: string, isArrayType?: boolean) => {
-    if (isArrayType) return selector;
-    return `FIRST_VALUE(${selector}) OVER(PARTITION BY document_name ORDER BY timestamp DESC)`;
-  };
+  // Use identity transformer - no FIRST_VALUE wrapping needed
+  // We'll use QUALIFY ROW_NUMBER() = 1 instead to filter to latest row
+  const identitySelector = (selector: string, _isArrayType?: boolean) =>
+    selector;
 
   // We need to pass the dataset id into the parser so that we can call the
   // fully qualified json2array persistent user-defined function in the proper
   // scope.
-  const result = processFirestoreSchema(datasetId, "data", schema, firstValue);
+  const result = processFirestoreSchema(
+    datasetId,
+    "data",
+    schema,
+    identitySelector
+  );
 
   const [
     schemaFieldExtractors,
@@ -135,6 +140,9 @@ export const buildLatestSchemaSnapshotViewQuery = (
     })
     .join(" ");
 
+  // Use QUALIFY with single ROW_NUMBER() instead of multiple FIRST_VALUE() calls
+  // This dramatically improves performance for wide schemas (200+ columns)
+  // by using only ONE window function regardless of field count
   let query = `
       SELECT
         document_name,
@@ -146,14 +154,15 @@ export const buildLatestSchemaSnapshotViewQuery = (
         SELECT
           document_name,
           document_id,
-          ${firstValue(`timestamp`)} AS timestamp,
-          ${firstValue(`operation`)} AS operation,
-          ${firstValue(`operation`)} = "DELETE" AS is_deleted${
-    fieldValueSelectorClauses.length > 0 ? `,` : ``
-  }
+          timestamp,
+          operation,
+          operation = "DELETE" AS is_deleted${
+            fieldValueSelectorClauses.length > 0 ? `,` : ``
+          }
           ${fieldValueSelectorClauses}
         FROM \`${process.env.PROJECT_ID}.${datasetId}.${rawViewName}\`
         ${offsetJoins}
+        QUALIFY ROW_NUMBER() OVER(PARTITION BY document_name ORDER BY timestamp DESC) = 1
       )
       WHERE NOT is_deleted
   `;

--- a/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
+++ b/firestore-bigquery-export/scripts/gen-schema-view/src/snapshot.ts
@@ -162,7 +162,7 @@ export const buildLatestSchemaSnapshotViewQuery = (
           ${fieldValueSelectorClauses}
         FROM \`${process.env.PROJECT_ID}.${datasetId}.${rawViewName}\`
         ${offsetJoins}
-        QUALIFY ROW_NUMBER() OVER(PARTITION BY document_name ORDER BY timestamp DESC) = 1
+        QUALIFY RANK() OVER(PARTITION BY document_name ORDER BY timestamp DESC) = 1
       )
       WHERE NOT is_deleted
   `;


### PR DESCRIPTION
Resolves https://github.com/firebase/extensions/issues/2557

Replaces O(N) `FIRST_VALUE(...) OVER(PARTITION BY ...)` window functions with a single `RANK() OVER(...) = 1` using BigQuery's `QUALIFY` clause.

The previous implementation wrapped each schema field in its own `FIRST_VALUE` window function to extract the latest value per document. While semantically correct, this caused BigQuery to perform separate partition/sort operations for each field, leading to severe performance degradation and potential resource exhaustion on wide schemas (200+ columns).

The fix uses a single `RANK()` window function to filter to the latest row per document, then extracts fields normally.

`SELECT COUNT(*) FROM '...'` produces the following:
<img width="859" height="126" alt="image" src="https://github.com/user-attachments/assets/35a4ec1f-8125-4bf1-933d-b4c093a4b91f" />