### PR TITLE
chore(deps): bump uuid to v10 across affected packages

### DIFF
--- a/firestore-counter/clients/node/package-lock.json
+++ b/firestore-counter/clients/node/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "uuid": "^8.3.2"
+        "uuid": "^10.0.0"
       },
       "devDependencies": {
         "firebase-admin": "^13.0.0"
@@ -262,6 +262,18 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -2181,9 +2193,14 @@
       "optional": true
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"

--- a/firestore-counter/clients/node/package-lock.json
+++ b/firestore-counter/clients/node/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "uuid": "^10.0.0"
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "firebase-admin": "^13.0.0"
@@ -1014,20 +1014,6 @@
       "optionalDependencies": {
         "@google-cloud/firestore": "^7.11.0",
         "@google-cloud/storage": "^7.19.0"
-      }
-    },
-    "node_modules/firebase-admin/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/form-data": {
@@ -2193,17 +2179,16 @@
       "optional": true
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/firestore-counter/clients/node/package.json
+++ b/firestore-counter/clients/node/package.json
@@ -9,6 +9,6 @@
     "firebase-admin": "^13.0.0"
   },
   "dependencies": {
-    "uuid": "^8.3.2"
+    "uuid": "^10.0.0"
   }
 }

--- a/firestore-counter/clients/node/package.json
+++ b/firestore-counter/clients/node/package.json
@@ -9,6 +9,6 @@
     "firebase-admin": "^13.0.0"
   },
   "dependencies": {
-    "uuid": "^10.0.0"
+    "uuid": "^11.1.0"
   }
 }

--- a/firestore-counter/clients/web/package-lock.json
+++ b/firestore-counter/clients/web/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/uuid": "^3.4.4",
-        "uuid": "^3.3.2"
+        "@types/uuid": "^10.0.0",
+        "uuid": "^10.0.0"
       },
       "devDependencies": {
         "firebase": "^12.0.0",
@@ -889,9 +889,10 @@
       }
     },
     "node_modules/@types/uuid": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.10.tgz",
