### PR TITLE
docs(kits): remove deprecation markers from kit READMEs

### DIFF
--- a/kits/firestore-bigquery-export/README.md
+++ b/kits/firestore-bigquery-export/README.md
@@ -1,9 +1,5 @@
 # @firebase/firestore-bigquery-export
 
-<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-bigquery-export" package="@firebase/firestore-bigquery-export" -->
-
-> **Deprecation Notice:** The Firebase Extension `firebase/firestore-bigquery-export` is deprecated. Please migrate to the [`@firebase/firestore-bigquery-export`](https://www.npmjs.com/package/@firebase/firestore-bigquery-export) package.
-
 Stream a Cloud Firestore collection to BigQuery. This is the Stream Firestore to
 BigQuery Firebase Extension as an npm package you add to your own Firebase
 Functions codebase and deploy.

--- a/kits/firestore-counter/README.md
+++ b/kits/firestore-counter/README.md
@@ -1,9 +1,5 @@
 # @firebase/firestore-counter
 
-<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-counter" package="@firebase/firestore-counter" -->
-
-> **Deprecation Notice:** The Firebase Extension `firebase/firestore-counter` is deprecated. Please migrate to the [`@firebase/firestore-counter`](https://www.npmjs.com/package/@firebase/firestore-counter) package.
-
 Distributed, sharded counters for Firestore
 
 > **Status: skeleton — not yet implemented.**

--- a/kits/firestore-genai-chatbot/README.md
+++ b/kits/firestore-genai-chatbot/README.md
@@ -1,9 +1,5 @@
 # @firebase/firestore-genai-chatbot
 
-<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="googlecloud/firestore-genai-chatbot" package="@firebase/firestore-genai-chatbot" -->
-
-> **Deprecation Notice:** The Firebase Extension `googlecloud/firestore-genai-chatbot` is deprecated. Please migrate to the [`@firebase/firestore-genai-chatbot`](https://www.npmjs.com/package/@firebase/firestore-genai-chatbot) package.
-
 Conversational GenAI chatbot backed by Firestore
 
 > **Status: skeleton — not yet implemented.**

--- a/kits/firestore-incremental-capture/README.md
+++ b/kits/firestore-incremental-capture/README.md
@@ -1,9 +1,5 @@
 # @firebase/firestore-incremental-capture
 
-<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="googlecloud/firestore-incremental-capture" package="@firebase/firestore-incremental-capture" -->
-
-> **Deprecation Notice:** The Firebase Extension `googlecloud/firestore-incremental-capture` is deprecated. Please migrate to the [`@firebase/firestore-incremental-capture`](https://www.npmjs.com/package/@firebase/firestore-incremental-capture) package.
-
 Incremental point-in-time capture of Firestore changes
 
 > **Status: skeleton — not yet implemented.**

--- a/kits/firestore-send-email/README.md
+++ b/kits/firestore-send-email/README.md
@@ -1,9 +1,5 @@
 # @firebase/firestore-send-email
 
-<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-send-email" package="@firebase/firestore-send-email" -->
-
-> **Deprecation Notice:** The Firebase Extension `firebase/firestore-send-email` is deprecated. Please migrate to the [`@firebase/firestore-send-email`](https://www.npmjs.com/package/@firebase/firestore-send-email) package.
-
 Send emails based on documents written to Firestore. This is the Trigger Email
 from Firestore Firebase Extension as an npm package you add to your own Firebase
 Functions codebase and deploy.

--- a/kits/firestore-translate-text/README.md
+++ b/kits/firestore-translate-text/README.md
@@ -1,9 +1,5 @@
 # @firebase/firestore-translate-text
 
-<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-translate-text" package="@firebase/firestore-translate-text" -->
-
-> **Deprecation Notice:** The Firebase Extension `firebase/firestore-translate-text` is deprecated. Please migrate to the [`@firebase/firestore-translate-text`](https://www.npmjs.com/package/@firebase/firestore-translate-text) package.
-
 Translate text written to a Firestore collection
 
 > **Status: skeleton — not yet implemented.**

--- a/kits/rtdb-limit-child-nodes/README.md
+++ b/kits/rtdb-limit-child-nodes/README.md
@@ -1,9 +1,5 @@
 # @firebase/rtdb-limit-child-nodes
 
-<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/rtdb-limit-child-nodes" package="@firebase/rtdb-limit-child-nodes" -->
-
-> **Deprecation Notice:** The Firebase Extension `firebase/rtdb-limit-child-nodes` is deprecated. Please migrate to the [`@firebase/rtdb-limit-child-nodes`](https://www.npmjs.com/package/@firebase/rtdb-limit-child-nodes) package.
-
 Limit the number of child nodes under a Realtime Database path. This is the
 Limit Child Nodes Firebase Extension as an npm package you add to your own
 Firebase Functions codebase and deploy.

--- a/kits/speech-to-text/README.md
+++ b/kits/speech-to-text/README.md
@@ -1,9 +1,5 @@
 # @firebase/speech-to-text
 
-<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="googlecloud/speech-to-text" package="@firebase/speech-to-text" -->
-
-> **Deprecation Notice:** The Firebase Extension `googlecloud/speech-to-text` is deprecated. Please migrate to the [`@firebase/speech-to-text`](https://www.npmjs.com/package/@firebase/speech-to-text) package.
-
 Transcribe audio files in Cloud Storage to text. This is the Transcribe Speech to
 Text Firebase Extension as a deployable Firebase Functions package.
 


### PR DESCRIPTION
## Summary

Removes the machine-readable deprecation markers and notices added in #2934.

Per Andy's feedback, the marker must live in the _extension_ source README (the repo you reach from the extension page's "source code" link), so that someone with write access to the extension source is provably designating the replacement kit. A marker in the kit README does not prove ownership, since anyone could publish a kit in an unrelated repo.

Extension-side markers are added in #2935 (targeting `kits`).
