### PR TITLE
docs: add machine-readable deprecation markers to extension READMEs

### DIFF
--- a/delete-user-data/PREINSTALL.md
+++ b/delete-user-data/PREINSTALL.md
@@ -1,3 +1,7 @@
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/delete-user-data" package="@firebase/delete-user-data" -->
+
+> **Deprecation Notice:** The Firebase Extension `firebase/delete-user-data` is deprecated. Please migrate to the [`@firebase/delete-user-data`](https://www.npmjs.com/package/@firebase/delete-user-data) package.
+
 Use this extension to automatically delete certain data keyed on a user ID when the user is deleted from Firebase Authentication.
 
 You can configure this extension to delete certain data keyed on a user ID from any or all of the following: Cloud Firestore, Realtime Database, or Cloud Storage. Each trigger of the extension to delete data is keyed to the user's UID.

--- a/delete-user-data/README.md
+++ b/delete-user-data/README.md
@@ -6,7 +6,11 @@
 
 
 
-**Details**: Use this extension to automatically delete certain data keyed on a user ID when the user is deleted from Firebase Authentication.
+**Details**: <!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/delete-user-data" package="@firebase/delete-user-data" -->
+
+> **Deprecation Notice:** The Firebase Extension `firebase/delete-user-data` is deprecated. Please migrate to the [`@firebase/delete-user-data`](https://www.npmjs.com/package/@firebase/delete-user-data) package.
+
+Use this extension to automatically delete certain data keyed on a user ID when the user is deleted from Firebase Authentication.
 
 You can configure this extension to delete certain data keyed on a user ID from any or all of the following: Cloud Firestore, Realtime Database, or Cloud Storage. Each trigger of the extension to delete data is keyed to the user's UID.
 

--- a/firestore-bigquery-export/PREINSTALL.md
+++ b/firestore-bigquery-export/PREINSTALL.md
@@ -1,3 +1,7 @@
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-bigquery-export" package="@firebase/firestore-bigquery-export" -->
+
+> **Deprecation Notice:** The Firebase Extension `firebase/firestore-bigquery-export` is deprecated. Please migrate to the [`@firebase/firestore-bigquery-export`](https://www.npmjs.com/package/@firebase/firestore-bigquery-export) package.
+
 Use this extension to export the documents in a Cloud Firestore collection to BigQuery. Exports are realtime and incremental, so the data in BigQuery is a mirror of your content in Cloud Firestore.
 
 The extension creates and updates a [dataset](https://cloud.google.com/bigquery/docs/datasets-intro) containing the following two BigQuery resources:

--- a/firestore-bigquery-export/README.md
+++ b/firestore-bigquery-export/README.md
@@ -6,7 +6,11 @@
 
 
 
-**Details**: Use this extension to export the documents in a Cloud Firestore collection to BigQuery. Exports are realtime and incremental, so the data in BigQuery is a mirror of your content in Cloud Firestore.
+**Details**: <!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-bigquery-export" package="@firebase/firestore-bigquery-export" -->
+
+> **Deprecation Notice:** The Firebase Extension `firebase/firestore-bigquery-export` is deprecated. Please migrate to the [`@firebase/firestore-bigquery-export`](https://www.npmjs.com/package/@firebase/firestore-bigquery-export) package.
+
+Use this extension to export the documents in a Cloud Firestore collection to BigQuery. Exports are realtime and incremental, so the data in BigQuery is a mirror of your content in Cloud Firestore.
 
 The extension creates and updates a [dataset](https://cloud.google.com/bigquery/docs/datasets-intro) containing the following two BigQuery resources:
 

--- a/firestore-counter/PREINSTALL.md
+++ b/firestore-counter/PREINSTALL.md
@@ -1,3 +1,7 @@
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-counter" package="@firebase/firestore-counter" -->
+
+> **Deprecation Notice:** The Firebase Extension `firebase/firestore-counter` is deprecated. Please migrate to the [`@firebase/firestore-counter`](https://www.npmjs.com/package/@firebase/firestore-counter) package.
+
 Use this extension to add a highly scalable counter service to your app. This is ideal for applications that count viral actions or any very high-velocity action such as views, likes, or shares.
 
 Since Cloud Firestore has a limit of one sustained write per second, per document, this extension instead shards your writes across documents in a `_counter_shards_` subcollection. Each client only increments their own unique shard while the background workers (provided by this extension) monitor and aggregate these shards into a main document.

--- a/firestore-counter/README.md
+++ b/firestore-counter/README.md
@@ -6,7 +6,11 @@
 
 
 
-**Details**: Use this extension to add a highly scalable counter service to your app. This is ideal for applications that count viral actions or any very high-velocity action such as views, likes, or shares.
+**Details**: <!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-counter" package="@firebase/firestore-counter" -->
+
+> **Deprecation Notice:** The Firebase Extension `firebase/firestore-counter` is deprecated. Please migrate to the [`@firebase/firestore-counter`](https://www.npmjs.com/package/@firebase/firestore-counter) package.
+
+Use this extension to add a highly scalable counter service to your app. This is ideal for applications that count viral actions or any very high-velocity action such as views, likes, or shares.
 
 Since Cloud Firestore has a limit of one sustained write per second, per document, this extension instead shards your writes across documents in a `_counter_shards_` subcollection. Each client only increments their own unique shard while the background workers (provided by this extension) monitor and aggregate these shards into a main document.
 

--- a/firestore-send-email/PREINSTALL.md
+++ b/firestore-send-email/PREINSTALL.md
@@ -1,3 +1,7 @@
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-send-email" package="@firebase/firestore-send-email" -->
+
+> **Deprecation Notice:** The Firebase Extension `firebase/firestore-send-email` is deprecated. Please migrate to the [`@firebase/firestore-send-email`](https://www.npmjs.com/package/@firebase/firestore-send-email) package.
+
 Use this extension to render and send emails that contain the information from documents added to a specified Cloud Firestore collection.
 
 Adding a document triggers this extension to send an email built from the document's fields. The document's top-level fields specify the email sender and recipients, including `to`, `cc`, and `bcc` options (each supporting UIDs). The document's `message` field specifies the other email elements, like subject line and email body (either plaintext or HTML)

--- a/firestore-send-email/README.md
+++ b/firestore-send-email/README.md
@@ -6,7 +6,11 @@
 
 
 
-**Details**: Use this extension to render and send emails that contain the information from documents added to a specified Cloud Firestore collection.
+**Details**: <!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-send-email" package="@firebase/firestore-send-email" -->
+
+> **Deprecation Notice:** The Firebase Extension `firebase/firestore-send-email` is deprecated. Please migrate to the [`@firebase/firestore-send-email`](https://www.npmjs.com/package/@firebase/firestore-send-email) package.
+
+Use this extension to render and send emails that contain the information from documents added to a specified Cloud Firestore collection.
 
 Adding a document triggers this extension to send an email built from the document's fields. The document's top-level fields specify the email sender and recipients, including `to`, `cc`, and `bcc` options (each supporting UIDs). The document's `message` field specifies the other email elements, like subject line and email body (either plaintext or HTML)
 

--- a/firestore-translate-text/PREINSTALL.md
+++ b/firestore-translate-text/PREINSTALL.md
@@ -1,3 +1,7 @@
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-translate-text" package="@firebase/firestore-translate-text" -->
+
+> **Deprecation Notice:** The Firebase Extension `firebase/firestore-translate-text` is deprecated. Please migrate to the [`@firebase/firestore-translate-text`](https://www.npmjs.com/package/@firebase/firestore-translate-text) package.
+
 Use this extension to translate strings (for example, text messages) written to a Cloud Firestore collection.
 
 This extension listens to your specified Cloud Firestore collection. If you add a string to a specified field in any document within that collection, this extension:

--- a/firestore-translate-text/README.md
+++ b/firestore-translate-text/README.md
@@ -6,7 +6,11 @@
 
 
 
-**Details**: Use this extension to translate strings (for example, text messages) written to a Cloud Firestore collection.
+**Details**: <!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-translate-text" package="@firebase/firestore-translate-text" -->
+
+> **Deprecation Notice:** The Firebase Extension `firebase/firestore-translate-text` is deprecated. Please migrate to the [`@firebase/firestore-translate-text`](https://www.npmjs.com/package/@firebase/firestore-translate-text) package.
+
+Use this extension to translate strings (for example, text messages) written to a Cloud Firestore collection.
 
 This extension listens to your specified Cloud Firestore collection. If you add a string to a specified field in any document within that collection, this extension:
 

--- a/rtdb-limit-child-nodes/PREINSTALL.md
+++ b/rtdb-limit-child-nodes/PREINSTALL.md
@@ -1,3 +1,7 @@
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/rtdb-limit-child-nodes" package="@firebase/rtdb-limit-child-nodes" -->
+
+> **Deprecation Notice:** The Firebase Extension `firebase/rtdb-limit-child-nodes` is deprecated. Please migrate to the [`@firebase/rtdb-limit-child-nodes`](https://www.npmjs.com/package/@firebase/rtdb-limit-child-nodes) package.
+
 Use this extension to control the maximum number of nodes stored in a Firebase Realtime Database path.
 
 If the number of nodes in your specified Realtime Database path exceeds the specified max count, this extension deletes the oldest nodes first until there are the max count number of nodes remaining.

--- a/rtdb-limit-child-nodes/README.md
+++ b/rtdb-limit-child-nodes/README.md
@@ -6,7 +6,11 @@
 
 
 
-**Details**: Use this extension to control the maximum number of nodes stored in a Firebase Realtime Database path.
+**Details**: <!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/rtdb-limit-child-nodes" package="@firebase/rtdb-limit-child-nodes" -->
+
+> **Deprecation Notice:** The Firebase Extension `firebase/rtdb-limit-child-nodes` is deprecated. Please migrate to the [`@firebase/rtdb-limit-child-nodes`](https://www.npmjs.com/package/@firebase/rtdb-limit-child-nodes) package.
+
+Use this extension to control the maximum number of nodes stored in a Firebase Realtime Database path.
 
 If the number of nodes in your specified Realtime Database path exceeds the specified max count, this extension deletes the oldest nodes first until there are the max count number of nodes remaining.
 

--- a/storage-resize-images/PREINSTALL.md
+++ b/storage-resize-images/PREINSTALL.md
@@ -1,3 +1,7 @@
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/storage-resize-images" package="@firebase/storage-resize-images" -->
+
+> **Deprecation Notice:** The Firebase Extension `firebase/storage-resize-images` is deprecated. Please migrate to the [`@firebase/storage-resize-images`](https://www.npmjs.com/package/@firebase/storage-resize-images) package.
+
 Use this extension to create resized versions of an image uploaded to a Cloud Storage bucket.
 
 When you upload a file to your specified Cloud Storage bucket, this extension:

--- a/storage-resize-images/README.md
+++ b/storage-resize-images/README.md
@@ -6,7 +6,11 @@
 
 
 
-**Details**: Use this extension to create resized versions of an image uploaded to a Cloud Storage bucket.
+**Details**: <!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/storage-resize-images" package="@firebase/storage-resize-images" -->
+
+> **Deprecation Notice:** The Firebase Extension `firebase/storage-resize-images` is deprecated. Please migrate to the [`@firebase/storage-resize-images`](https://www.npmjs.com/package/@firebase/storage-resize-images) package.
+
+Use this extension to create resized versions of an image uploaded to a Cloud Storage bucket.
 
 When you upload a file to your specified Cloud Storage bucket, this extension:
 


### PR DESCRIPTION
## Summary

Adds a machine-readable deprecation marker plus a visible deprecation notice to each extension whose replacement kit exists on the `kits` branch. Markers live in the extension READMEs (not the kit READMEs) so that someone with write access to the extension source is officially designating the replacement kit - see discussion with Varun and Andy.

Markers are added to `PREINSTALL.md` and the READMEs are regenerated with `lerna run generate-readme` (`firebase ext:info --markdown`), since READMEs are generated files.

Marker format (HTML comment, invisible when rendered):

```markdown
<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-send-email" package="@firebase/firestore-send-email" -->

> **Deprecation Notice:** The Firebase Extension `firebase/firestore-send-email` is deprecated. Please migrate to the [`@firebase/firestore-send-email`](https://www.npmjs.com/package/@firebase/firestore-send-email) package.
```

## Extensions covered

| Extension | Replacement package |
| --- | --- |
| firebase/delete-user-data | @firebase/delete-user-data |
| firebase/firestore-bigquery-export | @firebase/firestore-bigquery-export |
| firebase/firestore-counter | @firebase/firestore-counter |
| firebase/firestore-send-email | @firebase/firestore-send-email |
| firebase/firestore-translate-text | @firebase/firestore-translate-text |
| firebase/rtdb-limit-child-nodes | @firebase/rtdb-limit-child-nodes |
| firebase/storage-resize-images | @firebase/storage-resize-images |

## Notes

- `firestore-shorten-urls-bitly` has no kit yet, so no marker.
- Kits for `googlecloud/*` extensions (firestore-genai-chatbot, firestore-incremental-capture, speech-to-text, firestore-vector-search, bigquery-firestore-export) and `firestore-bundle-builder` need the same treatment in their own source repos - separate PRs.
- Supersedes the kit-README markers in #2934; that PR is being reduced to its CI fixes.