### PR TITLE
feat(bigquery-export): adopt firebase.json kit stanza

### DIFF
--- a/kits/firestore-bigquery-export/README.md
+++ b/kits/firestore-bigquery-export/README.md
@@ -71,9 +71,34 @@ nothing.
 
 ## Deploy
 
+The package's `firebase.json` declares a `kit` stanza (Firebase CLI 15.25.1 or
+later, behind the `kits` experiment):
+
+```json
+{
+  "functions": [
+    {
+      "source": ".",
+      "kit": "firestore-bigquery-export",
+      "instances": {
+        "default": "."
+      }
+    }
+  ]
+}
+```
+
+`instances` maps each instance id to the directory (relative to
+`firebase.json`) holding that instance's `.env`. The CLI prefixes every
+function and task queue name with `kit-<instance id>-`, so the functions above
+deploy as `kit-default-fsexportbigquery` and `kit-default-initBigQuerySync`.
+
 ```sh
+firebase experiments:enable kits
 firebase deploy --only functions
 ```
+
+Deploy a single instance with `firebase deploy --only functions:<instance id>`.
 
 ## Configuration
 
@@ -100,14 +125,21 @@ supplied by the CLI's built-in `PROJECT_ID` param.
 
 ## Multiple instances
 
-To export several collections, deploy the same source once per instance using
-the Firebase CLI's codebase `prefix` and `configDir` options: each
-`functions` entry in `firebase.json` points at the same source directory but
-namespaces its function (and task queue) names with `prefix` and reads its
-`.env` from its own `configDir`. See the
+To export several collections, add one entry per instance to the `instances`
+map, each pointing at its own config directory with its own `.env`:
+
+```json
+"instances": {
+  "users": "instances/users",
+  "orders": "instances/orders"
+}
+```
+
+Instance ids must be unique across all kit stanzas in the project, and every
+instance's function names are namespaced by its `kit-<instance id>-` prefix, so
+the instances cannot collide. See the
 [multi-instance example](../../examples/firestore-bigquery-export-multi/) for a
-complete project and the associated caveats (the options are recent and not yet
-officially documented).
+complete project.
 
 ## Provisioning
 
@@ -123,7 +155,7 @@ const { initializeApp } = require("firebase-admin/app");
 const { getFunctions } = require("firebase-admin/functions");
 initializeApp();
 getFunctions()
-  .taskQueue("locations/'"$DATABASE_REGION"'/functions/initBigQuerySync")
+  .taskQueue("locations/'"$DATABASE_REGION"'/functions/kit-default-initBigQuerySync")
   .enqueue({})
   .then(() => console.log("init task enqueued"));
 '
@@ -138,7 +170,7 @@ manual run you can also POST to it directly — note this skips the queue, so a
 failure is not retried:
 
 ```sh
-URL=$(gcloud functions describe initBigQuerySync \
+URL=$(gcloud functions describe kit-default-initBigQuerySync \
   --region "$DATABASE_REGION" --gen2 --format='value(url)')
 
 curl -fsS -X POST -H "Content-Type: application/json" -d '{"data":{}}' \

--- a/kits/firestore-bigquery-export/README.md
+++ b/kits/firestore-bigquery-export/README.md
@@ -129,9 +129,17 @@ To export several collections, add one entry per instance to the `instances`
 map, each pointing at its own config directory with its own `.env`:
 
 ```json
-"instances": {
-  "users": "instances/users",
-  "orders": "instances/orders"
+{
+  "functions": [
+    {
+      "source": ".",
+      "kit": "firestore-bigquery-export",
+      "instances": {
+        "users": "instances/users",
+        "orders": "instances/orders"
+      }
+    }
+  ]
 }
 ```
 
@@ -148,6 +156,9 @@ lifecycle task queue deployed alongside the other functions (as in the
 extension). Enqueue it once after deploy; Cloud Tasks retries a failed
 initialization on its own schedule, so a transient BigQuery error cannot leave
 the resources unprovisioned. It is idempotent.
+
+The snippets below use the `default` instance; substitute your instance id in
+the `kit-<instance id>-` prefix if you named yours differently.
 
 ```sh
 node -e '

--- a/kits/firestore-bigquery-export/firebase.json
+++ b/kits/firestore-bigquery-export/firebase.json
@@ -2,7 +2,10 @@
   "functions": [
     {
       "source": ".",
-      "codebase": "firestore-bigquery-export",
+      "kit": "firestore-bigquery-export",
+      "instances": {
+        "default": "."
+      },
       "ignore": ["node_modules", ".git", "src", "*.local"],
       "predeploy": ["npm --prefix \"$RESOURCE_DIR\" run build"]
     }


### PR DESCRIPTION
Adopts the new `kit` stanza shipped in firebase-tools 15.25.1 (behind the non-public `kits` experiment, PR firebase/firebase-tools#10842), replacing the `codebase` stanza. Also updates the README: deploy section documents the stanza and the `kit-<instance id>-` name prefix, the multi-instance section now uses the `instances` map instead of `prefix`/`configDir` (which the CLI team plans to remove), and the provisioning snippets use the prefixed task queue name.

## Verified against firebase-tools v15.25.1 source

- Stanza validates: `kit` name passes `validateKit` (≤40 chars, `[a-z0-9_-]+`); `source` + `instances` required and present; `codebase`/`remoteSource`/`prefix`/`configDir` correctly absent (forbidden in kit stanzas); `ignore`/`predeploy` are legal (`FunctionConfigBase` fields)
- Instance id `default` passes the instance-id regex; no collision (no codebase stanzas in this firebase.json)
- `instances` values resolve relative to firebase.json (`options.config.path(...)` in prepare.ts), so `"."` loads the package's own `.env`
- `build.applyPrefix` prefixes endpoint ids AND lifecycle hook task targets, so `afterFirstDeploy({ task: { function: "initBigQuerySync" } })` in src/index.ts remaps to `kit-default-initBigQuerySync` automatically; no code change needed
- Resulting ids (`kit-default-initBigQuerySync`, 28 chars) pass the 63-char/format checks
- Emulator + `--only functions:default` selector both handle kit instances

## Notes for testing

- Requires `firebase experiments:enable kits` on CLI >= 15.25.1
- `applyPrefix` also prefixes secret names; irrelevant here (no secrets) but will matter for the translate-text kit
- Instance id `default` coincides with the CLI's `DEFAULT_CODEBASE` constant. Validation allows it and deploy paths key off the instances map, but bare `--only functions:<fn>` selectors fall back to codebase `default` - watch for odd selector behaviour while testing

## Test plan

- [ ] `firebase deploy --only functions` from the kit dir deploys `kit-default-fsexportbigquery`, `kit-default-initBigQuerySync`, `kit-default-setupBigQuerySync`
- [ ] Lifecycle enqueue targets the prefixed queue after first deploy
- [ ] Emulator starts with the kit stanza