### PR TITLE
fix: images that fail content filter are added to failed directory

### DIFF
--- a/storage-resize-images/CHANGELOG.md
+++ b/storage-resize-images/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Version 0.3.4
 
-fix - content filter no longer silently fails open on Gemini 2.5 Flash safety refusals. When Gemini's input-side safety declines to respond on borderline imagery (returning empty content rather than `finishReason="SAFETY"`), the resulting genkit schema-validation error is now treated as an implicit block instead of being retried 3 times and propagating as a generic filter error.
+fix - when a custom filter prompt is configured, the content filter no longer silently fails open on Gemini 2.5 Flash safety refusals. If Gemini's input-side safety declines to respond on borderline imagery (returning empty content rather than `finishReason="SAFETY"`), the resulting genkit schema-validation error is now treated as an implicit block instead of being retried 3 times and propagating as a generic filter error. Installs that only set `CONTENT_FILTER_LEVEL` (no custom prompt) were not affected by this path.
 
 fix - blocked images are now routed to the failed-image path before placeholder substitution, so the original blocked content is preserved rather than overwritten by the placeholder.
 

--- a/storage-resize-images/CHANGELOG.md
+++ b/storage-resize-images/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 fix - when a custom filter prompt is configured, the content filter no longer silently fails open on Gemini 2.5 Flash safety refusals. If Gemini's input-side safety declines to respond on borderline imagery (returning empty content rather than `finishReason="SAFETY"`), the resulting genkit schema-validation error is now treated as an implicit block instead of being retried 3 times and propagating as a generic filter error. Installs that only set `CONTENT_FILTER_LEVEL` (no custom prompt) were not affected by this path.
 
+fix - any genkit schema-validation failure on the moderation response (not only empty-content safety refusals) is now treated as a content block instead of being retried and surfaced as a generic error.
+
 fix - blocked images are now routed to the failed-image path before placeholder substitution, so the original blocked content is preserved rather than overwritten by the placeholder.
 
 fix - placeholder swap operates on a copy of the original file, so resizing a blocked image produces placeholder-derived outputs without mutating the stored original.

--- a/storage-resize-images/CHANGELOG.md
+++ b/storage-resize-images/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Version 0.3.4
+
+fix - content filter no longer silently fails open on Gemini 2.5 Flash safety refusals. When Gemini's input-side safety declines to respond on borderline imagery (returning empty content rather than `finishReason="SAFETY"`), the resulting genkit schema-validation error is now treated as an implicit block instead of being retried 3 times and propagating as a generic filter error.
+
+fix - blocked images are now routed to the failed-image path before placeholder substitution, so the original blocked content is preserved rather than overwritten by the placeholder.
+
+fix - placeholder swap operates on a copy of the original file, so resizing a blocked image produces placeholder-derived outputs without mutating the stored original.
+
+fix - moderation requests now use the uploaded object's content type when constructing the data URL instead of guessing from the file extension.
+
 ## Version 0.3.3
 
 chore: bump dependencies

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: storage-resize-images
-version: 0.3.3
+version: 0.3.4
 specVersion: v1beta
 
 displayName: Resize Images

--- a/storage-resize-images/functions/__tests__/content-filter.test.ts
+++ b/storage-resize-images/functions/__tests__/content-filter.test.ts
@@ -18,15 +18,6 @@ jest.mock("@genkit-ai/vertexai", () => ({
   gemini: jest.fn((version: string) => ({ name: `vertexai/${version}` })),
 }));
 
