### PR TITLE
docs(kits): add machine-readable deprecation markers to kit READMEs

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/clustering.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/clustering.ts
@@ -33,7 +33,7 @@ const VALID_CLUSTERING_TYPES = [
   "TIMESTAMP",
 ] as const;
 
-type ValidClusteringType = typeof VALID_CLUSTERING_TYPES[number];
+type ValidClusteringType = (typeof VALID_CLUSTERING_TYPES)[number];
 
 interface InvalidFieldType {
   fieldName: string;

--- a/kits/delete-user-data/src/config.ts
+++ b/kits/delete-user-data/src/config.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {
   defineBoolean,
   defineInt,

--- a/kits/delete-user-data/src/events.ts
+++ b/kits/delete-user-data/src/events.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as eventArc from "firebase-admin/eventarc";
 
 let eventChannel: eventArc.Channel | undefined;

--- a/kits/delete-user-data/src/export-config.ts
+++ b/kits/delete-user-data/src/export-config.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export type FirestoreDeleteMode = "recursive" | "shallow";
 
 export interface DeleteUserDataConfig {

--- a/kits/delete-user-data/src/handlers.ts
+++ b/kits/delete-user-data/src/handlers.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type * as admin from "firebase-admin";
 import type { DocumentReference } from "firebase-admin/firestore";
 import { FieldPath } from "firebase-admin/firestore";

--- a/kits/delete-user-data/src/helpers.ts
+++ b/kits/delete-user-data/src/helpers.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { type DocumentReference, FieldPath } from "firebase-admin/firestore";
 
 export const hasValidUserPath = async (

--- a/kits/delete-user-data/src/lib.ts
+++ b/kits/delete-user-data/src/lib.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export {
   type DeleteUserDataConfig,
   type FirestoreDeleteMode,

--- a/kits/delete-user-data/src/recursiveDelete.ts
+++ b/kits/delete-user-data/src/recursiveDelete.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type * as admin from "firebase-admin";
 
 const MAX_RETRY_ATTEMPTS = 3;

--- a/kits/delete-user-data/src/runBatchPubSubDeletions.ts
+++ b/kits/delete-user-data/src/runBatchPubSubDeletions.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type { PubSub } from "@google-cloud/pubsub";
 import chunk from "lodash.chunk";
 import type { ResolvedDeleteUserDataConfig } from "./export-config";

--- a/kits/delete-user-data/src/runCustomSearchFunction.ts
+++ b/kits/delete-user-data/src/runCustomSearchFunction.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import fetch from "node-fetch";
 import * as logs from "./logs";
 import type { PublisherContext } from "./runBatchPubSubDeletions";

--- a/kits/delete-user-data/src/search.ts
+++ b/kits/delete-user-data/src/search.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type * as admin from "firebase-admin";
 import {
   type PublisherContext,

--- a/kits/firestore-bigquery-export/README.md
+++ b/kits/firestore-bigquery-export/README.md
@@ -1,6 +1,6 @@
 # @firebase/firestore-bigquery-export
 
-<!-- FIREBASE_EXTENSION_REPLACEMENT: extension=firebase/firestore-bigquery-export package=@firebase/firestore-bigquery-export -->
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-bigquery-export" package="@firebase/firestore-bigquery-export" -->
 
 > **Deprecation Notice:** The Firebase Extension `firebase/firestore-bigquery-export` is deprecated. Please migrate to the [`@firebase/firestore-bigquery-export`](https://www.npmjs.com/package/@firebase/firestore-bigquery-export) package.
 

--- a/kits/firestore-bigquery-export/README.md
+++ b/kits/firestore-bigquery-export/README.md
@@ -1,5 +1,9 @@
 # @firebase/firestore-bigquery-export
 
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension=firebase/firestore-bigquery-export package=@firebase/firestore-bigquery-export -->
+
+> **Deprecation Notice:** The Firebase Extension `firebase/firestore-bigquery-export` is deprecated. Please migrate to the [`@firebase/firestore-bigquery-export`](https://www.npmjs.com/package/@firebase/firestore-bigquery-export) package.
+
 Stream a Cloud Firestore collection to BigQuery. This is the Stream Firestore to
 BigQuery Firebase Extension as an npm package you add to your own Firebase
 Functions codebase and deploy.

--- a/kits/firestore-bundle-builder/tests/build-bundle.test.ts
+++ b/kits/firestore-bundle-builder/tests/build-bundle.test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { describe, expect, test } from "vitest";
 import {
   type ParamsSpec,

--- a/kits/firestore-bundle-builder/tests/export-config.test.ts
+++ b/kits/firestore-bundle-builder/tests/export-config.test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { describe, expect, test } from "vitest";
 import { resolveConfig } from "../src/export-config";
 

--- a/kits/firestore-bundle-builder/tests/handlers.test.ts
+++ b/kits/firestore-bundle-builder/tests/handlers.test.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { PassThrough, Readable, Writable } from "node:stream";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import type { BundleSpec } from "../src/build-bundle";

--- a/kits/firestore-counter/README.md
+++ b/kits/firestore-counter/README.md
@@ -1,5 +1,9 @@
 # @firebase/firestore-counter
 
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension=firebase/firestore-counter package=@firebase/firestore-counter -->
+
+> **Deprecation Notice:** The Firebase Extension `firebase/firestore-counter` is deprecated. Please migrate to the [`@firebase/firestore-counter`](https://www.npmjs.com/package/@firebase/firestore-counter) package.
+
 Distributed, sharded counters for Firestore
 
 > **Status: skeleton — not yet implemented.**

--- a/kits/firestore-counter/README.md
+++ b/kits/firestore-counter/README.md
@@ -1,6 +1,6 @@
 # @firebase/firestore-counter
 
-<!-- FIREBASE_EXTENSION_REPLACEMENT: extension=firebase/firestore-counter package=@firebase/firestore-counter -->
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-counter" package="@firebase/firestore-counter" -->
 
 > **Deprecation Notice:** The Firebase Extension `firebase/firestore-counter` is deprecated. Please migrate to the [`@firebase/firestore-counter`](https://www.npmjs.com/package/@firebase/firestore-counter) package.
 

--- a/kits/firestore-genai-chatbot/README.md
+++ b/kits/firestore-genai-chatbot/README.md
@@ -1,5 +1,9 @@
 # @firebase/firestore-genai-chatbot
 
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension=googlecloud/firestore-genai-chatbot package=@firebase/firestore-genai-chatbot -->
+
+> **Deprecation Notice:** The Firebase Extension `googlecloud/firestore-genai-chatbot` is deprecated. Please migrate to the [`@firebase/firestore-genai-chatbot`](https://www.npmjs.com/package/@firebase/firestore-genai-chatbot) package.
+
 Conversational GenAI chatbot backed by Firestore
 
 > **Status: skeleton — not yet implemented.**

--- a/kits/firestore-genai-chatbot/README.md
+++ b/kits/firestore-genai-chatbot/README.md
@@ -1,6 +1,6 @@
 # @firebase/firestore-genai-chatbot
 
-<!-- FIREBASE_EXTENSION_REPLACEMENT: extension=googlecloud/firestore-genai-chatbot package=@firebase/firestore-genai-chatbot -->
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="googlecloud/firestore-genai-chatbot" package="@firebase/firestore-genai-chatbot" -->
 
 > **Deprecation Notice:** The Firebase Extension `googlecloud/firestore-genai-chatbot` is deprecated. Please migrate to the [`@firebase/firestore-genai-chatbot`](https://www.npmjs.com/package/@firebase/firestore-genai-chatbot) package.
 

--- a/kits/firestore-incremental-capture/README.md
+++ b/kits/firestore-incremental-capture/README.md
@@ -1,5 +1,9 @@
 # @firebase/firestore-incremental-capture
 
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension=googlecloud/firestore-incremental-capture package=@firebase/firestore-incremental-capture -->
+
+> **Deprecation Notice:** The Firebase Extension `googlecloud/firestore-incremental-capture` is deprecated. Please migrate to the [`@firebase/firestore-incremental-capture`](https://www.npmjs.com/package/@firebase/firestore-incremental-capture) package.
+
 Incremental point-in-time capture of Firestore changes
 
 > **Status: skeleton — not yet implemented.**

--- a/kits/firestore-incremental-capture/README.md
+++ b/kits/firestore-incremental-capture/README.md
@@ -1,6 +1,6 @@
 # @firebase/firestore-incremental-capture
 
-<!-- FIREBASE_EXTENSION_REPLACEMENT: extension=googlecloud/firestore-incremental-capture package=@firebase/firestore-incremental-capture -->
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="googlecloud/firestore-incremental-capture" package="@firebase/firestore-incremental-capture" -->
 
 > **Deprecation Notice:** The Firebase Extension `googlecloud/firestore-incremental-capture` is deprecated. Please migrate to the [`@firebase/firestore-incremental-capture`](https://www.npmjs.com/package/@firebase/firestore-incremental-capture) package.
 

--- a/kits/firestore-send-email/README.md
+++ b/kits/firestore-send-email/README.md
@@ -1,6 +1,6 @@
 # @firebase/firestore-send-email
 
-<!-- FIREBASE_EXTENSION_REPLACEMENT: extension=firebase/firestore-send-email package=@firebase/firestore-send-email -->
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-send-email" package="@firebase/firestore-send-email" -->
 
 > **Deprecation Notice:** The Firebase Extension `firebase/firestore-send-email` is deprecated. Please migrate to the [`@firebase/firestore-send-email`](https://www.npmjs.com/package/@firebase/firestore-send-email) package.
 

--- a/kits/firestore-send-email/README.md
+++ b/kits/firestore-send-email/README.md
@@ -1,5 +1,9 @@
 # @firebase/firestore-send-email
 
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension=firebase/firestore-send-email package=@firebase/firestore-send-email -->
+
+> **Deprecation Notice:** The Firebase Extension `firebase/firestore-send-email` is deprecated. Please migrate to the [`@firebase/firestore-send-email`](https://www.npmjs.com/package/@firebase/firestore-send-email) package.
+
 Send emails based on documents written to Firestore. This is the Trigger Email
 from Firestore Firebase Extension as an npm package you add to your own Firebase
 Functions codebase and deploy.

--- a/kits/firestore-translate-text/README.md
+++ b/kits/firestore-translate-text/README.md
@@ -1,5 +1,9 @@
 # @firebase/firestore-translate-text
 
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension=firebase/firestore-translate-text package=@firebase/firestore-translate-text -->
+
+> **Deprecation Notice:** The Firebase Extension `firebase/firestore-translate-text` is deprecated. Please migrate to the [`@firebase/firestore-translate-text`](https://www.npmjs.com/package/@firebase/firestore-translate-text) package.
+
 Translate text written to a Firestore collection
 
 > **Status: skeleton — not yet implemented.**

--- a/kits/firestore-translate-text/README.md
+++ b/kits/firestore-translate-text/README.md
@@ -1,6 +1,6 @@
 # @firebase/firestore-translate-text
 
-<!-- FIREBASE_EXTENSION_REPLACEMENT: extension=firebase/firestore-translate-text package=@firebase/firestore-translate-text -->
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-translate-text" package="@firebase/firestore-translate-text" -->
 
 > **Deprecation Notice:** The Firebase Extension `firebase/firestore-translate-text` is deprecated. Please migrate to the [`@firebase/firestore-translate-text`](https://www.npmjs.com/package/@firebase/firestore-translate-text) package.
 

--- a/kits/firestore-translate-text/src/handlers.ts
+++ b/kits/firestore-translate-text/src/handlers.ts
@@ -32,7 +32,7 @@ const CHANGE_TYPE = {
   update: "update",
 } as const;
 
-type ChangeType = typeof CHANGE_TYPE[keyof typeof CHANGE_TYPE];
+type ChangeType = (typeof CHANGE_TYPE)[keyof typeof CHANGE_TYPE];
 
 export interface HandlerContext {
   firestore: Firestore;

--- a/kits/firestore-vector-search/src/config.ts
+++ b/kits/firestore-vector-search/src/config.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {
   defineBoolean,
   defineInt,

--- a/kits/firestore-vector-search/src/embeddings/client/base_class.ts
+++ b/kits/firestore-vector-search/src/embeddings/client/base_class.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export interface EmbedClient {
   readonly batchSize: number;
   getEmbeddings(inputs: ReadonlyArray<string>): Promise<number[][]>;

--- a/kits/firestore-vector-search/src/embeddings/client/genkit.ts
+++ b/kits/firestore-vector-search/src/embeddings/client/genkit.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { googleAI, vertexAI } from "@genkit-ai/google-genai";
 import { type EmbedderReference, type Genkit, genkit } from "genkit";
 import type { ResolvedVectorSearchConfig } from "../../export-config";

--- a/kits/firestore-vector-search/src/embeddings/client/multimodal/index.ts
+++ b/kits/firestore-vector-search/src/embeddings/client/multimodal/index.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type { ResolvedVectorSearchConfig } from "../../../export-config";
 import { BaseEmbedClient } from "../base_class";
 

--- a/kits/firestore-vector-search/src/embeddings/client/text/custom_function.ts
+++ b/kits/firestore-vector-search/src/embeddings/client/text/custom_function.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { z } from "zod";
 import type { ResolvedVectorSearchConfig } from "../../../export-config";
 import { BaseEmbedClient } from "../base_class";

--- a/kits/firestore-vector-search/src/embeddings/client/text/open_ai.ts
+++ b/kits/firestore-vector-search/src/embeddings/client/text/open_ai.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import OpenAI from "openai";
 import type { ResolvedVectorSearchConfig } from "../../../export-config";
 import { BaseEmbedClient } from "../base_class";

--- a/kits/firestore-vector-search/src/embeddings/index.ts
+++ b/kits/firestore-vector-search/src/embeddings/index.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type { ResolvedVectorSearchConfig } from "../export-config";
 import type { EmbedClient } from "./client/base_class";
 import { GenkitEmbedClient } from "./client/genkit";

--- a/kits/firestore-vector-search/src/events.ts
+++ b/kits/firestore-vector-search/src/events.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as eventArc from "firebase-admin/eventarc";
 
 const EXTENSION_NAME = "firestore-vector-search";

--- a/kits/firestore-vector-search/src/export-config.ts
+++ b/kits/firestore-vector-search/src/export-config.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export type EmbeddingProvider =
   | "gemini"
   | "multimodal"

--- a/kits/firestore-vector-search/src/handlers.ts
+++ b/kits/firestore-vector-search/src/handlers.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { type DocumentSnapshot, FieldValue } from "firebase-admin/firestore";
 import { getFunctions } from "firebase-admin/functions";
 import type { Change, FirestoreEvent } from "firebase-functions/v2/firestore";

--- a/kits/firestore-vector-search/src/lib.ts
+++ b/kits/firestore-vector-search/src/lib.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export { configFromEnv, geminiApiKey, openAiApiKey } from "./config";
 export { createEmbedClient, type EmbedClient } from "./embeddings";
 export {

--- a/kits/firestore-vector-search/src/logs.ts
+++ b/kits/firestore-vector-search/src/logs.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { logger } from "firebase-functions";
 import type { ResolvedVectorSearchConfig } from "./export-config";
 

--- a/kits/firestore-vector-search/src/queries/index.ts
+++ b/kits/firestore-vector-search/src/queries/index.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { z } from "zod";
 import type { EmbedClient } from "../embeddings";
 import type { ResolvedVectorSearchConfig } from "../export-config";

--- a/kits/firestore-vector-search/src/queries/setup.ts
+++ b/kits/firestore-vector-search/src/queries/setup.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { v1 as FirestoreV1 } from "@google-cloud/firestore";
 import { logger } from "firebase-functions";
 

--- a/kits/firestore-vector-search/src/vector-store/firestore.ts
+++ b/kits/firestore-vector-search/src/vector-store/firestore.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type { Query, VectorQuery } from "@google-cloud/firestore";
 import type { Firestore } from "firebase-admin/firestore";
 import { https } from "firebase-functions/v1";

--- a/kits/firestore-vector-search/src/vector-store/index.ts
+++ b/kits/firestore-vector-search/src/vector-store/index.ts
@@ -1,1 +1,17 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export { FirestoreVectorStoreClient } from "./firestore";

--- a/kits/rtdb-limit-child-nodes/README.md
+++ b/kits/rtdb-limit-child-nodes/README.md
@@ -1,5 +1,9 @@
 # @firebase/rtdb-limit-child-nodes
 
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension=firebase/rtdb-limit-child-nodes package=@firebase/rtdb-limit-child-nodes -->
+
+> **Deprecation Notice:** The Firebase Extension `firebase/rtdb-limit-child-nodes` is deprecated. Please migrate to the [`@firebase/rtdb-limit-child-nodes`](https://www.npmjs.com/package/@firebase/rtdb-limit-child-nodes) package.
+
 Limit the number of child nodes under a Realtime Database path. This is the
 Limit Child Nodes Firebase Extension as an npm package you add to your own
 Firebase Functions codebase and deploy.

--- a/kits/rtdb-limit-child-nodes/README.md
+++ b/kits/rtdb-limit-child-nodes/README.md
@@ -1,6 +1,6 @@
 # @firebase/rtdb-limit-child-nodes
 
-<!-- FIREBASE_EXTENSION_REPLACEMENT: extension=firebase/rtdb-limit-child-nodes package=@firebase/rtdb-limit-child-nodes -->
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/rtdb-limit-child-nodes" package="@firebase/rtdb-limit-child-nodes" -->
 
 > **Deprecation Notice:** The Firebase Extension `firebase/rtdb-limit-child-nodes` is deprecated. Please migrate to the [`@firebase/rtdb-limit-child-nodes`](https://www.npmjs.com/package/@firebase/rtdb-limit-child-nodes) package.
 

--- a/kits/speech-to-text/README.md
+++ b/kits/speech-to-text/README.md
@@ -1,6 +1,6 @@
 # @firebase/speech-to-text
 
-<!-- FIREBASE_EXTENSION_REPLACEMENT: extension=googlecloud/speech-to-text package=@firebase/speech-to-text -->
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="googlecloud/speech-to-text" package="@firebase/speech-to-text" -->
 
 > **Deprecation Notice:** The Firebase Extension `googlecloud/speech-to-text` is deprecated. Please migrate to the [`@firebase/speech-to-text`](https://www.npmjs.com/package/@firebase/speech-to-text) package.
 

--- a/kits/speech-to-text/README.md
+++ b/kits/speech-to-text/README.md
@@ -1,5 +1,9 @@
 # @firebase/speech-to-text
 
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension=googlecloud/speech-to-text package=@firebase/speech-to-text -->
+
+> **Deprecation Notice:** The Firebase Extension `googlecloud/speech-to-text` is deprecated. Please migrate to the [`@firebase/speech-to-text`](https://www.npmjs.com/package/@firebase/speech-to-text) package.
+
 Transcribe audio files in Cloud Storage to text. This is the Transcribe Speech to
 Text Firebase Extension as a deployable Firebase Functions package.
 

--- a/kits/storage-resize-images/src/config.ts
+++ b/kits/storage-resize-images/src/config.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {
   BUCKET_PICKER,
   defineBoolean,

--- a/kits/storage-resize-images/src/content-filter.ts
+++ b/kits/storage-resize-images/src/content-filter.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as fs from "node:fs";
 import vertexAI, { gemini } from "@genkit-ai/vertexai";
 import { genkit, z } from "genkit";

--- a/kits/storage-resize-images/src/events.ts
+++ b/kits/storage-resize-images/src/events.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as eventArc from "firebase-admin/eventarc";
 
 const EXTENSION_NAME = "storage-resize-images";

--- a/kits/storage-resize-images/src/file-operations.ts
+++ b/kits/storage-resize-images/src/file-operations.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/kits/storage-resize-images/src/filters.ts
+++ b/kits/storage-resize-images/src/filters.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as path from "node:path";
 
 import type { ResolvedResizeImagesConfig } from "./export-config";

--- a/kits/storage-resize-images/src/global.ts
+++ b/kits/storage-resize-images/src/global.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import PQueue from "p-queue";
 
 export const SUPPORTED_CONTENT_TYPES = [

--- a/kits/storage-resize-images/src/handlers.ts
+++ b/kits/storage-resize-images/src/handlers.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { File } from "@google-cloud/storage";

--- a/kits/storage-resize-images/src/lib.ts
+++ b/kits/storage-resize-images/src/lib.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export { checkImageContent } from "./content-filter";
 export {
   type ContentFilterLevel,

--- a/kits/storage-resize-images/src/logs.ts
+++ b/kits/storage-resize-images/src/logs.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { logger } from "firebase-functions";
 import type { ResolvedResizeImagesConfig } from "./export-config";
 

--- a/kits/storage-resize-images/src/placeholder.ts
+++ b/kits/storage-resize-images/src/placeholder.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import type { Bucket } from "@google-cloud/storage";
 import * as log from "./logs";
 import {

--- a/kits/storage-resize-images/src/resize-image.ts
+++ b/kits/storage-resize-images/src/resize-image.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/kits/storage-resize-images/src/util.ts
+++ b/kits/storage-resize-images/src/util.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "jest": "^29.7.0",
         "lerna": "^3.4.3",
         "lint-staged": "^12.4.0",
-        "prettier": "2.7.1",
+        "prettier": "2.8.8",
         "ts-jest": "29.4.11",
         "typescript": "^5.0.0"
       }
@@ -12543,9 +12543,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "jest": "^29.7.0",
     "lerna": "^3.4.3",
     "lint-staged": "^12.4.0",
-    "prettier": "2.7.1",
+    "prettier": "2.8.8",
     "ts-jest": "29.4.11",
     "typescript": "^5.0.0"
   },


### PR DESCRIPTION
## Summary

Adds a machine-readable deprecation marker plus a visible deprecation notice to the top of each kit README on the `kits` branch. A scraping script can pick up the HTML comment to power CLI warnings and migration nudges for users of the deprecated extensions.

Marker format:

```markdown
<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-send-email" package="@firebase/firestore-send-email" -->

> **Deprecation Notice:** The Firebase Extension `firebase/firestore-send-email` is deprecated. Please migrate to the [`@firebase/firestore-send-email`](https://www.npmjs.com/package/@firebase/firestore-send-email) package.
```

The marker includes an `extension=` field alongside `package=` so the scraper does not need to infer the extension ID from the repo path. This matters because publishers differ across kits:

| Kit | Deprecated extension | Replacement package |
| --- | --- | --- |
| firestore-bigquery-export | firebase/firestore-bigquery-export | @firebase/firestore-bigquery-export |
| firestore-counter | firebase/firestore-counter | @firebase/firestore-counter |
| firestore-genai-chatbot | googlecloud/firestore-genai-chatbot | @firebase/firestore-genai-chatbot |
| firestore-incremental-capture | googlecloud/firestore-incremental-capture | @firebase/firestore-incremental-capture |
| firestore-send-email | firebase/firestore-send-email | @firebase/firestore-send-email |
| firestore-translate-text | firebase/firestore-translate-text | @firebase/firestore-translate-text |
| rtdb-limit-child-nodes | firebase/rtdb-limit-child-nodes | @firebase/rtdb-limit-child-nodes |
| speech-to-text | googlecloud/speech-to-text | @firebase/speech-to-text |

## Notes

- Several kits (firestore-counter, firestore-genai-chatbot, firestore-incremental-capture, firestore-translate-text) are still skeletons. Their markers are included so the scraper can be tested end to end, but the npm package links will not resolve until those packages are published.
- Draft until the marker format is agreed with the scraper side.
