### PR TITLE
Set up functions kits packages for publishing

### DIFF
--- a/kits/bigquery-firestore-export/CHANGELOG.md
+++ b/kits/bigquery-firestore-export/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Initial release

--- a/kits/bigquery-firestore-export/package.json
+++ b/kits/bigquery-firestore-export/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@firebase/bigquery-firestore-export",
-  "version": "0.1.0",
+  "name": "@firebase-functions-kits/bigquery-firestore-export",
+  "version": "0.0.0",
   "private": false,
   "description": "Reverse-sync rows from BigQuery into Firestore",
   "license": "Apache-2.0",

--- a/kits/bigquery-firestore-export/package.json
+++ b/kits/bigquery-firestore-export/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-functions-kits/bigquery-firestore-export",
+  "name": "@firebase-function-kits/bigquery-firestore-export",
   "version": "0.0.0",
   "private": false,
   "description": "Reverse-sync rows from BigQuery into Firestore",

--- a/kits/delete-user-data/CHANGELOG.md
+++ b/kits/delete-user-data/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Initial release

--- a/kits/delete-user-data/package.json
+++ b/kits/delete-user-data/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-functions-kits/delete-user-data",
+  "name": "@firebase-function-kits/delete-user-data",
   "version": "0.0.0",
   "description": "Delete user data across Firestore, RTDB, and Storage on account deletion",
   "license": "Apache-2.0",

--- a/kits/delete-user-data/package.json
+++ b/kits/delete-user-data/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@firebase/delete-user-data",
-  "version": "0.1.0",
+  "name": "@firebase-functions-kits/delete-user-data",
+  "version": "0.0.0",
   "description": "Delete user data across Firestore, RTDB, and Storage on account deletion",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/kits/firestore-bigquery-export/CHANGELOG.md
+++ b/kits/firestore-bigquery-export/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Initial release

--- a/kits/firestore-bigquery-export/package.json
+++ b/kits/firestore-bigquery-export/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@firebase/firestore-bigquery-export",
-  "version": "0.1.0",
+  "name": "@firebase-function-kits/firestore-bigquery-export",
+  "version": "0.0.0",
   "description": "Stream a Cloud Firestore collection to BigQuery as a deployable Firebase Function",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/kits/firestore-bigquery-export/package.json
+++ b/kits/firestore-bigquery-export/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-functions-kits/firestore-bigquery-export",
+  "name": "@firebase-function-kits/firestore-bigquery-export",
   "version": "0.0.0",
   "description": "Stream a Cloud Firestore collection to BigQuery as a deployable Firebase Function",
   "license": "Apache-2.0",

--- a/kits/firestore-bigquery-export/package.json
+++ b/kits/firestore-bigquery-export/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-function-kits/firestore-bigquery-export",
+  "name": "@firebase-functions-kits/firestore-bigquery-export",
   "version": "0.0.0",
   "description": "Stream a Cloud Firestore collection to BigQuery as a deployable Firebase Function",
   "license": "Apache-2.0",

--- a/kits/firestore-bundle-builder/CHANGELOG.md
+++ b/kits/firestore-bundle-builder/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Initial release

--- a/kits/firestore-bundle-builder/package.json
+++ b/kits/firestore-bundle-builder/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-functions-kits/firestore-bundle-builder",
+  "name": "@firebase-function-kits/firestore-bundle-builder",
   "version": "0.0.0",
   "description": "Build and serve Firestore data bundles as a deployable Firebase Function",
   "license": "Apache-2.0",

--- a/kits/firestore-bundle-builder/package.json
+++ b/kits/firestore-bundle-builder/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@firebase/firestore-bundle-builder",
-  "version": "0.1.0",
+  "name": "@firebase-function-kits/firestore-bundle-builder",
+  "version": "0.0.0",
   "description": "Build and serve Firestore data bundles as a deployable Firebase Function",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/kits/firestore-bundle-builder/package.json
+++ b/kits/firestore-bundle-builder/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-function-kits/firestore-bundle-builder",
+  "name": "@firebase-functions-kits/firestore-bundle-builder",
   "version": "0.0.0",
   "description": "Build and serve Firestore data bundles as a deployable Firebase Function",
   "license": "Apache-2.0",

--- a/kits/firestore-counter/CHANGELOG.md
+++ b/kits/firestore-counter/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Initial release

--- a/kits/firestore-counter/package.json
+++ b/kits/firestore-counter/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-function-kits/firestore-counter",
+  "name": "@firebase-functions-kits/firestore-counter",
   "version": "0.0.0",
   "description": "Distributed, sharded counters for Firestore",
   "license": "Apache-2.0",

--- a/kits/firestore-counter/package.json
+++ b/kits/firestore-counter/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@firebase/firestore-counter",
-  "version": "0.1.0",
+  "name": "@firebase-function-kits/firestore-counter",
+  "version": "0.0.0",
   "description": "Distributed, sharded counters for Firestore",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/kits/firestore-counter/package.json