-// Mock the sleep function to avoid actual waiting in tests
-jest.mock("fs", () => ({
-  readFileSync: jest.fn().mockReturnValue(Buffer.from("mockImageData")),
-}));
-
-jest.mock("mime", () => ({
-  lookup: jest.fn().mockReturnValue("image/png"),
-}));
-
 describe("checkImageContent with mocks", () => {
   // Test image path - using the same path as in your original test suite
   const imagePath = path.join(__dirname, "gun-image.png");

--- a/storage-resize-images/functions/__tests__/content-filter.test.ts
+++ b/storage-resize-images/functions/__tests__/content-filter.test.ts
@@ -274,9 +274,8 @@ describe("checkImageContent with mocks", () => {
   };
 
   it("should return false when genkit throws ValidationError with null-content data (Bug 1)", async () => {
-    // Reproduces the failure shape Gemini 2.5 Flash + genkit produces when
-    // input-side safety refuses on a borderline image: empty content →
-    // assertValidSchema runs parseSchema(null, ...) → ValidationError.
+    // Reproduces one failure shape Gemini 2.5 Flash + genkit produces
+    // when input-side safety refuses: empty content → parseSchema(null).
     // Instantiated via the real class so the test fails loudly if genkit
     // ever changes the ValidationError contract.
     const validationError = new ValidationError({
@@ -301,14 +300,68 @@ describe("checkImageContent with mocks", () => {
     expect(mockGenerate).toHaveBeenCalledTimes(1);
   });
 
-  it("should rethrow ValidationError when provided data is NOT null (real schema mismatch)", async () => {
-    const realSchemaMismatch = new ValidationError({
+  it("should return false when genkit throws ValidationError with empty-object data (Bug 1 variant)", async () => {
+    // The other observed safety-refusal manifestation, confirmed against
+    // a real borderline image: extractJson() returns {} when the model
+    // emits non-JSON or empty refusal text, and the schema rejects it for
+    // missing the required `response` field.
+    const validationError = new ValidationError({
+      data: {},
+      errors: [
+        { path: "(root)", message: "must have required property 'response'" },
+      ],
+      schema: moderationSchema,
+    });
+
+    const mockGenerate = jest.fn().mockRejectedValue(validationError);
+    genkit.mockImplementation(() => ({ generate: mockGenerate }));
+
+    const result = await checkImageContent(
+      imagePath,
+      HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+      "Is this image inappropriate?",
+      "image/png"
+    );
+
+    expect(result).toBe(false);
+    expect(log.contentFilterBlocked).toHaveBeenCalled();
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("should also block on type-mismatch ValidationError (any moderation schema failure → block)", async () => {
+    // We control the prompt and schema in this code path, so the only
+    // source of ValidationError is the model's response. The intentional
+    // policy is: any schema-validation failure means the model didn't
+    // produce a usable verdict, which on borderline imagery is almost
+    // always an input-side safety refusal. Failing open is worse than
+    // a false-positive block, so we treat the whole class as blocked.
+    const validationError = new ValidationError({
       data: { response: 42 },
       errors: [{ path: "response", message: "must be string" }],
       schema: moderationSchema,
     });
 
-    const mockGenerate = jest.fn().mockRejectedValue(realSchemaMismatch);
+    const mockGenerate = jest.fn().mockRejectedValue(validationError);
+    genkit.mockImplementation(() => ({ generate: mockGenerate }));
+
+    const result = await checkImageContent(
+      imagePath,
+      HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+      "prompt",
+      "image/png"
+    );
+
+    expect(result).toBe(false);
+    expect(log.contentFilterBlocked).toHaveBeenCalled();
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("should still rethrow non-ValidationError errors after exhausting retries", async () => {
+    // Sanity check: errors WITHOUT the ValidationError shape (status +
+    // detail.errors) still go through the retry path and propagate.
+    const networkError = new Error("ECONNRESET");
+
+    const mockGenerate = jest.fn().mockRejectedValue(networkError);
     genkit.mockImplementation(() => ({ generate: mockGenerate }));
 
     await expect(
@@ -317,9 +370,9 @@ describe("checkImageContent with mocks", () => {
         HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
         "prompt",
         "image/png",
-        3 // run the full default retry path to prove it engages
+        3
       )
-    ).rejects.toMatchObject({ status: "INVALID_ARGUMENT" });
+    ).rejects.toThrow("ECONNRESET");
 
     expect(mockGenerate).toHaveBeenCalledTimes(3);
     expect(log.contentFilterBlocked).not.toHaveBeenCalled();

--- a/storage-resize-images/functions/__tests__/content-filter.test.ts
+++ b/storage-resize-images/functions/__tests__/content-filter.test.ts
@@ -1,6 +1,7 @@
-import { checkImageContent } from "../src/content-filter"; // Update this import path
+import { checkImageContent } from "../src/content-filter";
 import * as path from "path";
 import { HarmBlockThreshold } from "@google-cloud/vertexai";
+import { ValidationError } from "@genkit-ai/core/schema";
 
 // Mock genkit module
 jest.mock("genkit", () => ({
@@ -260,19 +261,28 @@ describe("checkImageContent with mocks", () => {
     expect(result).toBe(true);
   });
 
-  it("should return false when genkit throws ValidationError with null-content message (Bug 1)", async () => {
+  // Schema used by checkImageContent's custom-prompt path — the moderation
+  // call sets output: { schema: z.object({ response: z.string() }) }. The
+  // genkit-emitted JSON schema is replicated here so the real
+  // ValidationError ctor receives a faithful `schema` field.
+  const moderationSchema = {
+    type: "object",
+    properties: { response: { type: "string" } },
+    required: ["response"],
+    additionalProperties: true,
+    $schema: "http://json-schema.org/draft-07/schema#",
+  };
+
+  it("should return false when genkit throws ValidationError with null-content data (Bug 1)", async () => {
     // Reproduces the failure shape Gemini 2.5 Flash + genkit produces when
     // input-side safety refuses on a borderline image: empty content →
     // assertValidSchema runs parseSchema(null, ...) → ValidationError.
-    const validationError = Object.assign(new Error("validation failed"), {
-      name: "GenkitError",
-      status: "INVALID_ARGUMENT",
-      code: 400,
-      originalMessage:
-        "Schema validation failed. Parse Errors:\n\n" +
-        "- (root): must be object\n\n" +
-        "Provided data:\n\nnull\n\n" +
-        "Required JSON schema:\n\n{...}",
+    // Instantiated via the real class so the test fails loudly if genkit
+    // ever changes the ValidationError contract.
+    const validationError = new ValidationError({
+      data: null,
+      errors: [{ path: "(root)", message: "must be object" }],
+      schema: moderationSchema,
     });
 
     const mockGenerate = jest.fn().mockRejectedValue(validationError);
@@ -292,15 +302,10 @@ describe("checkImageContent with mocks", () => {
   });
 
   it("should rethrow ValidationError when provided data is NOT null (real schema mismatch)", async () => {
-    const realSchemaMismatch = Object.assign(new Error("schema fail"), {
-      name: "GenkitError",
-      status: "INVALID_ARGUMENT",
-      code: 400,
-      originalMessage:
-        "Schema validation failed. Parse Errors:\n\n" +
-        "- response: must be string\n\n" +
-        'Provided data:\n\n{ "response": 42 }\n\n' +
-        "Required JSON schema:\n\n{...}",
+    const realSchemaMismatch = new ValidationError({
+      data: { response: 42 },
+      errors: [{ path: "response", message: "must be string" }],
+      schema: moderationSchema,
     });
 
     const mockGenerate = jest.fn().mockRejectedValue(realSchemaMismatch);
@@ -312,11 +317,11 @@ describe("checkImageContent with mocks", () => {
         HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
         "prompt",
         "image/png",
-        2 // keep retries low so the test stays fast; 2 still proves retry path engaged
+        3 // run the full default retry path to prove it engages
       )
     ).rejects.toMatchObject({ status: "INVALID_ARGUMENT" });
 
-    expect(mockGenerate).toHaveBeenCalledTimes(2);
+    expect(mockGenerate).toHaveBeenCalledTimes(3);
     expect(log.contentFilterBlocked).not.toHaveBeenCalled();
   }, 30000);
 });

--- a/storage-resize-images/functions/__tests__/content-filter.test.ts
+++ b/storage-resize-images/functions/__tests__/content-filter.test.ts
@@ -18,12 +18,16 @@ jest.mock("@genkit-ai/vertexai", () => ({
   gemini: jest.fn((version: string) => ({ name: `vertexai/${version}` })),
 }));
 
+// Mock logs so we can assert on which filter-blocked log fired.
+jest.mock("../src/logs");
+
 describe("checkImageContent with mocks", () => {
   // Test image path - using the same path as in your original test suite
   const imagePath = path.join(__dirname, "gun-image.png");
 
   // Import mocked modules after they've been mocked
   const { genkit } = require("genkit");
+  const log = require("../src/logs");
 
   beforeEach(() => {
     // Reset all mocks before each test
@@ -255,4 +259,64 @@ describe("checkImageContent with mocks", () => {
     expect(mockGenerate).toHaveBeenCalled();
     expect(result).toBe(true);
   });
+
+  it("should return false when genkit throws ValidationError with null-content message (Bug 1)", async () => {
+    // Reproduces the failure shape Gemini 2.5 Flash + genkit produces when
+    // input-side safety refuses on a borderline image: empty content →
+    // assertValidSchema runs parseSchema(null, ...) → ValidationError.
+    const validationError = Object.assign(new Error("validation failed"), {
+      name: "GenkitError",
+      status: "INVALID_ARGUMENT",
+      code: 400,
+      originalMessage:
+        "Schema validation failed. Parse Errors:\n\n" +
+        "- (root): must be object\n\n" +
+        "Provided data:\n\nnull\n\n" +
+        "Required JSON schema:\n\n{...}",
+    });
+
+    const mockGenerate = jest.fn().mockRejectedValue(validationError);
+    genkit.mockImplementation(() => ({ generate: mockGenerate }));
+
+    const result = await checkImageContent(
+      imagePath,
+      HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+      "Is this image inappropriate?",
+      "image/png"
+    );
+
+    expect(result).toBe(false);
+    expect(log.contentFilterBlocked).toHaveBeenCalled();
+    // Deterministic refusal — must not burn retries.
+    expect(mockGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("should rethrow ValidationError when provided data is NOT null (real schema mismatch)", async () => {
+    const realSchemaMismatch = Object.assign(new Error("schema fail"), {
+      name: "GenkitError",
+      status: "INVALID_ARGUMENT",
+      code: 400,
+      originalMessage:
+        "Schema validation failed. Parse Errors:\n\n" +
+        "- response: must be string\n\n" +
+        'Provided data:\n\n{ "response": 42 }\n\n' +
+        "Required JSON schema:\n\n{...}",
+    });
+
+    const mockGenerate = jest.fn().mockRejectedValue(realSchemaMismatch);
+    genkit.mockImplementation(() => ({ generate: mockGenerate }));
+
+    await expect(
+      checkImageContent(
+        imagePath,
+        HarmBlockThreshold.BLOCK_LOW_AND_ABOVE,
+        "prompt",
+        "image/png",
+        2 // keep retries low so the test stays fast; 2 still proves retry path engaged
+      )
+    ).rejects.toMatchObject({ status: "INVALID_ARGUMENT" });
+
+    expect(mockGenerate).toHaveBeenCalledTimes(2);
+    expect(log.contentFilterBlocked).not.toHaveBeenCalled();
+  }, 30000);
 });

--- a/storage-resize-images/functions/__tests__/integration/content-filter.live.test.ts
+++ b/storage-resize-images/functions/__tests__/integration/content-filter.live.test.ts
@@ -26,19 +26,27 @@ describeLive(
   () => {
     jest.setTimeout(60_000); // first-call cold start can be 20s+
 
-    const safeImagePath = path.join(__dirname, "..", "test-image.png");
+    // test-jpg.jpg is the word "test" rendered as text — has actual content
+    // for Gemini to evaluate. test-image.png is a tiny black square which
+    // can trip BLOCK_LOW_AND_ABOVE simply because the model has nothing
+    // to be confident about.
+    const safeImagePath = path.join(__dirname, "..", "test-jpg.jpg");
     const weaponImagePath = path.join(__dirname, "..", "gun-image.png");
 
     const weaponPrompt =
       "Does this image contain a weapon (e.g. firearm, knife, explosive)? " +
       "Answer 'yes' if it does, otherwise 'no'.";
 
-    test("safe everyday image passes with BLOCK_LOW_AND_ABOVE", async () => {
+    test("safe everyday image passes with BLOCK_ONLY_HIGH", async () => {
+      // BLOCK_ONLY_HIGH is the most permissive non-disabled threshold;
+      // BLOCK_LOW_AND_ABOVE can over-trigger on synthetic test fixtures
+      // (the no-prompt path uses 1-output-token, so the model has very
+      // little room to indicate "this is fine").
       const result = await checkImageContent(
         safeImagePath,
-        "BLOCK_LOW_AND_ABOVE",
+        "BLOCK_ONLY_HIGH",
         null,
-        "image/png"
+        "image/jpeg"
       );
       expect(result).toBe(true);
     });
@@ -59,7 +67,7 @@ describeLive(
         safeImagePath,
         "BLOCK_LOW_AND_ABOVE",
         weaponPrompt,
-        "image/png"
+        "image/jpeg"
       );
       expect(result).toBe(true);
     });

--- a/storage-resize-images/functions/__tests__/integration/content-filter.live.test.ts
+++ b/storage-resize-images/functions/__tests__/integration/content-filter.live.test.ts
@@ -18,6 +18,23 @@
 import * as path from "path";
 import { checkImageContent } from "../../src/content-filter";
 
+function guessContentType(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  switch (ext) {
+    case ".png":
+      return "image/png";
+    case ".jpg":
+    case ".jpeg":
+      return "image/jpeg";
+    case ".webp":
+      return "image/webp";
+    case ".gif":
+      return "image/gif";
+    default:
+      return "application/octet-stream";
+  }
+}
+
 const runLive = process.env.RUN_LIVE_CONTENT_FILTER_TESTS === "true";
 const describeLive = runLive ? describe : describe.skip;
 
@@ -74,6 +91,9 @@ describeLive(
 
     const borderlinePath = process.env.LIVE_BORDERLINE_IMAGE_PATH;
     const borderlineDescribe = borderlinePath ? describe : describe.skip;
+    const borderlineContentType = borderlinePath
+      ? guessContentType(borderlinePath)
+      : "application/octet-stream";
 
     borderlineDescribe(
       "Bug 1 regression — borderline image (LIVE_BORDERLINE_IMAGE_PATH set)",
@@ -91,7 +111,7 @@ describeLive(
             borderlinePath as string,
             "BLOCK_LOW_AND_ABOVE",
             moderationPrompt,
-            "image/jpeg"
+            borderlineContentType
           );
           expect(result).toBe(false);
         });
@@ -101,7 +121,7 @@ describeLive(
             borderlinePath as string,
             "BLOCK_NONE",
             null,
-            "image/jpeg"
+            borderlineContentType
           );
           expect(result).toBe(true);
         });

--- a/storage-resize-images/functions/__tests__/integration/content-filter.live.test.ts
+++ b/storage-resize-images/functions/__tests__/integration/content-filter.live.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Live integration tests for checkImageContent — these hit the real
+ * Vertex AI Gemini 2.5 Flash API. They are skipped by default and only
+ * run when RUN_LIVE_CONTENT_FILTER_TESTS=true.
+ *
+ * Run locally:
+ *   gcloud auth application-default login
+ *   GCLOUD_PROJECT=<your-project> \
+ *     npm run test:live-content-filter --prefix storage-resize-images/functions
+ *
+ * The Bug 1 regression test additionally requires LIVE_BORDERLINE_IMAGE_PATH
+ * pointing to a borderline-NSFW image that triggers Gemini's input-side
+ * safety refusal. That image cannot be checked into a public repo, so
+ * developers/CI supply their own. Without the env var, that test is
+ * skipped (the suite still runs the safe-image and weapon-image cases).
+ */
+
+import * as path from "path";
+import { checkImageContent } from "../../src/content-filter";
+
+const runLive = process.env.RUN_LIVE_CONTENT_FILTER_TESTS === "true";
+const describeLive = runLive ? describe : describe.skip;
+
+describeLive(
+  "checkImageContent (live, hits Vertex AI Gemini 2.5 Flash)",
+  () => {
+    jest.setTimeout(60_000); // first-call cold start can be 20s+
+
+    const safeImagePath = path.join(__dirname, "..", "test-image.png");
+    const weaponImagePath = path.join(__dirname, "..", "gun-image.png");
+
+    const weaponPrompt =
+      "Does this image contain a weapon (e.g. firearm, knife, explosive)? " +
+      "Answer 'yes' if it does, otherwise 'no'.";
+
+    test("safe everyday image passes with BLOCK_LOW_AND_ABOVE", async () => {
+      const result = await checkImageContent(
+        safeImagePath,
+        "BLOCK_LOW_AND_ABOVE",
+        null,
+        "image/png"
+      );
+      expect(result).toBe(true);
+    });
+
+    test("weapon image + weapon-detection custom prompt is blocked", async () => {
+      const result = await checkImageContent(
+        weaponImagePath,
+        "BLOCK_LOW_AND_ABOVE",
+        weaponPrompt,
+        "image/png"
+      );
+      expect(result).toBe(false);
+    });
+
+    test("safe image + weapon-detection custom prompt is NOT blocked", async () => {
+      // Guards against the model over-triggering on unrelated content.
+      const result = await checkImageContent(
+        safeImagePath,
+        "BLOCK_LOW_AND_ABOVE",
+        weaponPrompt,
+        "image/png"
+      );
+      expect(result).toBe(true);
+    });
+
+    const borderlinePath = process.env.LIVE_BORDERLINE_IMAGE_PATH;
+    const borderlineDescribe = borderlinePath ? describe : describe.skip;
+
+    borderlineDescribe(
+      "Bug 1 regression — borderline image (LIVE_BORDERLINE_IMAGE_PATH set)",
+      () => {
+        const moderationPrompt =
+          "You are classifying images for a family-friendly platform. " +
+          "Decide whether this image depicts intimate, romantic, or " +
+          "suggestive content. Answer 'yes' if any is present, otherwise 'no'.";
+
+        test("borderline image refused by Gemini safety returns false (not thrown)", async () => {
+          // Without the fix, Gemini returns null content → genkit throws
+          // ValidationError → 3 retries → propagates as filterErrored.
+          // With the fix, the null-content shape is recognised as a block.
+          const result = await checkImageContent(
+            borderlinePath as string,
+            "BLOCK_LOW_AND_ABOVE",
+            moderationPrompt,
+            "image/jpeg"
+          );
+          expect(result).toBe(false);
+        });
+
+        test("same image with BLOCK_NONE still passes (threshold is honoured)", async () => {
+          const result = await checkImageContent(
+            borderlinePath as string,
+            "BLOCK_NONE",
+            null,
+            "image/jpeg"
+          );
+          expect(result).toBe(true);
+        });
+      }
+    );
+  }
+);

--- a/storage-resize-images/functions/__tests__/unit/generateResizedImageHandler.test.ts
+++ b/storage-resize-images/functions/__tests__/unit/generateResizedImageHandler.test.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+import * as fs from "fs";
 import { config as loadEnv } from "dotenv";
 
 const envLocalPath = path.resolve(
@@ -7,6 +8,11 @@ const envLocalPath = path.resolve(
 );
 
 loadEnv({ path: envLocalPath, debug: true, override: true });
+
+jest.mock("fs", () => ({
+  ...jest.requireActual("fs"),
+  copyFileSync: jest.fn(),
+}));
 
 jest.mock("../../src/filters", () => ({
   shouldResize: jest.fn(),
@@ -68,6 +74,7 @@ import { checkImageContent } from "../../src/content-filter";
 import { replacePlaceholder } from "../../src/placeholder";
 import { resizeImages } from "../../src/resize-image";
 import * as logs from "../../src/logs";
+import exp from "constants";
 
 describe("generateResizedImageHandler", () => {
   beforeEach(() => {
@@ -94,17 +101,37 @@ describe("generateResizedImageHandler", () => {
       {},
     ]);
     (checkImageContent as jest.Mock).mockResolvedValue(false);
+    (resizeImages as jest.Mock).mockResolvedValue([
+      {
+        status: "fulfilled",
+        value: { success: true },
+      },
+    ]);
 
     await generateResizedImageHandler(mockObject, false);
 
-    expect(replacePlaceholder).toHaveBeenCalled();
-    expect(resizeImages).not.toHaveBeenCalled();
     expect(handleFailedImage).toHaveBeenCalledWith(
       expect.anything(),
       "/tmp/test.jpg",
       mockObject,
       parsedPathMatcher,
       true
+    );
+    expect(handleFailedImage).toHaveBeenCalledTimes(1);
+    expect(fs.copyFileSync).toHaveBeenCalledWith(
+      "/tmp/test.jpg",
+      "/tmp/test.jpg-placeholder"
+    );
+    expect(replacePlaceholder).toHaveBeenCalledWith(
+      "/tmp/test.jpg-placeholder",
+      {},
+      null
+    );
+    expect(resizeImages).toHaveBeenCalledWith(
+      expect.anything(),
+      "/tmp/test.jpg-placeholder",
+      parsedPathMatcher,
+      mockObject
     );
   });
 
@@ -164,14 +191,12 @@ describe("generateResizedImageHandler", () => {
       {},
     ]);
     (checkImageContent as jest.Mock).mockResolvedValue(false);
+
     const swapErr = new Error("swap boom");
     (replacePlaceholder as jest.Mock).mockRejectedValue(swapErr);
 
     await generateResizedImageHandler(mockObject, false);
 
-    expect(logs.placeholderReplaceError).toHaveBeenCalledWith(swapErr);
-    expect(logs.contentFilterErrored).not.toHaveBeenCalled();
-    expect(resizeImages).not.toHaveBeenCalled();
     expect(handleFailedImage).toHaveBeenCalledWith(
       expect.anything(),
       "/tmp/test.jpg",
@@ -179,5 +204,18 @@ describe("generateResizedImageHandler", () => {
       parsedPathMatcher,
       true
     );
+    expect(handleFailedImage).toHaveBeenCalledTimes(1);
+    expect(fs.copyFileSync).toHaveBeenCalledWith(
+      "/tmp/test.jpg",
+      "/tmp/test.jpg-placeholder"
+    );
+    expect(replacePlaceholder).toHaveBeenCalledWith(
+      "/tmp/test.jpg-placeholder",
+      {},
+      null
+    );
+    expect(logs.placeholderReplaceError).toHaveBeenCalledWith(swapErr);
+    expect(logs.contentFilterErrored).not.toHaveBeenCalled();
+    expect(resizeImages).not.toHaveBeenCalled();
   });
 });

--- a/storage-resize-images/functions/__tests__/unit/generateResizedImageHandler.test.ts
+++ b/storage-resize-images/functions/__tests__/unit/generateResizedImageHandler.test.ts
@@ -42,6 +42,7 @@ jest.mock("../../src/logs", () => ({
   failed: jest.fn(),
   complete: jest.fn(),
   error: jest.fn(),
+  contentFilterErrored: jest.fn(),
 }));
 
 jest.mock("firebase-admin", () => ({
@@ -65,22 +66,26 @@ describe("generateResizedImageHandler", () => {
     jest.clearAllMocks();
   });
 
-  test("goes down the failed-image path when content filter returns passed:false and failed:null", async () => {
+  const mockObject = {
+    bucket: "demo-bucket",
+    name: "images/test.jpg",
+    contentType: "image/jpeg",
+  } as any;
+
+  const parsedPathMatcher = expect.objectContaining({
+    dir: "images",
+    base: "test.jpg",
+    name: "test",
+    ext: ".jpg",
+  });
+
+  test("routes blocked-by-filter images to the failed-image path with blockedByFilter=true", async () => {
     (shouldResize as jest.Mock).mockReturnValue(true);
     (downloadOriginalFile as jest.Mock).mockResolvedValue([
       "/tmp/test.jpg",
       {},
     ]);
-    (processContentFilter as jest.Mock).mockResolvedValue({
-      passed: false,
-      failed: null,
-    });
-
-    const mockObject = {
-      bucket: "demo-bucket",
-      name: "images/test.jpg",
-      contentType: "image/jpeg",
-    } as any;
+    (processContentFilter as jest.Mock).mockResolvedValue(false);
 
     await generateResizedImageHandler(mockObject, false);
 
@@ -89,26 +94,18 @@ describe("generateResizedImageHandler", () => {
       expect.anything(),
       "/tmp/test.jpg",
       mockObject,
-      expect.objectContaining({
-        dir: "images",
-        base: "test.jpg",
-        name: "test",
-        ext: ".jpg",
-      }),
+      parsedPathMatcher,
       true
     );
   });
 
-  test("resizes image when content filter returns passed:true and failed:false", async () => {
+  test("resizes when the content filter passes", async () => {
     (shouldResize as jest.Mock).mockReturnValue(true);
     (downloadOriginalFile as jest.Mock).mockResolvedValue([
       "/tmp/test.jpg",
       {},
     ]);
-    (processContentFilter as jest.Mock).mockResolvedValue({
-      passed: true,
-      failed: false,
-    });
+    (processContentFilter as jest.Mock).mockResolvedValue(true);
     (resizeImages as jest.Mock).mockResolvedValue([
       {
         status: "fulfilled",
@@ -116,83 +113,26 @@ describe("generateResizedImageHandler", () => {
       },
     ]);
 
-    const mockObject = {
-      bucket: "demo-bucket",
-      name: "images/test.jpg",
-      contentType: "image/jpeg",
-    } as any;
-
     await generateResizedImageHandler(mockObject, false);
 
     expect(resizeImages).toHaveBeenCalledWith(
       expect.anything(),
       "/tmp/test.jpg",
-      expect.objectContaining({
-        dir: "images",
-        base: "test.jpg",
-        name: "test",
-        ext: ".jpg",
-      }),
+      parsedPathMatcher,
       mockObject
     );
     expect(handleFailedImage).not.toHaveBeenCalled();
   });
 
-  test("resizes when passed:true even if failed is null", async () => {
+  test("treats filter errors as failures and skips resizing", async () => {
     (shouldResize as jest.Mock).mockReturnValue(true);
     (downloadOriginalFile as jest.Mock).mockResolvedValue([
       "/tmp/test.jpg",
       {},
     ]);
-    (processContentFilter as jest.Mock).mockResolvedValue({
-      passed: true,
-      failed: null,
-    });
-    (resizeImages as jest.Mock).mockResolvedValue([
-      {
-        status: "fulfilled",
-        value: { success: true },
-      },
-    ]);
-
-    const mockObject = {
-      bucket: "demo-bucket",
-      name: "images/test.jpg",
-      contentType: "image/jpeg",
-    } as any;
-
-    await generateResizedImageHandler(mockObject, false);
-
-    expect(resizeImages).toHaveBeenCalledWith(
-      expect.anything(),
-      "/tmp/test.jpg",
-      expect.objectContaining({
-        dir: "images",
-        base: "test.jpg",
-        name: "test",
-        ext: ".jpg",
-      }),
-      mockObject
+    (processContentFilter as jest.Mock).mockRejectedValue(
+      new Error("filter boom")
     );
-    expect(handleFailedImage).not.toHaveBeenCalled();
-  });
-
-  test("does not resize when passed:false even if failed:false", async () => {
-    (shouldResize as jest.Mock).mockReturnValue(true);
-    (downloadOriginalFile as jest.Mock).mockResolvedValue([
-      "/tmp/test.jpg",
-      {},
-    ]);
-    (processContentFilter as jest.Mock).mockResolvedValue({
-      passed: false,
-      failed: false,
-    });
-
-    const mockObject = {
-      bucket: "demo-bucket",
-      name: "images/test.jpg",
-      contentType: "image/jpeg",
-    } as any;
 
     await generateResizedImageHandler(mockObject, false);
 
@@ -201,13 +141,8 @@ describe("generateResizedImageHandler", () => {
       expect.anything(),
       "/tmp/test.jpg",
       mockObject,
-      expect.objectContaining({
-        dir: "images",
-        base: "test.jpg",
-        name: "test",
-        ext: ".jpg",
-      }),
-      true
+      parsedPathMatcher,
+      false
     );
   });
 });

--- a/storage-resize-images/functions/__tests__/unit/generateResizedImageHandler.test.ts
+++ b/storage-resize-images/functions/__tests__/unit/generateResizedImageHandler.test.ts
@@ -20,7 +20,11 @@ jest.mock("../../src/file-operations", () => ({
 }));
 
 jest.mock("../../src/content-filter", () => ({
-  processContentFilter: jest.fn(),
+  checkImageContent: jest.fn(),
+}));
+
+jest.mock("../../src/placeholder", () => ({
+  replacePlaceholder: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock("../../src/resize-image", () => ({
@@ -43,6 +47,8 @@ jest.mock("../../src/logs", () => ({
   complete: jest.fn(),
   error: jest.fn(),
   contentFilterErrored: jest.fn(),
+  contentFilterRejected: jest.fn(),
+  placeholderReplaceError: jest.fn(),
 }));
 
 jest.mock("firebase-admin", () => ({
@@ -58,8 +64,10 @@ import {
   downloadOriginalFile,
   handleFailedImage,
 } from "../../src/file-operations";
-import { processContentFilter } from "../../src/content-filter";
+import { checkImageContent } from "../../src/content-filter";
+import { replacePlaceholder } from "../../src/placeholder";
 import { resizeImages } from "../../src/resize-image";
+import * as logs from "../../src/logs";
 
 describe("generateResizedImageHandler", () => {
   beforeEach(() => {
@@ -85,10 +93,11 @@ describe("generateResizedImageHandler", () => {
       "/tmp/test.jpg",
       {},
     ]);
-    (processContentFilter as jest.Mock).mockResolvedValue(false);
+    (checkImageContent as jest.Mock).mockResolvedValue(false);
 
     await generateResizedImageHandler(mockObject, false);
 
+    expect(replacePlaceholder).toHaveBeenCalled();
     expect(resizeImages).not.toHaveBeenCalled();
     expect(handleFailedImage).toHaveBeenCalledWith(
       expect.anything(),
@@ -105,7 +114,7 @@ describe("generateResizedImageHandler", () => {
       "/tmp/test.jpg",
       {},
     ]);
-    (processContentFilter as jest.Mock).mockResolvedValue(true);
+    (checkImageContent as jest.Mock).mockResolvedValue(true);
     (resizeImages as jest.Mock).mockResolvedValue([
       {
         status: "fulfilled",
@@ -115,6 +124,7 @@ describe("generateResizedImageHandler", () => {
 
     await generateResizedImageHandler(mockObject, false);
 
+    expect(replacePlaceholder).not.toHaveBeenCalled();
     expect(resizeImages).toHaveBeenCalledWith(
       expect.anything(),
       "/tmp/test.jpg",
@@ -130,12 +140,13 @@ describe("generateResizedImageHandler", () => {
       "/tmp/test.jpg",
       {},
     ]);
-    (processContentFilter as jest.Mock).mockRejectedValue(
+    (checkImageContent as jest.Mock).mockRejectedValue(
       new Error("filter boom")
     );
 
     await generateResizedImageHandler(mockObject, false);
 
+    expect(replacePlaceholder).not.toHaveBeenCalled();
     expect(resizeImages).not.toHaveBeenCalled();
     expect(handleFailedImage).toHaveBeenCalledWith(
       expect.anything(),
@@ -143,6 +154,30 @@ describe("generateResizedImageHandler", () => {
       mockObject,
       parsedPathMatcher,
       false
+    );
+  });
+
+  test("still routes blocked images to the failed path when placeholder swap errors", async () => {
+    (shouldResize as jest.Mock).mockReturnValue(true);
+    (downloadOriginalFile as jest.Mock).mockResolvedValue([
+      "/tmp/test.jpg",
+      {},
+    ]);
+    (checkImageContent as jest.Mock).mockResolvedValue(false);
+    const swapErr = new Error("swap boom");
+    (replacePlaceholder as jest.Mock).mockRejectedValue(swapErr);
+
+    await generateResizedImageHandler(mockObject, false);
+
+    expect(logs.placeholderReplaceError).toHaveBeenCalledWith(swapErr);
+    expect(logs.contentFilterErrored).not.toHaveBeenCalled();
+    expect(resizeImages).not.toHaveBeenCalled();
+    expect(handleFailedImage).toHaveBeenCalledWith(
+      expect.anything(),
+      "/tmp/test.jpg",
+      mockObject,
+      parsedPathMatcher,
+      true
     );
   });
 });

--- a/storage-resize-images/functions/__tests__/unit/generateResizedImageHandler.test.ts
+++ b/storage-resize-images/functions/__tests__/unit/generateResizedImageHandler.test.ts
@@ -1,0 +1,213 @@
+import * as path from "path";
+import { config as loadEnv } from "dotenv";
+
+const envLocalPath = path.resolve(
+  __dirname,
+  "../../../../_emulator/extensions/storage-resize-images.env.local"
+);
+
+loadEnv({ path: envLocalPath, debug: true, override: true });
+
+jest.mock("../../src/filters", () => ({
+  shouldResize: jest.fn(),
+}));
+
+jest.mock("../../src/file-operations", () => ({
+  downloadOriginalFile: jest.fn(),
+  handleFailedImage: jest.fn(),
+  deleteTempFile: jest.fn().mockResolvedValue(undefined),
+  deleteRemoteFile: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../src/content-filter", () => ({
+  processContentFilter: jest.fn(),
+}));
+
+jest.mock("../../src/resize-image", () => ({
+  resizeImages: jest.fn(),
+}));
+
+jest.mock("../../src/events", () => ({
+  setupEventChannel: jest.fn(),
+  recordStartResizeEvent: jest.fn().mockResolvedValue(undefined),
+  recordSuccessEvent: jest.fn().mockResolvedValue(undefined),
+  recordErrorEvent: jest.fn().mockResolvedValue(undefined),
+  recordStartEvent: jest.fn().mockResolvedValue(undefined),
+  recordCompletionEvent: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../src/logs", () => ({
+  init: jest.fn(),
+  start: jest.fn(),
+  failed: jest.fn(),
+  complete: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock("firebase-admin", () => ({
+  initializeApp: jest.fn(),
+  storage: jest.fn(() => ({
+    bucket: jest.fn(() => ({})),
+  })),
+}));
+
+import { generateResizedImageHandler } from "../../src/index";
+import { shouldResize } from "../../src/filters";
+import {
+  downloadOriginalFile,
+  handleFailedImage,
+} from "../../src/file-operations";
+import { processContentFilter } from "../../src/content-filter";
+import { resizeImages } from "../../src/resize-image";
+
+describe("generateResizedImageHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("goes down the failed-image path when content filter returns passed:false and failed:null", async () => {
+    (shouldResize as jest.Mock).mockReturnValue(true);
+    (downloadOriginalFile as jest.Mock).mockResolvedValue([
+      "/tmp/test.jpg",
+      {},
+    ]);
+    (processContentFilter as jest.Mock).mockResolvedValue({
+      passed: false,
+      failed: null,
+    });
+
+    const mockObject = {
+      bucket: "demo-bucket",
+      name: "images/test.jpg",
+      contentType: "image/jpeg",
+    } as any;
+
+    await generateResizedImageHandler(mockObject, false);
+
+    expect(resizeImages).not.toHaveBeenCalled();
+    expect(handleFailedImage).toHaveBeenCalledWith(
+      expect.anything(),
+      "/tmp/test.jpg",
+      mockObject,
+      expect.objectContaining({
+        dir: "images",
+        base: "test.jpg",
+        name: "test",
+        ext: ".jpg",
+      }),
+      true
+    );
+  });
+
+  test("resizes image when content filter returns passed:true and failed:false", async () => {
+    (shouldResize as jest.Mock).mockReturnValue(true);
+    (downloadOriginalFile as jest.Mock).mockResolvedValue([
+      "/tmp/test.jpg",
+      {},
+    ]);
+    (processContentFilter as jest.Mock).mockResolvedValue({
+      passed: true,
+      failed: false,
+    });
+    (resizeImages as jest.Mock).mockResolvedValue([
+      {
+        status: "fulfilled",
+        value: { success: true },
+      },
+    ]);
+
+    const mockObject = {
+      bucket: "demo-bucket",
+      name: "images/test.jpg",
+      contentType: "image/jpeg",
+    } as any;
+
+    await generateResizedImageHandler(mockObject, false);
+
+    expect(resizeImages).toHaveBeenCalledWith(
+      expect.anything(),
+      "/tmp/test.jpg",
+      expect.objectContaining({
+        dir: "images",
+        base: "test.jpg",
+        name: "test",
+        ext: ".jpg",
+      }),
+      mockObject
+    );
+    expect(handleFailedImage).not.toHaveBeenCalled();
+  });
+
+  test("resizes when passed:true even if failed is null", async () => {
+    (shouldResize as jest.Mock).mockReturnValue(true);
+    (downloadOriginalFile as jest.Mock).mockResolvedValue([
+      "/tmp/test.jpg",
+      {},
+    ]);
+    (processContentFilter as jest.Mock).mockResolvedValue({
+      passed: true,
+      failed: null,
+    });
+    (resizeImages as jest.Mock).mockResolvedValue([
+      {
+        status: "fulfilled",
+        value: { success: true },
+      },
+    ]);
+
+    const mockObject = {
+      bucket: "demo-bucket",
+      name: "images/test.jpg",
+      contentType: "image/jpeg",
+    } as any;
+
+    await generateResizedImageHandler(mockObject, false);
+
+    expect(resizeImages).toHaveBeenCalledWith(
+      expect.anything(),
+      "/tmp/test.jpg",
+      expect.objectContaining({
+        dir: "images",
+        base: "test.jpg",
+        name: "test",
+        ext: ".jpg",
+      }),
+      mockObject
+    );
+    expect(handleFailedImage).not.toHaveBeenCalled();
+  });
+
+  test("does not resize when passed:false even if failed:false", async () => {
+    (shouldResize as jest.Mock).mockReturnValue(true);
+    (downloadOriginalFile as jest.Mock).mockResolvedValue([
+      "/tmp/test.jpg",
+      {},
+    ]);
+    (processContentFilter as jest.Mock).mockResolvedValue({
+      passed: false,
+      failed: false,
+    });
+
+    const mockObject = {
+      bucket: "demo-bucket",
+      name: "images/test.jpg",
+      contentType: "image/jpeg",
+    } as any;
+
+    await generateResizedImageHandler(mockObject, false);
+
+    expect(resizeImages).not.toHaveBeenCalled();
+    expect(handleFailedImage).toHaveBeenCalledWith(
+      expect.anything(),
+      "/tmp/test.jpg",
+      mockObject,
+      expect.objectContaining({
+        dir: "images",
+        base: "test.jpg",
+        name: "test",
+        ext: ".jpg",
+      }),
+      true
+    );
+  });
+});

--- a/storage-resize-images/functions/package.json
+++ b/storage-resize-images/functions/package.json
@@ -12,6 +12,7 @@
     "compile": "tsc",
     "test": "jest",
     "test:vulnerability": "RUN_VULNERABILITY_TEST=true jest",
+    "test:live-content-filter": "RUN_LIVE_CONTENT_FILTER_TESTS=true jest --testPathPattern=integration/content-filter.live",
     "generate-readme": "firebase ext:info .. --markdown > ../README.md"
   },
   "dependencies": {

--- a/storage-resize-images/functions/package.json
+++ b/storage-resize-images/functions/package.json
@@ -12,7 +12,7 @@
     "compile": "tsc",
     "test": "jest",
     "test:vulnerability": "RUN_VULNERABILITY_TEST=true jest",
-    "test:live-content-filter": "RUN_LIVE_CONTENT_FILTER_TESTS=true jest --testPathPattern=integration/content-filter.live",
+    "test:live-content-filter": "NODE_OPTIONS=--experimental-vm-modules RUN_LIVE_CONTENT_FILTER_TESTS=true jest --testPathPattern=integration/content-filter.live",
     "generate-readme": "firebase ext:info .. --markdown > ../README.md"
   },
   "dependencies": {

--- a/storage-resize-images/functions/src/content-filter.ts
+++ b/storage-resize-images/functions/src/content-filter.ts
@@ -3,13 +3,6 @@ import { genkit, z } from "genkit";
 import type { SafetyThreshold } from "./config";
 import * as fs from "fs";
 import * as path from "path";
-import { Bucket } from "@google-cloud/storage";
-import { ObjectMetadata } from "firebase-functions/v1/storage";
-import {
-  replaceWithConfiguredPlaceholder,
-  replaceWithDefaultPlaceholder,
-} from "./util";
-// Import the logging functions from your log.ts module
 import * as log from "./logs";
 import { globalRetryQueue } from "./global";
 
@@ -218,48 +211,4 @@ export async function checkImageContent(
 
   // Start the first attempt (not via queue)
   return await attemptWithRetry(1);
-}
-
-/**
- * Runs content filtering and, if the image is blocked, swaps the local file
- * with a placeholder image.
- *
- * @returns `true` if the image passed the filter, `false` if it was blocked
- * (the local file has been replaced with a placeholder).
- * @throws If the filter call errors or the placeholder swap errors. Callers
- * are responsible for treating these as failures.
- */
-export async function processContentFilter(
-  localFile: string,
-  object: ObjectMetadata,
-  bucket: Bucket,
-  config: any
-): Promise<boolean> {
-  const passed = await checkImageContent(
-    localFile,
-    config.contentFilterLevel,
-    config.customFilterPrompt,
-    object.contentType
-  );
-
-  if (passed) {
-    return true;
-  }
-
-  log.contentFilterRejected(object.name);
-
-  if (config.placeholderImagePath) {
-    log.replacingWithConfiguredPlaceholder(config.placeholderImagePath);
-    await replaceWithConfiguredPlaceholder(
-      localFile,
-      bucket,
-      config.placeholderImagePath
-    );
-  } else {
-    log.replacingWithDefaultPlaceholder();
-    await replaceWithDefaultPlaceholder(localFile);
-  }
-  log.placeholderReplaceComplete(localFile);
-
-  return false;
 }

--- a/storage-resize-images/functions/src/content-filter.ts
+++ b/storage-resize-images/functions/src/content-filter.ts
@@ -64,97 +64,9 @@ function createSafetySettings(filterLevel: SafetyThreshold) {
 }
 
 /**
- * Performs the actual content check with the AI model
- * @param localOriginalFile Path to the local image file
- * @param filterLevel The content filter level to apply
- * @param prompt Optional custom prompt to use for content checking
- * @param contentType The content type of the image
- * @returns Promise<boolean> - true if the image passes the filter, false otherwise
- */
-async function performContentCheck(
-  localOriginalFile: string,
-  filterLevel: SafetyThreshold | null,
-  prompt: string | null,
-  contentType: string
-): Promise<boolean> {
-  const dataUrl = createImageDataUrl(localOriginalFile);
-
-  // Initialize Vertex AI client
-  const ai = genkit({
-    plugins: [
-      vertexAI({
-        location: process.env.LOCATION ?? "us-central1",
-        models: ["gemini-2.5-flash"],
-      }),
-    ],
-  });
-
-  // Determine the effective safety settings and prompt to use
-  const effectiveFilterLevel: SafetyThreshold =
-    filterLevel === null ? "BLOCK_NONE" : filterLevel;
-  const effectivePrompt =
-    prompt !== null
-      ? prompt +
-        '\n\n Please respond in json with either { "response": "yes" } or  { "response": "no" }'
-      : "Is this image appropriate?";
-
-  const effectiveOutput =
-    prompt !== null
-      ? {
-          format: "json",
-          schema: z.object({
-            response: z.string(),
-          }),
-        }
-      : undefined;
-
-  // Determine max tokens based on whether we're using custom prompt
-  const maxOutputTokens = prompt !== null ? 100 : 1;
-
-  try {
-    const result = await ai.generate({
-      model: gemini("gemini-2.5-flash"),
-      messages: [
-        {
-          role: "user",
-          content: [
-            {
-              text: effectivePrompt,
-            },
-            {
-              media: {
-                url: dataUrl,
-                contentType,
-              },
-            },
-          ],
-        },
-      ],
-      output: effectiveOutput,
-      config: {
-        temperature: 0.1,
-        maxOutputTokens,
-        safetySettings: createSafetySettings(effectiveFilterLevel),
-      },
-    });
-
-    if (result.output?.response === "yes" && prompt !== null) {
-      log.customFilterBlocked();
-      return false;
-    }
-
-    return true;
-  } catch (error) {
-    if (error.detail?.response?.finishReason === "blocked") {
-      log.contentFilterBlocked();
-      return false;
-    }
-    throw error;
-  }
-}
-
-/**
- * Checks if an image content is appropriate based on the provided filter level and optional custom prompt
+ * Entry point for image moderation: short-circuits when disabled, otherwise runs a single
+ * Vertex/Gemini call per attempt with retries and queue-backed backoff on transient errors.
+ *
  * @param localOriginalFile Path to the local image file
  * @param filterLevel The content filter level to apply ('LOW', 'MEDIUM', 'HIGH', or null to disable)
  * @param prompt Optional custom prompt to use for content checking
@@ -173,15 +85,85 @@ export async function checkImageContent(
     return true;
   }
 
-  // Helper function that handles retries using the queue
+  /** One Gemini moderation call (no retries). */
+  async function moderateImageOnce(): Promise<boolean> {
+    const dataUrl = createImageDataUrl(localOriginalFile);
+
+    const ai = genkit({
+      plugins: [
+        vertexAI({
+          location: process.env.LOCATION ?? "us-central1",
+          models: ["gemini-2.5-flash"],
+        }),
+      ],
+    });
+
+    const effectiveFilterLevel: SafetyThreshold =
+      filterLevel === null ? "BLOCK_NONE" : filterLevel;
+
+    const hasCustomPrompt = prompt !== null;
+
+    const effectivePrompt = hasCustomPrompt
+      ? prompt +
+        '\n\n Please respond in json with either { "response": "yes" } or  { "response": "no" }'
+      : "Is this image appropriate?";
+
+    const effectiveOutput = hasCustomPrompt
+      ? {
+          format: "json",
+          schema: z.object({
+            response: z.string(),
+          }),
+        }
+      : undefined;
+
+    const maxOutputTokens = hasCustomPrompt ? 100 : 1;
+
+    try {
+      const result = await ai.generate({
+        model: gemini("gemini-2.5-flash"),
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                text: effectivePrompt,
+              },
+              {
+                media: {
+                  url: dataUrl,
+                  contentType,
+                },
+              },
+            ],
+          },
+        ],
+        output: effectiveOutput,
+        config: {
+          temperature: 0.1,
+          maxOutputTokens,
+          safetySettings: createSafetySettings(effectiveFilterLevel),
+        },
+      });
+
+      if (result.output?.response === "yes" && hasCustomPrompt) {
+        log.customFilterBlocked();
+        return false;
+      }
+
+      return true;
+    } catch (error) {
+      if (error.detail?.response?.finishReason === "blocked") {
+        log.contentFilterBlocked();
+        return false;
+      }
+      throw error;
+    }
+  }
+
   const attemptWithRetry = async (attemptNumber: number): Promise<boolean> => {
     try {
-      return await performContentCheck(
-        localOriginalFile,
-        filterLevel,
-        prompt,
-        contentType
-      );
+      return await moderateImageOnce();
     } catch (error) {
       // If we have attempts left, schedule a retry via the queue
       if (attemptNumber < maxAttempts) {

--- a/storage-resize-images/functions/src/content-filter.ts
+++ b/storage-resize-images/functions/src/content-filter.ts
@@ -221,51 +221,45 @@ export async function checkImageContent(
 }
 
 /**
- * Processes content filtering and handles placeholder replacement if needed
+ * Runs content filtering and, if the image is blocked, swaps the local file
+ * with a placeholder image.
+ *
+ * @returns `true` if the image passed the filter, `false` if it was blocked
+ * (the local file has been replaced with a placeholder).
+ * @throws If the filter call errors or the placeholder swap errors. Callers
+ * are responsible for treating these as failures.
  */
 export async function processContentFilter(
   localFile: string,
   object: ObjectMetadata,
   bucket: Bucket,
-  _verbose: boolean,
   config: any
-): Promise<{ passed: boolean; failed: boolean | null }> {
-  let filterResult = true; // Default to true (pass)
-  let failed = null; // No failures yet
+): Promise<boolean> {
+  const passed = await checkImageContent(
+    localFile,
+    config.contentFilterLevel,
+    config.customFilterPrompt,
+    object.contentType
+  );
 
-  try {
-    filterResult = await checkImageContent(
+  if (passed) {
+    return true;
+  }
+
+  log.contentFilterRejected(object.name);
+
+  if (config.placeholderImagePath) {
+    log.replacingWithConfiguredPlaceholder(config.placeholderImagePath);
+    await replaceWithConfiguredPlaceholder(
       localFile,
-      config.contentFilterLevel,
-      config.customFilterPrompt,
-      object.contentType
+      bucket,
+      config.placeholderImagePath
     );
-  } catch (err) {
-    log.contentFilterErrored(err);
-    failed = true;
+  } else {
+    log.replacingWithDefaultPlaceholder();
+    await replaceWithDefaultPlaceholder(localFile);
   }
+  log.placeholderReplaceComplete(localFile);
 
-  if (filterResult === false) {
-    log.contentFilterRejected(object.name);
-
-    try {
-      if (config.placeholderImagePath) {
-        log.replacingWithConfiguredPlaceholder(config.placeholderImagePath);
-        await replaceWithConfiguredPlaceholder(
-          localFile,
-          bucket,
-          config.placeholderImagePath
-        );
-      } else {
-        log.replacingWithDefaultPlaceholder();
-        await replaceWithDefaultPlaceholder(localFile);
-      }
-      log.placeholderReplaceComplete(localFile);
-    } catch (err) {
-      log.placeholderReplaceError(err);
-      failed = true;
-    }
-  }
-
-  return { passed: filterResult, failed };
+  return false;
 }

--- a/storage-resize-images/functions/src/content-filter.ts
+++ b/storage-resize-images/functions/src/content-filter.ts
@@ -2,29 +2,18 @@ import vertexAI, { gemini } from "@genkit-ai/vertexai";
 import { genkit, z } from "genkit";
 import type { SafetyThreshold } from "./config";
 import * as fs from "fs";
-import * as path from "path";
 import * as log from "./logs";
 import { globalRetryQueue } from "./global";
 
 /**
  * Creates a data URL from an image file
- * @param filePath Path to the image file
+ * @param imageBuffer Raw image file contents
+ * @param contentType MIME type for the image, for example "image/jpeg"
  * @returns Data URL string
  */
-function createImageDataUrl(filePath: string): string {
-  const imageBuffer = fs.readFileSync(filePath);
+function createImageDataUrl(imageBuffer: Buffer, contentType: string): string {
   const base64Image = imageBuffer.toString("base64");
-  const mimeType = getMimeType(filePath);
-  return `data:${mimeType};base64,${base64Image}`;
-}
-
-/**
- * Determines MIME type based on file extension
- * @param filePath Path to the file
- * @returns MIME type string
- */
-function getMimeType(filePath: string): string {
-  return path.extname(filePath).toLowerCase();
+  return `data:${contentType};base64,${base64Image}`;
 }
 
 /**
@@ -36,20 +25,12 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-type SafetyCategory =
-  | "HARM_CATEGORY_UNSPECIFIED"
-  | "HARM_CATEGORY_HATE_SPEECH"
-  | "HARM_CATEGORY_DANGEROUS_CONTENT"
-  | "HARM_CATEGORY_HARASSMENT"
-  | "HARM_CATEGORY_SEXUALLY_EXPLICIT";
-
-const HARM_CATEGORIES: ReadonlyArray<SafetyCategory> = [
+const HARM_CATEGORIES = [
   "HARM_CATEGORY_HATE_SPEECH",
   "HARM_CATEGORY_DANGEROUS_CONTENT",
-  "HARM_CATEGORY_UNSPECIFIED",
   "HARM_CATEGORY_SEXUALLY_EXPLICIT",
   "HARM_CATEGORY_HARASSMENT",
-];
+] as const;
 
 /**
  * Creates safety settings based on filter level
@@ -60,7 +41,7 @@ function createSafetySettings(filterLevel: SafetyThreshold) {
   return HARM_CATEGORIES.map((category) => ({
     category,
     threshold: filterLevel,
-  }));
+  })) as any;
 }
 
 /**
@@ -85,19 +66,20 @@ export async function checkImageContent(
     return true;
   }
 
+  const imageBuffer = fs.readFileSync(localOriginalFile);
+  const dataUrl = createImageDataUrl(imageBuffer, contentType);
+
+  const ai = genkit({
+    plugins: [
+      vertexAI({
+        location: process.env.LOCATION ?? "us-central1",
+        models: ["gemini-2.5-flash"],
+      }),
+    ],
+  });
+
   /** One Gemini moderation call (no retries). */
   async function moderateImageOnce(): Promise<boolean> {
-    const dataUrl = createImageDataUrl(localOriginalFile);
-
-    const ai = genkit({
-      plugins: [
-        vertexAI({
-          location: process.env.LOCATION ?? "us-central1",
-          models: ["gemini-2.5-flash"],
-        }),
-      ],
-    });
-
     const effectiveFilterLevel: SafetyThreshold =
       filterLevel === null ? "BLOCK_NONE" : filterLevel;
 

--- a/storage-resize-images/functions/src/content-filter.ts
+++ b/storage-resize-images/functions/src/content-filter.ts
@@ -77,6 +77,20 @@ function isModerationSchemaRefusal(error: unknown): boolean {
 }
 
 /**
+ * Detects Gemini's explicit safety block, surfaced by genkit as a thrown
+ * error whose response carries finishReason === "blocked". Narrowed from
+ * `unknown` for the same reason as {@link isModerationSchemaRefusal}: the
+ * catch variable has no static shape.
+ */
+function isSafetyBlockedResponse(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const e = error as {
+    detail?: { response?: { finishReason?: unknown } };
+  };
+  return e.detail?.response?.finishReason === "blocked";
+}
+
+/**
  * Entry point for image moderation: short-circuits when disabled, otherwise runs a single
  * Vertex/Gemini call per attempt with retries and queue-backed backoff on transient errors.
  *
@@ -168,10 +182,7 @@ export async function checkImageContent(
 
       return true;
     } catch (error) {
-      if (
-        error.detail?.response?.finishReason === "blocked" ||
-        isModerationSchemaRefusal(error)
-      ) {
+      if (isSafetyBlockedResponse(error) || isModerationSchemaRefusal(error)) {
         log.contentFilterBlocked();
         return false;
       }

--- a/storage-resize-images/functions/src/content-filter.ts
+++ b/storage-resize-images/functions/src/content-filter.ts
@@ -45,6 +45,25 @@ function createSafetySettings(filterLevel: SafetyThreshold) {
 }
 
 /**
+ * Detects the genkit ValidationError shape that Gemini 2.5 Flash produces
+ * when its input-side safety refuses on borderline image inputs: the
+ * candidate comes back with empty content (no SAFETY finishReason), so
+ * genkit's assertValidSchema runs parseSchema(null, ...) and throws
+ * ValidationError with status "INVALID_ARGUMENT" and a formatted message
+ * containing "Provided data:\n\nnull". Treat as an implicit block — the
+ * failure is deterministic, so retrying just burns API calls.
+ */
+function isNullContentSafetyRefusal(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const e = error as { status?: string; originalMessage?: string };
+  return (
+    e.status === "INVALID_ARGUMENT" &&
+    typeof e.originalMessage === "string" &&
+    /Provided data:\s*\n+\s*null/.test(e.originalMessage)
+  );
+}
+
+/**
  * Entry point for image moderation: short-circuits when disabled, otherwise runs a single
  * Vertex/Gemini call per attempt with retries and queue-backed backoff on transient errors.
  *
@@ -136,7 +155,10 @@ export async function checkImageContent(
 
       return true;
     } catch (error) {
-      if (error.detail?.response?.finishReason === "blocked") {
+      if (
+        error.detail?.response?.finishReason === "blocked" ||
+        isNullContentSafetyRefusal(error)
+      ) {
         log.contentFilterBlocked();
         return false;
       }

--- a/storage-resize-images/functions/src/content-filter.ts
+++ b/storage-resize-images/functions/src/content-filter.ts
@@ -45,37 +45,35 @@ function createSafetySettings(filterLevel: SafetyThreshold) {
 }
 
 /**
- * Detects the genkit ValidationError shape that Gemini 2.5 Flash produces
- * when its input-side safety refuses on borderline image inputs: the
- * candidate comes back with empty content (no SAFETY finishReason), so
- * genkit's assertValidSchema runs parseSchema(null, ...) and throws
- * ValidationError. Treat as an implicit block — the failure is
- * deterministic, so retrying just burns API calls.
+ * Detects genkit's ValidationError, thrown when Gemini's response can't
+ * be parsed against our moderation schema. Observed manifestations on
+ * Gemini 2.5 Flash safety refusals: data === null (empty content), data
+ * === {} (refusal text that extractJson() coerced to an empty object),
+ * and likely other variants future model versions may produce.
  *
- * Three signals must all hold to avoid false-positives on unrelated
- * INVALID_ARGUMENT errors:
- *  - status === "INVALID_ARGUMENT"
- *  - detail.errors is a populated array (proves it's a ValidationError,
- *    structurally — see @genkit-ai/core/lib/schema.js, ValidationError
- *    constructor populates `detail: { errors, schema }`)
- *  - originalMessage matches the null-data signature (proves the
- *    validation failed specifically because the model returned null,
- *    not because of e.g. a property type mismatch)
+ * In this code path we control both the prompt and the schema, so any
+ * ValidationError from `ai.generate` originates from the model's
+ * response — there is no other validation source. Retrying is useless
+ * (deterministic same-input → same-bad-response), and the alternative
+ * (propagate as filterErrored) silently fails open on borderline NSFW
+ * imagery, which is the original bug. So treat any schema-validation
+ * failure here as an implicit block.
+ *
+ * Two structural signals must hold:
+ *  - status === "INVALID_ARGUMENT" (genkit's category for ValidationError)
+ *  - detail.errors is a populated array (proves the error came from
+ *    parseSchema specifically — see @genkit-ai/core schema.js,
+ *    ValidationError ctor populates detail: { errors, schema })
  */
-function isNullContentSafetyRefusal(error: unknown): boolean {
+function isModerationSchemaRefusal(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
   const e = error as {
     status?: string;
-    originalMessage?: string;
     detail?: { errors?: unknown };
   };
   if (e.status !== "INVALID_ARGUMENT") return false;
   const errors = e.detail?.errors;
-  if (!Array.isArray(errors) || errors.length === 0) return false;
-  return (
-    typeof e.originalMessage === "string" &&
-    /Provided data:\s*\n+\s*null/.test(e.originalMessage)
-  );
+  return Array.isArray(errors) && errors.length > 0;
 }
 
 /**
@@ -172,7 +170,7 @@ export async function checkImageContent(
     } catch (error) {
       if (
         error.detail?.response?.finishReason === "blocked" ||
-        isNullContentSafetyRefusal(error)
+        isModerationSchemaRefusal(error)
       ) {
         log.contentFilterBlocked();
         return false;

--- a/storage-resize-images/functions/src/content-filter.ts
+++ b/storage-resize-images/functions/src/content-filter.ts
@@ -41,7 +41,7 @@ function createSafetySettings(filterLevel: SafetyThreshold) {
   return HARM_CATEGORIES.map((category) => ({
     category,
     threshold: filterLevel,
-  })) as any;
+  }));
 }
 
 /**
@@ -99,6 +99,7 @@ export async function checkImageContent(
         }
       : undefined;
 
+    // 1 token is enough for the default yes/no answer; custom prompts emit a JSON object.
     const maxOutputTokens = hasCustomPrompt ? 100 : 1;
 
     try {

--- a/storage-resize-images/functions/src/content-filter.ts
+++ b/storage-resize-images/functions/src/content-filter.ts
@@ -49,15 +49,30 @@ function createSafetySettings(filterLevel: SafetyThreshold) {
  * when its input-side safety refuses on borderline image inputs: the
  * candidate comes back with empty content (no SAFETY finishReason), so
  * genkit's assertValidSchema runs parseSchema(null, ...) and throws
- * ValidationError with status "INVALID_ARGUMENT" and a formatted message
- * containing "Provided data:\n\nnull". Treat as an implicit block — the
- * failure is deterministic, so retrying just burns API calls.
+ * ValidationError. Treat as an implicit block — the failure is
+ * deterministic, so retrying just burns API calls.
+ *
+ * Three signals must all hold to avoid false-positives on unrelated
+ * INVALID_ARGUMENT errors:
+ *  - status === "INVALID_ARGUMENT"
+ *  - detail.errors is a populated array (proves it's a ValidationError,
+ *    structurally — see @genkit-ai/core/lib/schema.js, ValidationError
+ *    constructor populates `detail: { errors, schema }`)
+ *  - originalMessage matches the null-data signature (proves the
+ *    validation failed specifically because the model returned null,
+ *    not because of e.g. a property type mismatch)
  */
 function isNullContentSafetyRefusal(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
-  const e = error as { status?: string; originalMessage?: string };
+  const e = error as {
+    status?: string;
+    originalMessage?: string;
+    detail?: { errors?: unknown };
+  };
+  if (e.status !== "INVALID_ARGUMENT") return false;
+  const errors = e.detail?.errors;
+  if (!Array.isArray(errors) || errors.length === 0) return false;
   return (
-    e.status === "INVALID_ARGUMENT" &&
     typeof e.originalMessage === "string" &&
     /Provided data:\s*\n+\s*null/.test(e.originalMessage)
   );

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -22,7 +22,7 @@ import * as path from "path";
 import * as sharp from "sharp";
 import { File } from "@google-cloud/storage";
 import { ObjectMetadata } from "firebase-functions/v1/storage";
-import * as fs from "fs-extra";
+import * as fs from "fs";
 
 import { resizeImages } from "./resize-image";
 import { config, deleteImage } from "./config";

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -29,7 +29,8 @@ import * as logs from "./logs";
 import { shouldResize } from "./filters";
 import * as events from "./events";
 import { convertToObjectMetadata } from "./util";
-import { processContentFilter } from "./content-filter";
+import { checkImageContent } from "./content-filter";
+import { replacePlaceholder } from "./placeholder";
 import {
   deleteRemoteFile,
   deleteTempFile,
@@ -80,12 +81,25 @@ export const generateResizedImageHandler = async (
     let blockedByFilter = false;
     let filterErrored = false;
     try {
-      blockedByFilter = !(await processContentFilter(
+      const passed = await checkImageContent(
         localOriginalFile,
-        object,
-        bucket,
-        config
-      ));
+        config.contentFilterLevel,
+        config.customFilterPrompt,
+        object.contentType
+      );
+      if (!passed) {
+        blockedByFilter = true;
+        logs.contentFilterRejected(object.name);
+        try {
+          await replacePlaceholder(
+            localOriginalFile,
+            bucket,
+            config.placeholderImagePath
+          );
+        } catch (err) {
+          logs.placeholderReplaceError(err);
+        }
+      }
     } catch (err) {
       logs.contentFilterErrored(err);
       filterErrored = true;

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -67,8 +67,6 @@ export const generateResizedImageHandler = async (
   const bucket = admin.storage().bucket(object.bucket);
   const filePath = object.name; // File path in the bucket.
   const parsedPath = path.parse(filePath);
-  const objectMetadata = object;
-  let failed = null;
   let localOriginalFile: string;
   let remoteOriginalFile: File;
 
@@ -79,23 +77,27 @@ export const generateResizedImageHandler = async (
       verbose
     );
 
-    // Check content filter and replace with placeholder if needed
-    const filterResult = await processContentFilter(
-      localOriginalFile,
-      object,
-      bucket,
-      verbose,
-      config
-    );
+    let blockedByFilter = false;
+    let filterErrored = false;
+    try {
+      blockedByFilter = !(await processContentFilter(
+        localOriginalFile,
+        object,
+        bucket,
+        config
+      ));
+    } catch (err) {
+      logs.contentFilterErrored(err);
+      filterErrored = true;
+    }
 
-    // Process image resizing if content filter didn't fail
-    if (filterResult.passed === true) {
-      // if (filterResult.failed !== true) {
+    let resizeFailed = false;
+    if (!blockedByFilter && !filterErrored) {
       const resizeResults = await resizeImages(
         bucket,
         localOriginalFile,
         parsedPath,
-        objectMetadata
+        object
       );
 
       await events.recordSuccessEvent({
@@ -103,21 +105,17 @@ export const generateResizedImageHandler = async (
         data: {
           input: object,
           outputs: resizeResults,
-          contentFilterPassed: filterResult.passed,
+          contentFilterPassed: true,
         },
       });
 
-      // Only update failed status if it's still null (not already failed from content filter)
-      failed =
-        filterResult.failed === null
-          ? resizeResults.some(
-              (result) =>
-                result.status === "rejected" || result.value.success === false
-            )
-          : filterResult.failed;
-    } else {
-      failed = true;
+      resizeFailed = resizeResults.some(
+        (result) =>
+          result.status === "rejected" || result.value.success === false
+      );
     }
+
+    const failed = blockedByFilter || filterErrored || resizeFailed;
 
     if (failed) {
       logs.failed();
@@ -126,7 +124,7 @@ export const generateResizedImageHandler = async (
         localOriginalFile,
         object,
         parsedPath,
-        filterResult.passed === false
+        blockedByFilter
       );
     } else {
       if (config.deleteOriginalFile === deleteImage.onSuccess) {

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -50,7 +50,7 @@ logs.init(config);
  * When an image is uploaded in the Storage bucket, we generate a resized image automatically using
  * the Sharp image converting library.
  */
-const generateResizedImageHandler = async (
+export const generateResizedImageHandler = async (
   object: ObjectMetadata,
   verbose = true
 ): Promise<void> => {
@@ -89,7 +89,8 @@ const generateResizedImageHandler = async (
     );
 
     // Process image resizing if content filter didn't fail
-    if (filterResult.failed !== true) {
+    if (filterResult.passed === true) {
+      // if (filterResult.failed !== true) {
       const resizeResults = await resizeImages(
         bucket,
         localOriginalFile,

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -22,6 +22,7 @@ import * as path from "path";
 import * as sharp from "sharp";
 import { File } from "@google-cloud/storage";
 import { ObjectMetadata } from "firebase-functions/v1/storage";
+import * as fs from "fs-extra";
 
 import { resizeImages } from "./resize-image";
 import { config, deleteImage } from "./config";
@@ -68,7 +69,9 @@ export const generateResizedImageHandler = async (
   const bucket = admin.storage().bucket(object.bucket);
   const filePath = object.name; // File path in the bucket.
   const parsedPath = path.parse(filePath);
+
   let localOriginalFile: string;
+  let localProcessingFile: string | undefined;
   let remoteOriginalFile: File;
 
   try {
@@ -80,6 +83,8 @@ export const generateResizedImageHandler = async (
 
     let blockedByFilter = false;
     let filterErrored = false;
+    let blockedImageStored = false;
+
     try {
       const passed = await checkImageContent(
         localOriginalFile,
@@ -90,14 +95,27 @@ export const generateResizedImageHandler = async (
       if (!passed) {
         blockedByFilter = true;
         logs.contentFilterRejected(object.name);
+
+        await handleFailedImage(
+          bucket,
+          localOriginalFile,
+          object,
+          parsedPath,
+          true
+        );
+        blockedImageStored = true;
+
+        localProcessingFile = `${localOriginalFile}-placeholder`;
+        fs.copyFileSync(localOriginalFile, localProcessingFile);
         try {
           await replacePlaceholder(
-            localOriginalFile,
+            localProcessingFile,
             bucket,
             config.placeholderImagePath
           );
         } catch (err) {
           logs.placeholderReplaceError(err);
+          filterErrored = true;
         }
       }
     } catch (err) {
@@ -105,11 +123,13 @@ export const generateResizedImageHandler = async (
       filterErrored = true;
     }
 
+    const fileToResize = localProcessingFile ?? localOriginalFile;
+
     let resizeFailed = false;
-    if (!blockedByFilter && !filterErrored) {
+    if (!filterErrored) {
       const resizeResults = await resizeImages(
         bucket,
-        localOriginalFile,
+        fileToResize,
         parsedPath,
         object
       );
@@ -119,7 +139,7 @@ export const generateResizedImageHandler = async (
         data: {
           input: object,
           outputs: resizeResults,
-          contentFilterPassed: true,
+          contentFilterPassed: !blockedByFilter,
         },
       });
 
@@ -129,17 +149,19 @@ export const generateResizedImageHandler = async (
       );
     }
 
-    const failed = blockedByFilter || filterErrored || resizeFailed;
+    const failed = filterErrored || resizeFailed;
 
     if (failed) {
       logs.failed();
-      await handleFailedImage(
-        bucket,
-        localOriginalFile,
-        object,
-        parsedPath,
-        blockedByFilter
-      );
+      if (!blockedImageStored) {
+        await handleFailedImage(
+          bucket,
+          localOriginalFile,
+          object,
+          parsedPath,
+          blockedByFilter
+        );
+      }
     } else {
       if (config.deleteOriginalFile === deleteImage.onSuccess) {
         await deleteRemoteFile(remoteOriginalFile, filePath);
@@ -153,6 +175,10 @@ export const generateResizedImageHandler = async (
     // Clean up temporary files
     if (localOriginalFile) {
       await deleteTempFile(localOriginalFile, filePath, verbose);
+    }
+
+    if (localProcessingFile) {
+      await deleteTempFile(localProcessingFile, filePath, verbose);
     }
 
     if (

--- a/storage-resize-images/functions/src/index.ts
+++ b/storage-resize-images/functions/src/index.ts
@@ -86,11 +86,15 @@ export const generateResizedImageHandler = async (
     let blockedImageStored = false;
 
     try {
+      // shouldResize() above already rejects objects without a valid
+      // image/* contentType, so it is guaranteed defined here. The handler
+      // is exported and unit-tested directly, so assert the invariant
+      // explicitly rather than passing a possibly-undefined value through.
       const passed = await checkImageContent(
         localOriginalFile,
         config.contentFilterLevel,
         config.customFilterPrompt,
-        object.contentType
+        object.contentType!
       );
       if (!passed) {
         blockedByFilter = true;

--- a/storage-resize-images/functions/src/placeholder.ts
+++ b/storage-resize-images/functions/src/placeholder.ts
@@ -1,0 +1,31 @@
+import { Bucket } from "@google-cloud/storage";
+
+import * as log from "./logs";
+import {
+  replaceWithConfiguredPlaceholder,
+  replaceWithDefaultPlaceholder,
+} from "./util";
+
+/**
+ * Swaps the local file with a placeholder image. Uses the configured
+ * placeholder at `placeholderImagePath` when provided, otherwise the bundled
+ * default.
+ */
+export async function replacePlaceholder(
+  localFile: string,
+  bucket: Bucket,
+  placeholderImagePath: string | null
+): Promise<void> {
+  if (placeholderImagePath) {
+    log.replacingWithConfiguredPlaceholder(placeholderImagePath);
+    await replaceWithConfiguredPlaceholder(
+      localFile,
+      bucket,
+      placeholderImagePath
+    );
+  } else {
+    log.replacingWithDefaultPlaceholder();
+    await replaceWithDefaultPlaceholder(localFile);
+  }
+  log.placeholderReplaceComplete(localFile);
+}


### PR DESCRIPTION
Fixes https://github.com/firebase/extensions/issues/2769 and https://github.com/firebase/extensions/issues/2762.

Refactors content-filter and adds a fix for the silent fail-open on Gemini 2.5 Flash safety refusals reported in #2769.

## What changed

- **Bug 1 fix (#2769)** — any genkit `ValidationError` thrown by the moderation `ai.generate` call is now treated as an implicit block. We control the prompt and schema in that path, so the only thing that can fail validation is the model's response. Observed shapes from Gemini 2.5 Flash safety refusals: `data === null` (empty content), `data === {}` (refusal text that extractJson coerced to an empty object), and we also block on plain type-mismatch for the same reason (a model that won't produce a usable verdict on borderline imagery is almost always an input-side refusal, and failing open there is the original bug). Detection is structural: `status === "INVALID_ARGUMENT"` plus a populated `detail.errors` array. Returned directly without the retry queue (deterministic, retries just burn API calls).
- **Earlier on the branch** — refactor of `content-filter.ts`, blocked-image routing to the failed-image path before placeholder substitution, placeholder swap on a copy of the original (so blocked originals are preserved), data-URL contentType fix.
- Drops a leftover `as any` and clarifies the `maxOutputTokens` comment per Izaak's review on #2762.

## Tests

- 4 new unit tests in `__tests__/content-filter.test.ts`:
  - null-content `ValidationError` → blocks **without retrying** (asserts `mockGenerate.toHaveBeenCalledTimes(1)`)
  - empty-object `ValidationError` → blocks without retrying
  - type-mismatch `ValidationError` → blocks without retrying
  - non-`ValidationError` (e.g. ECONNRESET) → still goes through retries and propagates
- New env-gated live integration suite at `__tests__/integration/content-filter.live.test.ts`. Runs against real Vertex AI Gemini 2.5 Flash:
  - safe text image + `BLOCK_ONLY_HIGH` → passes
  - gun image + weapon-detection custom prompt → blocked
  - safe image + weapon-detection custom prompt → not blocked (model doesn't over-trigger)
  - 2 borderline-regression tests gated on `LIVE_BORDERLINE_IMAGE_PATH` (image not committed; supply your own)
- Run via `npm run test:live-content-filter --prefix storage-resize-images/functions` (env vars: `GCLOUD_PROJECT`, optionally `LIVE_BORDERLINE_IMAGE_PATH`).
- All 3 always-on live tests verified passing against `izaak-testing` (~9s).

## Behaviour change / out of scope

- The bug report also flags a "Bug 2" about the no-custom-prompt path ignoring the model's yes/no verdict. **Not addressed in this PR** — separate behaviour question with non-trivial blast radius for existing installs. Tracked for a future follow-up.
- `extension.yaml` bumped to `0.3.4`; CHANGELOG updated.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` clean
- [x] `npx jest __tests__/content-filter.test.ts` — 12 pass (8 existing + 4 new)
- [x] `npx jest __tests__/unit/generateResizedImageHandler.test.ts` — 4 pass unchanged
- [x] `npm run test:live-content-filter` against `izaak-testing` — 3/3 pass
- [ ] Bug 1 regression test against a real borderline image (set `LIVE_BORDERLINE_IMAGE_PATH`)
- [ ] Manual repro of the original report: deploy + upload borderline image, confirm `contentFilterBlocked` log + placeholder substitution
