### PR TITLE
chore: bump extension versions for dependency updates

### DIFF
--- a/delete-user-data/CHANGELOG.md
+++ b/delete-user-data/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.29
+
+chore: bump dependencies
+
 ## Version 0.1.28
 
 chore: bump dependencies

--- a/delete-user-data/extension.yaml
+++ b/delete-user-data/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: delete-user-data
-version: 0.1.28
+version: 0.1.29
 specVersion: v1beta
 
 displayName: Delete User Data

--- a/firestore-counter/CHANGELOG.md
+++ b/firestore-counter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.2.16
+
+chore: bump dependencies
+
 ## Version 0.2.15
 
 chore: bump dependencies

--- a/firestore-counter/extension.yaml
+++ b/firestore-counter/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-counter
-version: 0.2.15
+version: 0.2.16
 specVersion: v1beta
 
 displayName: Distributed Counter

--- a/firestore-send-email/CHANGELOG.md
+++ b/firestore-send-email/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.2.9
+
+chore: bump dependencies
+
 ## Version 0.2.8
 
 chore: bump dependencies

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-send-email
-version: 0.2.8
+version: 0.2.9
 specVersion: v1beta
 
 displayName: Trigger Email from Firestore

--- a/firestore-shorten-urls-bitly/CHANGELOG.md
+++ b/firestore-shorten-urls-bitly/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.2.5
+
+chore: bump dependencies
+
 ## Version 0.2.4
 
 chore: bump dependencies

--- a/firestore-shorten-urls-bitly/extension.yaml
+++ b/firestore-shorten-urls-bitly/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-shorten-urls-bitly
-version: 0.2.4
+version: 0.2.5
 specVersion: v1beta
 
 displayName: Shorten URLs in Firestore

--- a/firestore-translate-text/CHANGELOG.md
+++ b/firestore-translate-text/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.29
+
+chore: bump dependencies
+
 ## Version 0.1.28
 
 chore: switch from `googleai` and `vertexai` Genkit plugins to `google-genai`

--- a/firestore-translate-text/extension.yaml
+++ b/firestore-translate-text/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-translate-text
-version: 0.1.28
+version: 0.1.29
 specVersion: v1beta
 
 tags: [ai]

--- a/rtdb-limit-child-nodes/CHANGELOG.md
+++ b/rtdb-limit-child-nodes/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.19
+
+chore: bump dependencies
+
 ## Version 0.1.18
 
 chore: bump dependencies

--- a/rtdb-limit-child-nodes/extension.yaml
+++ b/rtdb-limit-child-nodes/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: rtdb-limit-child-nodes
-version: 0.1.18
+version: 0.1.19
 specVersion: v1beta
 
 displayName: Limit Child Nodes

--- a/storage-resize-images/CHANGELOG.md
+++ b/storage-resize-images/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.3.4
+
+chore: bump dependencies
+
 ## Version 0.3.3
 
 chore: bump dependencies

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: storage-resize-images
-version: 0.3.3
+version: 0.3.4
 specVersion: v1beta
 
 displayName: Resize Images


### PR DESCRIPTION
## Summary

- Bumps 7 extensions to capture security and minor dep bumps that have accumulated since the last collective bump in #2738 (commit `eea0e40d`, 2026-04-14).
- `firestore-bigquery-export` already current at `0.3.2` via #2813, so omitted.
- Each extension gets a patch bump and a `chore: bump dependencies` CHANGELOG entry, matching the convention established by every prior dep-only release.

Feeds the pending release PR #2812.

## Bumps

| Extension | From | To |
|-----------|------|----|
| delete-user-data | 0.1.28 | 0.1.29 |
| firestore-counter | 0.2.15 | 0.2.16 |
| firestore-send-email | 0.2.8 | 0.2.9 |
| firestore-shorten-urls-bitly | 0.2.4 | 0.2.5 |
| firestore-translate-text | 0.1.28 | 0.1.29 |
| rtdb-limit-child-nodes | 0.1.18 | 0.1.19 |
| storage-resize-images | 0.3.3 | 0.3.4 |

## Test plan

- [x] All 7 `extension.yaml` versions match their new top `CHANGELOG.md` entry.
- [x] Diff is exactly 14 files (7 yaml + 7 CHANGELOG), no incidental changes.