+++ b/kits/firestore-counter/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-functions-kits/firestore-counter",
+  "name": "@firebase-function-kits/firestore-counter",
   "version": "0.0.0",
   "description": "Distributed, sharded counters for Firestore",
   "license": "Apache-2.0",

--- a/kits/firestore-genai-chatbot/CHANGELOG.md
+++ b/kits/firestore-genai-chatbot/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Initial release

--- a/kits/firestore-genai-chatbot/package.json
+++ b/kits/firestore-genai-chatbot/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-function-kits/firestore-genai-chatbot",
+  "name": "@firebase-functions-kits/firestore-genai-chatbot",
   "version": "0.0.0",
   "description": "Conversational GenAI chatbot backed by Firestore",
   "license": "Apache-2.0",

--- a/kits/firestore-genai-chatbot/package.json
+++ b/kits/firestore-genai-chatbot/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@firebase/firestore-genai-chatbot",
-  "version": "0.1.0",
+  "name": "@firebase-function-kits/firestore-genai-chatbot",
+  "version": "0.0.0",
   "description": "Conversational GenAI chatbot backed by Firestore",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/kits/firestore-genai-chatbot/package.json
+++ b/kits/firestore-genai-chatbot/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-functions-kits/firestore-genai-chatbot",
+  "name": "@firebase-function-kits/firestore-genai-chatbot",
   "version": "0.0.0",
   "description": "Conversational GenAI chatbot backed by Firestore",
   "license": "Apache-2.0",

--- a/kits/firestore-incremental-capture/CHANGELOG.md
+++ b/kits/firestore-incremental-capture/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Initial release

--- a/kits/firestore-incremental-capture/package.json
+++ b/kits/firestore-incremental-capture/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-functions-kits/firestore-incremental-capture",
+  "name": "@firebase-function-kits/firestore-incremental-capture",
   "version": "0.0.0",
   "private": true,
   "description": "Incremental point-in-time capture of Firestore changes",

--- a/kits/firestore-incremental-capture/package.json
+++ b/kits/firestore-incremental-capture/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-function-kits/firestore-incremental-capture",
+  "name": "@firebase-functions-kits/firestore-incremental-capture",
   "version": "0.0.0",
   "private": true,
   "description": "Incremental point-in-time capture of Firestore changes",

--- a/kits/firestore-incremental-capture/package.json
+++ b/kits/firestore-incremental-capture/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@firebase/firestore-incremental-capture",
-  "version": "0.1.0",
+  "name": "@firebase-function-kits/firestore-incremental-capture",
+  "version": "0.0.0",
   "private": true,
   "description": "Incremental point-in-time capture of Firestore changes",
   "license": "Apache-2.0",

--- a/kits/firestore-send-email/CHANGELOG.md
+++ b/kits/firestore-send-email/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Initial release

--- a/kits/firestore-send-email/package.json
+++ b/kits/firestore-send-email/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-functions-kits/firestore-send-email",
+  "name": "@firebase-function-kits/firestore-send-email",
   "version": "0.0.0",
   "description": "Send emails based on documents written to Firestore",
   "license": "Apache-2.0",

--- a/kits/firestore-send-email/package.json
+++ b/kits/firestore-send-email/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-function-kits/firestore-send-email",
+  "name": "@firebase-functions-kits/firestore-send-email",
   "version": "0.0.0",
   "description": "Send emails based on documents written to Firestore",
   "license": "Apache-2.0",

--- a/kits/firestore-send-email/package.json
+++ b/kits/firestore-send-email/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@firebase/firestore-send-email",
-  "version": "0.1.0",
+  "name": "@firebase-function-kits/firestore-send-email",
+  "version": "0.0.0",
   "description": "Send emails based on documents written to Firestore",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/kits/firestore-translate-text/CHANGELOG.md
+++ b/kits/firestore-translate-text/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Initial release

--- a/kits/firestore-translate-text/package-lock.json
+++ b/kits/firestore-translate-text/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase/firestore-translate-text",
+  "name": "@firebase-function-kits/firestore-translate-text",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,

--- a/kits/firestore-translate-text/package.json
+++ b/kits/firestore-translate-text/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-fuction-kits/firestore-translate-text",
+  "name": "@firebase-function-kits/firestore-translate-text",
   "version": "0.0.0",
   "description": "Translate text written to a Firestore collection",
   "license": "Apache-2.0",

--- a/kits/firestore-translate-text/package.json
+++ b/kits/firestore-translate-text/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@firebase/firestore-translate-text",
-  "version": "0.1.0",
+  "name": "@firebase-fuction-kits/firestore-translate-text",
+  "version": "0.0.0",
   "description": "Translate text written to a Firestore collection",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/kits/firestore-vector-search/CHANGELOG.md
+++ b/kits/firestore-vector-search/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Initial release

