### PR TITLE
chore: update extension release metadata

### DIFF
--- a/delete-user-data/CHANGELOG.md
+++ b/delete-user-data/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.30
+
+chore: remove unused runtime dependencies
+
 ## Version 0.1.29
 
 chore: bump dependencies

--- a/delete-user-data/extension.yaml
+++ b/delete-user-data/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: delete-user-data
-version: 0.1.29
+version: 0.1.30
 specVersion: v1beta
 
 displayName: Delete User Data

--- a/firestore-bigquery-export/CHANGELOG.md
+++ b/firestore-bigquery-export/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.3.3
+
+chore: remove unused runtime dependencies and bump change-tracker consumers
+
 ## Version 0.3.2
 
 fix: restore acceptance of ISO 8601 date/datetime strings as partition field values, regression introduced in 0.3.0 (#2803)

--- a/firestore-bigquery-export/extension.yaml
+++ b/firestore-bigquery-export/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-bigquery-export
-version: 0.3.2
+version: 0.3.3
 specVersion: v1beta
 
 displayName: Stream Firestore to BigQuery

--- a/firestore-counter/CHANGELOG.md
+++ b/firestore-counter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.2.17
+
+chore: replace uuid and deep-equal dependencies with Node.js built-ins
+
 ## Version 0.2.16
 
 chore: bump dependencies

--- a/firestore-counter/extension.yaml
+++ b/firestore-counter/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-counter
-version: 0.2.16
+version: 0.2.17
 specVersion: v1beta
 
 displayName: Distributed Counter

--- a/firestore-send-email/CHANGELOG.md
+++ b/firestore-send-email/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.2.10
+
+chore: bump nodemailer to v9 and remove unused rimraf dependency
+
 ## Version 0.2.9
 
 chore: bump dependencies

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-send-email
-version: 0.2.9
+version: 0.2.10
 specVersion: v1beta
 
 displayName: Trigger Email from Firestore

--- a/firestore-shorten-urls-bitly/CHANGELOG.md
+++ b/firestore-shorten-urls-bitly/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.2.6
+
+chore: remove unused rimraf dependency
+
 ## Version 0.2.5
 
 chore: bump dependencies

--- a/firestore-shorten-urls-bitly/extension.yaml
+++ b/firestore-shorten-urls-bitly/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-shorten-urls-bitly
-version: 0.2.5
+version: 0.2.6
 specVersion: v1beta
 
 displayName: Shorten URLs in Firestore

--- a/firestore-translate-text/CHANGELOG.md
+++ b/firestore-translate-text/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.30
+
+chore: remove unused rimraf dependency
+
 ## Version 0.1.29
 
 chore: bump dependencies

--- a/firestore-translate-text/extension.yaml
+++ b/firestore-translate-text/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-translate-text
-version: 0.1.29
+version: 0.1.30
 specVersion: v1beta
 
 tags: [ai]

--- a/rtdb-limit-child-nodes/CHANGELOG.md
+++ b/rtdb-limit-child-nodes/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.1.20
+
+chore: bump Firebase Admin and Functions dependencies
+
 ## Version 0.1.19
 
 chore: bump dependencies

--- a/rtdb-limit-child-nodes/extension.yaml
+++ b/rtdb-limit-child-nodes/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: rtdb-limit-child-nodes
-version: 0.1.19
+version: 0.1.20
 specVersion: v1beta
 
 displayName: Limit Child Nodes

--- a/storage-resize-images/CHANGELOG.md
+++ b/storage-resize-images/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.3.6
+
+chore: replace temp file helper dependencies with Node.js built-ins
+
 ## Version 0.3.5
 
 fix - when a custom filter prompt is configured, the content filter no longer silently fails open on Gemini 2.5 Flash safety refusals. If Gemini's input-side safety declines to respond on borderline imagery (returning empty content rather than `finishReason="SAFETY"`), the resulting genkit schema-validation error is now treated as an implicit block instead of being retried 3 times and propagating as a generic filter error. Installs that only set `CONTENT_FILTER_LEVEL` (no custom prompt) were not affected by this path.

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: storage-resize-images
-version: 0.3.5
+version: 0.3.6
 specVersion: v1beta
 
 displayName: Resize Images


### PR DESCRIPTION
## Summary
- Bump extension versions and changelogs for packages with runtime dependency or source changes compared with master.
- Covers delete-user-data, firestore-bigquery-export, firestore-counter, firestore-send-email, firestore-shorten-urls-bitly, firestore-translate-text, rtdb-limit-child-nodes, and storage-resize-images.

## Test plan
- ReadLints on edited release metadata files.
- Pre-commit prettier hook.


Made with [Cursor](https://cursor.com)