### PR TITLE
docs(kits): remove stale factory-pattern references

### DIFF
--- a/kits/firestore-incremental-capture/src/index.ts
+++ b/kits/firestore-incremental-capture/src/index.ts
@@ -19,9 +19,10 @@
  * the same name.
  *
  * Skeleton package: not yet implemented. Target shape follows the
- * firestore-bigquery-export reference package — a `define...` factory (tier 3)
- * over injectable handlers (tier 2), with a side-effect-free `./lib` surface and
- * this env-driven entry registering functions for the clone-and-deploy example.
+ * firestore-bigquery-export reference package — this entry wires triggers
+ * directly at module top level with deploy-time param expressions over
+ * injectable handlers, with a side-effect-free `./lib` surface for the
+ * handlers and config types.
  */
 
 export {};

--- a/kits/firestore-translate-text/SPEC.md
+++ b/kits/firestore-translate-text/SPEC.md
@@ -66,9 +66,10 @@ export const fstranslate: CloudFunction<FirestoreEvent<...>>;
 1. Scaffold from reference; keep `events.ts`.
 2. Port `translate/` modules; abstract the provider behind a small interface so
    `google-translate` vs `gemini` is a typed switch.
-3. Wire the secret via `defineSecret("GOOGLE_AI_API_KEY")`; pass into factory
-   `secrets`; read with `.value()` in the handler context. Document granting it
-   and **reusing the existing secret** on migration (don't re-enter).
+3. Wire the secret via `defineSecret("GOOGLE_AI_API_KEY")`; pass it in the
+   trigger's `secrets` option; read with `.value()` in the handler context.
+   Document granting it and **reusing the existing secret** on migration
+   (don't re-enter).
 4. Map params in `config.ts`; preserve update-detection (only translate when the
    input field changed) and delete handling.
 5. Register roles/APIs from `extension.yaml` in `index.ts`.


### PR DESCRIPTION
The define-factory tier was dropped from the kits pattern; the reference package (firestore-bigquery-export) now wires triggers directly at module top level with deploy-time param expressions.

Two docs still described the old shape:

- kits/firestore-incremental-capture/src/index.ts - stub comment described a "define... factory (tier 3)"
- kits/firestore-translate-text/SPEC.md - step 3 said to pass the secret "into factory secrets"

Both updated to describe the current pattern (direct trigger wiring, secrets via the trigger's secrets option).