### PR TITLE
chore(firestore-bigquery-export): bump change-tracker dep to 2.0.3

### DIFF
--- a/firestore-bigquery-export/functions/package.json
+++ b/firestore-bigquery-export/functions/package.json
@@ -13,7 +13,7 @@
   "author": "Jan Wyszynski <wyszynski@google.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@firebaseextensions/firestore-bigquery-change-tracker": "^2.0.2",
+    "@firebaseextensions/firestore-bigquery-change-tracker": "^2.0.3",
     "@google-cloud/bigquery": "^7.6.0",
     "@types/express-serve-static-core": "4.19.8",
     "firebase-admin": "^13.2.0",


### PR DESCRIPTION
## Summary
- Bump `@firebaseextensions/firestore-bigquery-change-tracker` dep in extension functions from ^2.0.2 to ^2.0.3.
- Picks up ISO 8601 partition-value fix (#2813) and dep cleanup.

## Test plan
- [ ] CI green