### PR TITLE
chore(dependabot): group security & supply chain attack hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       - "/**"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+      semver-major-days: 7
+      semver-minor-days: 7
+      semver-patch-days: 7
 
     labels:
       - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,23 +1,39 @@
 version: 2
+
 updates:
   - package-ecosystem: "npm"
     directories:
       - "/**"
     schedule:
       interval: "weekly"
+
     labels:
       - "dependencies"
       - "automated"
+
     commit-message:
       prefix: "chore"
       include: "scope"
+
     groups:
-      minor-and-patch:
+      version-minor-and-patch-by-dependency:
+        applies-to: version-updates
         patterns:
           - "*"
         update-types:
-          - "minor"
-          - "patch"
+          - minor
+          - patch
+
+      security-minor-and-patch:
+        applies-to: security-updates
+        patterns:
+          - "*"
+        update-types:
+          - major
+          - minor
+          - patch
+
     ignore:
       - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+        update-types:
+          - "version-update:semver-major"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
       include: "scope"
 
     groups:
-      version-minor-and-patch-by-dependency:
+      version-minor-and-patch:
         applies-to: version-updates
         patterns:
           - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
           - minor
           - patch
 
-      security-minor-and-patch:
+      security-updates:
         applies-to: security-updates
         patterns:
           - "*"


### PR DESCRIPTION
This pull request updates the `.github/dependabot.yml` configuration to improve how dependency updates are grouped, labeled, and managed. The changes refine update grouping for both regular and security updates, add commit message customization, and clarify ignored update types.

Dependabot configuration improvements:

* Split dependency update groups into `version-minor-and-patch-by-dependency` for regular updates and `security-minor-and-patch` for security updates, with more precise control over which update types are included in each group.
* `cooldown` helps avoid vulnerable package releases, as seen recently with the [Mini Shai-Hulud worm stuff](https://www.picussecurity.com/resource/blog/mini-shai-hulud-the-npm-supply-chain-worm-explained). These types of releases are often detected very early, so this property should massively aid in avoiding this problem.