### PR TITLE
chore(firestore-bigquery-change-tracker): bump to 2.0.3

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/package-lock.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@firebaseextensions/firestore-bigquery-change-tracker",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@firebaseextensions/firestore-bigquery-change-tracker",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/bigquery": "^7.6.0",

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
@@ -5,7 +5,7 @@
     "url": "git+https://github.com/firebase/extensions.git",
     "directory": "firestore-bigquery-export/firestore-bigquery-change-tracker"
   },
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Core change-tracker library for Cloud Firestore Collection BigQuery Exports",
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bump `@firebaseextensions/firestore-bigquery-change-tracker` from 2.0.2 to 2.0.3 for next release.

## Test plan
- [ ] CI green