-      "integrity": "sha512-BgeaZuElf7DEYZhWYDTc/XcLZXdVgFkVSTa13BqKvbnmUrxr3TJFKofUxCtDO9UQOdhnV+HPOESdHiHKZOJV1A=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -2481,12 +2482,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/watchpack": {

--- a/firestore-counter/clients/web/package-lock.json
+++ b/firestore-counter/clients/web/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/uuid": "^10.0.0",
-        "uuid": "^10.0.0"
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "firebase": "^12.0.0",
@@ -887,12 +886,6 @@
       "dependencies": {
         "undici-types": "~7.19.0"
       }
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "license": "MIT"
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
@@ -2482,17 +2475,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/watchpack": {

--- a/firestore-counter/clients/web/package.json
+++ b/firestore-counter/clients/web/package.json
@@ -6,8 +6,7 @@
   "license": "Apache-2.0",
   "description": "Web SDK to access sharded counters.",
   "dependencies": {
-    "@types/uuid": "^10.0.0",
-    "uuid": "^10.0.0"
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "firebase": "^12.0.0",

--- a/firestore-counter/clients/web/package.json
+++ b/firestore-counter/clients/web/package.json
@@ -6,8 +6,8 @@
   "license": "Apache-2.0",
   "description": "Web SDK to access sharded counters.",
   "dependencies": {
-    "@types/uuid": "^3.4.4",
-    "uuid": "^3.3.2"
+    "@types/uuid": "^10.0.0",
+    "uuid": "^10.0.0"
   },
   "devDependencies": {
     "firebase": "^12.0.0",

--- a/firestore-counter/functions/package-lock.json
+++ b/firestore-counter/functions/package-lock.json
@@ -13,7 +13,7 @@
         "firebase-functions": "^4.9.0",
         "rimraf": "^2.6.3",
         "typescript": "^4.9.4",
-        "uuid": "^3.3.2"
+        "uuid": "^10.0.0"
       },
       "devDependencies": {
         "@types/deep-equal": "^1.0.1",
@@ -3183,19 +3183,6 @@
       "optionalDependencies": {
         "@google-cloud/firestore": "^7.7.0",
         "@google-cloud/storage": "^7.7.0"
-      }
-    },
-    "node_modules/firebase-admin/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/firebase-functions": {
@@ -6453,12 +6440,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -9051,13 +9043,6 @@
         "jwks-rsa": "^3.1.0",
         "node-forge": "^1.3.1",
         "uuid": "^10.0.0"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "10.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-          "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
-        }
       }
     },
     "firebase-functions": {
@@ -11350,9 +11335,9 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/firestore-counter/functions/package-lock.json
+++ b/firestore-counter/functions/package-lock.json
@@ -13,7 +13,7 @@
         "firebase-functions": "^4.9.0",
         "rimraf": "^2.6.3",
         "typescript": "^4.9.4",
-        "uuid": "^10.0.0"
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@types/deep-equal": "^1.0.1",
@@ -3183,6 +3183,20 @@
       "optionalDependencies": {
         "@google-cloud/firestore": "^7.7.0",
         "@google-cloud/storage": "^7.7.0"
+      }
+    },
+    "node_modules/firebase-admin/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/firebase-functions": {
@@ -6440,17 +6454,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -9043,6 +9056,13 @@
         "jwks-rsa": "^3.1.0",
         "node-forge": "^1.3.1",
         "uuid": "^10.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+          "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
+        }
       }
     },
     "firebase-functions": {
@@ -11335,9 +11355,9 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
     "uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/firestore-counter/functions/package.json
+++ b/firestore-counter/functions/package.json
@@ -8,7 +8,7 @@
     "deep-equal": "^1.0.1",
     "firebase-admin": "^12.1.0",
     "firebase-functions": "^4.9.0",
-    "uuid": "^3.3.2",
+    "uuid": "^10.0.0",
     "rimraf": "^2.6.3",
     "typescript": "^4.9.4",
     "@types/express-serve-static-core": "4.19.8"

--- a/firestore-counter/functions/package.json
+++ b/firestore-counter/functions/package.json
@@ -8,7 +8,7 @@
     "deep-equal": "^1.0.1",
     "firebase-admin": "^12.1.0",
     "firebase-functions": "^4.9.0",
-    "uuid": "^10.0.0",
+    "uuid": "^11.1.0",
     "rimraf": "^2.6.3",
     "typescript": "^4.9.4",
     "@types/express-serve-static-core": "4.19.8"

--- a/storage-resize-images/functions/package-lock.json
+++ b/storage-resize-images/functions/package-lock.json
@@ -18,8 +18,7 @@
         "sharp": "^0.34.5",
         "shx": "^0.4.0",
         "typescript": "^5.7.3",
-        "uuid": "^11.0.5",
-        "uuidv4": "^6.1.0"
+        "uuid": "^10.0.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
@@ -1310,19 +1309,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/@genkit-ai/ai/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@genkit-ai/core": {
@@ -4963,11 +4949,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
-    },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
@@ -6653,6 +6634,19 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/firebase-admin/node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/firebase-functions": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.6.0.tgz",
@@ -6881,18 +6875,6 @@
         "@genkit-ai/ai": "1.33.0",
         "@genkit-ai/core": "1.33.0",
         "uuid": "^10.0.0"
-      }
-    },
-    "node_modules/genkit/node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/gensync": {
@@ -10766,30 +10748,15 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
-    "node_modules/uuidv4": {
-      "version": "6.2.13",
-      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
-      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
-      "dependencies": {
-        "@types/uuid": "8.3.4",
-        "uuid": "8.3.2"
-      }
-    },
-    "node_modules/uuidv4/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/storage-resize-images/functions/package-lock.json
+++ b/storage-resize-images/functions/package-lock.json
@@ -18,7 +18,7 @@
         "sharp": "^0.34.5",
         "shx": "^0.4.0",
         "typescript": "^5.7.3",
-        "uuid": "^10.0.0"
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
@@ -1309,6 +1309,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@genkit-ai/ai/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@genkit-ai/core": {
@@ -6634,19 +6648,6 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
-    "node_modules/firebase-admin/node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
-    },
     "node_modules/firebase-functions": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-6.6.0.tgz",
