### PR TITLE
fix(fs-bq-import-collection): so it respects existing firestore-bigquery-export BigQuery configuration during backfill

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/checkUpdates.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/checkUpdates.ts
@@ -6,6 +6,7 @@ import { ChangeTrackerConfig } from ".";
 
 interface TableRequiresUpdateOptions {
   table: Table;
+  metadata: TableMetadata;
   config: ChangeTrackerConfig;
   documentIdColExists: boolean;
   pathParamsColExists: boolean;
@@ -14,13 +15,13 @@ interface TableRequiresUpdateOptions {
 
 export async function tableRequiresUpdate({
   table,
+  metadata,
   config,
   documentIdColExists,
   pathParamsColExists,
   oldDataColExists,
 }: TableRequiresUpdateOptions): Promise<boolean> {
   /* Setup checks */
-  const { metadata } = table;
 
   /** Check clustering */
   const configCluster = JSON.stringify(config.clustering);

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/index.ts
@@ -341,14 +341,13 @@ export class FirestoreBigQueryEventHistoryTracker
 
       await clustering.updateClustering(metadata);
 
-      const documentIdColExists = fields.find(
+      const documentIdColExists = fields.some(
         (column) => column.name === "document_id"
       );
-      const pathParamsColExists = fields.find(
+      const pathParamsColExists = fields.some(
         (column) => column.name === "path_params"
       );
-
-      const oldDataColExists = fields.find(
+      const oldDataColExists = fields.some(
         (column) => column.name === "old_data"
       );
 
@@ -372,6 +371,7 @@ export class FirestoreBigQueryEventHistoryTracker
       /** Updated table metadata if required */
       const shouldUpdate = await tableRequiresUpdate({
         table,
+        metadata,
         config: this.config,
         documentIdColExists,
         pathParamsColExists,

--- a/firestore-bigquery-export/scripts/import/src/config.ts
+++ b/firestore-bigquery-export/scripts/import/src/config.ts
@@ -1,4 +1,3 @@
-//import * as program from "commander";
 import { program } from "commander";
 import filenamify from "filenamify";
 import inquirer from "inquirer";

--- a/firestore-bigquery-export/scripts/import/src/config.ts
+++ b/firestore-bigquery-export/scripts/import/src/config.ts
@@ -1,4 +1,5 @@
-import * as program from "commander";
+//import * as program from "commander";
+import { program } from "commander";
 import filenamify from "filenamify";
 import inquirer from "inquirer";
 
@@ -13,6 +14,12 @@ const GCP_PROJECT_VALID_CHARACTERS = /^[a-z][a-z0-9-]{0,29}$/;
 const PROJECT_ID_MAX_CHARS = 6144;
 export const FIRESTORE_COLLECTION_NAME_MAX_CHARS = 6144;
 const BIGQUERY_RESOURCE_NAME_MAX_CHARS = 1024;
+
+const VALID_VIEW_TYPES = [
+  "view",
+  "materialized_incremental",
+  "materialized_non_incremental",
+];
 
 const validateBatchSize = (value: string) => {
   return parseInt(value, 10) > 0;
@@ -52,6 +59,15 @@ const validateLocation = (value: string) => {
 
   return index !== -1;
 };
+
+function parseClustering(value?: string): string[] | null {
+  if (value === undefined) return undefined as any;
+  if (value.trim() === "") return [];
+  return value
+    .split(",")
+    .map((field) => field.trim())
+    .filter(Boolean);
+}
 
 export const validateInput = (
   value: string,
@@ -248,6 +264,15 @@ export async function parseConfig(): Promise<CliConfig | CliConfigError> {
       errors.push("Invalid batch size.");
     }
 
+    if (
+      program.viewType !== undefined &&
+      !VALID_VIEW_TYPES.includes(program.viewType)
+    ) {
+      errors.push(
+        "ViewType must be one of: view, materialized_incremental, materialized_non_incremental."
+      );
+    }
+
     if (errors.length !== 0) {
       program.outputHelp();
       return { kind: "ERROR", errors };
@@ -279,6 +304,8 @@ export async function parseConfig(): Promise<CliConfig | CliConfigError> {
       failedBatchOutput: program.failedBatchOutput,
       transformFunctionUrl: program.transformFunctionUrl,
       firestoreInstanceId: program.firestoreInstanceId || "(default)",
+      clustering: parseClustering(program.clustering),
+      viewType: program.viewType || "view",
     };
   }
   const {

--- a/firestore-bigquery-export/scripts/import/src/config.ts
+++ b/firestore-bigquery-export/scripts/import/src/config.ts
@@ -59,8 +59,8 @@ const validateLocation = (value: string) => {
   return index !== -1;
 };
 
-function parseClustering(value?: string): string[] | null {
-  if (value === undefined) return undefined as any;
+function parseClustering(value?: string): string[] | undefined {
+  if (value === undefined) return undefined;
   if (value.trim() === "") return [];
   return value
     .split(",")
@@ -219,6 +219,21 @@ const questions = [
     name: "failedBatchOutput",
     type: "input",
   },
+  {
+    message:
+      "What type of latest view is used by the deployed extension? (view, materialized_incremental, materialized_non_incremental)",
+    name: "viewType",
+    type: "list",
+    choices: VALID_VIEW_TYPES,
+    default: "view",
+  },
+  {
+    message:
+      "What clustering fields should be preserved on the raw changelog table? (Comma-separated, leave blank for none)",
+    name: "clustering",
+    type: "input",
+    default: "",
+  },
 ];
 
 export async function parseConfig(): Promise<CliConfig | CliConfigError> {
@@ -322,6 +337,8 @@ export async function parseConfig(): Promise<CliConfig | CliConfigError> {
     useEmulator,
     failedBatchOutput,
     transformFunctionUrl,
+    viewType,
+    clustering,
   } = await inquirer.prompt(questions);
 
   const rawChangeLogName = `${table}_raw_changelog`;
@@ -350,6 +367,8 @@ export async function parseConfig(): Promise<CliConfig | CliConfigError> {
     failedBatchOutput,
     transformFunctionUrl,
     firestoreInstanceId: firestoreInstanceId || "(default)",
+    clustering: parseClustering(clustering),
+    viewType: viewType || "view",
   };
 }
 

--- a/firestore-bigquery-export/scripts/import/src/index.ts
+++ b/firestore-bigquery-export/scripts/import/src/index.ts
@@ -52,6 +52,8 @@ const run = async (): Promise<number> => {
     cursorPositionFile,
     transformFunctionUrl,
     firestoreInstanceId,
+    clustering,
+    viewType,
   } = config;
   if (useEmulator) {
     console.log("Using emulator");
@@ -94,6 +96,11 @@ const run = async (): Promise<number> => {
     bqProjectId: bigQueryProjectId,
     transformFunction: transformFunctionUrl,
     firestoreInstanceId: firestoreInstanceId,
+    clustering,
+    useMaterializedView:
+      viewType === "materialized_incremental" ||
+      viewType === "materialized_non_incremental",
+    useIncrementalMaterializedView: viewType === "materialized_incremental",
   });
 
   await initializeDataSink(dataSink, config);

--- a/firestore-bigquery-export/scripts/import/src/program.ts
+++ b/firestore-bigquery-export/scripts/import/src/program.ts
@@ -1,4 +1,3 @@
-// import * as program from "commander";
 import { program } from "commander";
 
 const packageJson = require("../package.json");

--- a/firestore-bigquery-export/scripts/import/src/program.ts
+++ b/firestore-bigquery-export/scripts/import/src/program.ts
@@ -79,6 +79,6 @@ export const getCLIOptions = () => {
     )
     .option(
       "--clustering <clustering>",
-      "Comma-separated clustering fiels for the raw changelog table, e.g. timestamp or timestamp,document_id"
+      "Comma-separated clustering fields for the raw changelog table, e.g. timestamp or timestamp,document_id"
     );
 };

--- a/firestore-bigquery-export/scripts/import/src/program.ts
+++ b/firestore-bigquery-export/scripts/import/src/program.ts
@@ -1,4 +1,5 @@
-import * as program from "commander";
+// import * as program from "commander";
+import { program } from "commander";
 
 const packageJson = require("../package.json");
 
@@ -70,5 +71,14 @@ export const getCLIOptions = () => {
       "--firestore-instance-id <database-id>",
       "The Firestore database instance ID. Use '(default)' for the default database.",
       "(default)"
+    )
+    .option(
+      "--view-type <view-type>",
+      "View type used by the deployed extension: view, materialized_incremental, materialized_non_incremental",
+      "view"
+    )
+    .option(
+      "--clustering <clustering>",
+      "Comma-separated clustering fiels for the raw changelog table, e.g. timestamp or timestamp,document_id"
     );
 };

--- a/firestore-bigquery-export/scripts/import/src/types.ts
+++ b/firestore-bigquery-export/scripts/import/src/types.ts
@@ -18,6 +18,12 @@ export interface CliConfig {
   failedBatchOutput?: string;
   transformFunctionUrl?: string;
   firestoreInstanceId: string;
+
+  clustering?: string[] | null;
+  viewType?:
+    | "view"
+    | "materialized_incremental"
+    | "materialized_non_incremental";
 }
 
 export interface CliConfigError {


### PR DESCRIPTION
# Summary

  Fix `fs-bq-import-collection` so it respects existing `firestore-bigquery-export` BigQuery configuration during backfill.

The import script was not passing view/clustering settings into `FirestoreBigQueryEventHistoryTracker`, which caused problems when importing into an extension deployment using materialized latest views and clustering. In that state, the import path could treat *_raw_latest as a standard view and could also trigger unnecessary changelog metadata updates.

This PR:

- adds import CLI support for viewType and clustering
- threads those settings through both non-interactive and interactive config flows
- passes them into FirestoreBigQueryEventHistoryTracker
- fixes changelog update detection to use fetched table metadata and proper boolean field checks

## Problem

For an extension configured with:

- `VIEW_TYPE=materialized_incremental`
- `CLUSTERING=timestamp`

the import script did not initialize the change tracker with equivalent settings. That meant the backfill path could diverge from the deployed extension’s BigQuery resource configuration.

In practice this caused two issues:

- *_raw_latest could be handled as a normal view instead of a materialized view
- existing *_raw_changelog metadata could be treated as needing update even when it already matched

## Changes

- Add --view-type and --clustering options to the import CLI
- Parse and return `viewType` and `clustering` from both:
      - non-interactive mode
      - interactive prompt mode
- Pass the following into `FirestoreBigQueryEventHistoryTracker`:
      - `clustering`
      - `useMaterializedView`
      - `useIncrementalMaterializedView`
     
- Fix changelog update detection by:
      - comparing against fresh `table.getMetadata()` results rather than `table.metadata`
      - using boolean field existence checks instead of find() return values

## Validation

  Validated locally against an existing extension-managed dataset configured with:

- `VIEW_TYPE=materialized_incremental`
- `clustering=timestamp`

Observed behavior after this change:

- existing `*_raw_latest` materialized view is recognized and skipped when config matches
- import no longer updates changelog metadata unnecessarily in the verified case
- import completes successfully in both:
  - non-interactive mode
  - interactive mode

## Notes

There is still a log line from clustering initialization that can read as if clustering was updated even when no metadata write occurs. In the verified flow, that appears to be a logging artifact rather than an actual BigQuery table update.