### PR TITLE
ci: satisfy zizmor policy in remaining workflows

### DIFF
--- a/.github/workflows/npm_publish_bq_scripts.yml
+++ b/.github/workflows/npm_publish_bq_scripts.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     name: publish_if_newer_version
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
       - name: NPM install

--- a/.github/workflows/readmes-updated.yml
+++ b/.github/workflows/readmes-updated.yml
@@ -17,20 +17,23 @@ concurrency:
 env:
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 22
           cache: "npm"
@@ -44,7 +47,7 @@ jobs:
           echo "::set-output name=dir::$(npm config get prefix)"
 
       - name: Cache global dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.global-deps-setup.outputs.dir }}
           key:
@@ -54,8 +57,10 @@ jobs:
             ${{ runner.os }}-npm-global-deps-v1-
 
       - name: Install Firebase and Lerna
+        env:
+          NPM_GLOBAL_PREFIX: ${{ steps.global-deps-setup.outputs.dir }}
         run: |
-          echo "${{ steps.global-deps-setup.outputs.dir }}/bin" >> $GITHUB_PATH
+          echo "${NPM_GLOBAL_PREFIX}/bin" >> "$GITHUB_PATH"
           npm install -g firebase-tools lerna
 
       - name: Install local dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,15 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: "Create Releases"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
       - name: Release Script
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions:
+  contents: read
+
 jobs:
   nodejs:
     runs-on: ubuntu-latest
@@ -14,9 +17,9 @@ jobs:
         node: ["22"]
     name: node.js_${{ matrix.node }}_test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: ${{ matrix.node }}
           cache: "npm"
@@ -26,7 +29,7 @@ jobs:
       - name: Build emulator functions
         run: cd _emulator/functions && npm i && npm run build & cd ../..
       - name: Install Firebase CLI
-        uses: nick-invision/retry@v1
+        uses: nick-invision/retry@39da88d5f7d15a96aed861dbabbe8b7443e3182a # v1.0.4
         with:
           timeout_minutes: 10
           retry_wait_seconds: 60


### PR DESCRIPTION
The GitHub Actions Scan check runs zizmor over any workflow file a PR touches, and fails on its mandatory rules (`unpinned-uses`, `template-injection`, and five others) as well as on any medium finding. `validate.yml` was brought in line in #2928; this does the same for the other four, so touching them no longer blocks a PR.

- Every action is pinned to the commit its moving tag resolves to today, with the resolved version in a comment. Nothing changes about what actually runs.
- `test.yml` and `readmes-updated.yml` get `contents: read`; `release.yml` gets `contents: write` because `release.sh` creates releases.
- `readmes-updated.yml` passes the npm prefix step output through `env` rather than interpolating it into the `run` body, which is the `template-injection` finding.

Verified locally with zizmor 1.25.2 and the org config the check downloads: no mandatory and no medium findings remain across all five workflows. Six low `artipacked` findings (checkout without `persist-credentials: false`) are left as they are, since the gate allows low.

`validate.yml` stays on the checkout and setup-node pins it already has, v3.6.0 and v3.8.1 against the v3.7.0 and v3.9.1 pinned here, rather than widening the diff.