@@ -6875,6 +6876,20 @@
         "@genkit-ai/ai": "1.33.0",
         "@genkit-ai/core": "1.33.0",
         "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/genkit/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/gensync": {
@@ -10748,17 +10763,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/storage-resize-images/functions/package.json
+++ b/storage-resize-images/functions/package.json
@@ -26,7 +26,7 @@
     "sharp": "^0.34.5",
     "shx": "^0.4.0",
     "typescript": "^5.7.3",
-    "uuid": "^10.0.0"
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/storage-resize-images/functions/package.json
+++ b/storage-resize-images/functions/package.json
@@ -26,8 +26,7 @@
     "sharp": "^0.34.5",
     "shx": "^0.4.0",
     "typescript": "^5.7.3",
-    "uuid": "^11.0.5",
-    "uuidv4": "^6.1.0"
+    "uuid": "^10.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/storage-resize-images/functions/src/resize-image.ts
+++ b/storage-resize-images/functions/src/resize-image.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import * as fs from "fs";
 
 import { Bucket } from "@google-cloud/storage";
-import { uuid } from "uuidv4";
+import { v4 as uuidv4 } from "uuid";
 
 import { config } from "./config";
 import * as logs from "./logs";
@@ -103,7 +103,7 @@ export const modifyImage = async ({
   let modifiedFile: string;
 
   try {
-    modifiedFile = path.join(os.tmpdir(), uuid());
+    modifiedFile = path.join(os.tmpdir(), uuidv4());
 
     // filename\*=utf-8''  selects any string match the filename notation.
     // [^;\s]+ searches any following string until either a space or semi-colon.
@@ -203,7 +203,7 @@ export const constructMetadata = (
     config.regenerateToken &&
     metadata.metadata.firebaseStorageDownloadTokens
   ) {
-    metadata.metadata.firebaseStorageDownloadTokens = uuid();
+    metadata.metadata.firebaseStorageDownloadTokens = uuidv4();
   }
   return metadata;
 };


### PR DESCRIPTION
## Summary

Supersedes five stale dependabot PRs that all attempted to bump `uuid` to v14:

- closes #2807 — firestore-counter/functions
- closes #2806 — firestore-counter/clients/node
- closes #2805 — firestore-counter/clients/web
- closes #2789 — storage-resize-images/functions
- closes #2788 — root (lockfile-only)

uuid v14 (and v12+) is ESM-only and drops CJS exports. Every consumer in this repo compiles to CJS (`tsconfig.module: "commonjs"`, no `"type": "module"` in any package.json), so the dependabot bumps would have broken every callsite without a tsconfig + import-style refactor.

uuid v11 is the only currently-supported CJS-capable line. v10 is deprecated upstream ("uuid@10 and below is no longer supported"); v12+ dropped CJS again. v11.1.0+ ships dual CJS+ESM exports via the `exports` field.

## Changes

- `firestore-counter/functions`: `uuid` `^3.3.2` -> `^11.1.0`
- `firestore-counter/clients/node`: `uuid` `^8.3.2` -> `^11.1.0`
- `firestore-counter/clients/web`: `uuid` `^3.3.2` -> `^11.1.0`, dropped now-redundant `@types/uuid` (uuid ships its own types from v9+)
- `storage-resize-images/functions`:
  - `uuid` `^11.0.5` -> `^11.1.0` (minor)
  - dropped the duplicate `uuidv4` legacy package
  - migrated `src/resize-image.ts` to `import { v4 as uuidv4 } from "uuid"`, matching `util.ts` and `file-operations.ts` already in the same package

No tsconfig changes, no module-system changes, no webpack changes.

## Test plan

- [x] `npm run build` clean in firestore-counter/functions
- [x] `npm run build` (webpack) clean in firestore-counter/clients/web (uuid resolved from `uuid/dist/cjs-browser`)
- [x] `npm run build` clean in storage-resize-images/functions
- [x] `npm test` in storage-resize-images/functions: 49 unit tests pass; 4 e2e failures are pre-existing emulator-connect issues (`ECONNREFUSED 127.0.0.1:9199`) unrelated to this change
- [x] Lockfiles regenerated and resolve to uuid 11.1.1 in all four packages
- [ ] CI to confirm