--- a/kits/firestore-vector-search/package.json
+++ b/kits/firestore-vector-search/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@firebase/firestore-vector-search",
-  "version": "0.1.0",
+  "name": "@firebase-function-kits/firestore-vector-search",
+  "version": "0.0.0",
   "description": "Vector similarity search over a Firestore collection",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/kits/firestore-vector-search/package.json
+++ b/kits/firestore-vector-search/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-functions-kits/firestore-vector-search",
+  "name": "@firebase-function-kits/firestore-vector-search",
   "version": "0.0.0",
   "description": "Vector similarity search over a Firestore collection",
   "license": "Apache-2.0",

--- a/kits/firestore-vector-search/package.json
+++ b/kits/firestore-vector-search/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-function-kits/firestore-vector-search",
+  "name": "@firebase-functions-kits/firestore-vector-search",
   "version": "0.0.0",
   "description": "Vector similarity search over a Firestore collection",
   "license": "Apache-2.0",

--- a/kits/rtdb-limit-child-nodes/CHANGELOG.md
+++ b/kits/rtdb-limit-child-nodes/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Initial release

--- a/kits/rtdb-limit-child-nodes/package.json
+++ b/kits/rtdb-limit-child-nodes/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-functions-kits/rtdb-limit-child-nodes",
+  "name": "@firebase-function-kits/rtdb-limit-child-nodes",
   "version": "0.0.0",
   "description": "Limit the number of child nodes under a Realtime Database path",
   "license": "Apache-2.0",

--- a/kits/rtdb-limit-child-nodes/package.json
+++ b/kits/rtdb-limit-child-nodes/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@firebase/rtdb-limit-child-nodes",
-  "version": "0.1.0",
+  "name": "@firebase-function-kits/rtdb-limit-child-nodes",
+  "version": "0.0.0",
   "description": "Limit the number of child nodes under a Realtime Database path",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/kits/rtdb-limit-child-nodes/package.json
+++ b/kits/rtdb-limit-child-nodes/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-function-kits/rtdb-limit-child-nodes",
+  "name": "@firebase-functions-kits/rtdb-limit-child-nodes",
   "version": "0.0.0",
   "description": "Limit the number of child nodes under a Realtime Database path",
   "license": "Apache-2.0",

--- a/kits/speech-to-text/CHANGELOG.md
+++ b/kits/speech-to-text/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Initial release

--- a/kits/speech-to-text/package.json
+++ b/kits/speech-to-text/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-functions-kits/speech-to-text",
+  "name": "@firebase-function-kits/speech-to-text",
   "version": "0.0.0",
   "description": "Transcribe audio files in Cloud Storage to text using Cloud Speech-to-Text, as a deployable Firebase Function",
   "license": "Apache-2.0",

--- a/kits/speech-to-text/package.json
+++ b/kits/speech-to-text/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-function-kits/speech-to-text",
+  "name": "@firebase-functions-kits/speech-to-text",
   "version": "0.0.0",
   "description": "Transcribe audio files in Cloud Storage to text using Cloud Speech-to-Text, as a deployable Firebase Function",
   "license": "Apache-2.0",

--- a/kits/speech-to-text/package.json
+++ b/kits/speech-to-text/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@firebase/speech-to-text",
-  "version": "0.1.0",
+  "name": "@firebase-function-kits/speech-to-text",
+  "version": "0.0.0",
   "description": "Transcribe audio files in Cloud Storage to text using Cloud Speech-to-Text, as a deployable Firebase Function",
   "license": "Apache-2.0",
   "main": "lib/index.js",

--- a/kits/storage-resize-images/CHANGELOG.md
+++ b/kits/storage-resize-images/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Initial release

--- a/kits/storage-resize-images/package.json
+++ b/kits/storage-resize-images/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-function-kits/storage-resize-images",
+  "name": "@firebase-functions-kits/storage-resize-images",
   "version": "0.0.0",
   "description": "Resize images uploaded to Cloud Storage",
   "license": "Apache-2.0",

--- a/kits/storage-resize-images/package.json
+++ b/kits/storage-resize-images/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@firebase-functions-kits/storage-resize-images",
+  "name": "@firebase-function-kits/storage-resize-images",
   "version": "0.0.0",
   "description": "Resize images uploaded to Cloud Storage",
   "license": "Apache-2.0",

--- a/kits/storage-resize-images/package.json
+++ b/kits/storage-resize-images/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@firebase/storage-resize-images",
-  "version": "0.1.0",
+  "name": "@firebase-function-kits/storage-resize-images",
+  "version": "0.0.0",
   "description": "Resize images uploaded to Cloud Storage",
   "license": "Apache-2.0",
   "main": "lib/index.js",


### PR DESCRIPTION
Put all packages in a new @firebase-function-kits namespace and resets the version number to 0.0.0, which means the first canary will be 0.0.1-rc.0