### PR TITLE
Fix release kit action

### DIFF
--- a/.github/workflows/release-kit.yaml
+++ b/.github/workflows/release-kit.yaml
@@ -222,7 +222,9 @@ jobs:
 
       - name: Push Version Commit & Tags to Branch
         if: ${{ !inputs.dry_run }}
-        run: git push origin ${{ inputs.target_branch }} --follow-tags
+        env:
+          TARGET_BRANCH: ${{ inputs.target_branch }}
+        run: git push origin "$TARGET_BRANCH" --follow-tags
 
       - name: Publish to NPM
         # zizmor: ignore[use-trusted-publishing]
@@ -258,6 +260,7 @@ jobs:
           VERSION: ${{ steps.versioning.outputs.version }}
           IS_PRERELEASE: ${{ inputs.is_prerelease }}
           NOTES: ${{ steps.changelog.outputs.notes }}
+          TARGET_BRANCH: ${{ inputs.target_branch }}
         run: |
           PRERELEASE_FLAG=""
           if [ "$IS_PRERELEASE" = "true" ]; then
@@ -267,5 +270,5 @@ jobs:
           gh release create "$TAG_NAME" \
             --title "$PKG_NAME v$VERSION" \
             --notes "$NOTES" \
-            --target "${{ inputs.target_branch }}" \
+            --target "$TARGET_BRANCH" \
             $PRERELEASE_FLAG

--- a/.github/workflows/release-kit.yaml
+++ b/.github/workflows/release-kit.yaml
@@ -91,6 +91,7 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://wombat-dressing-room.appspot.com"
+          always-auth: false
 
       - name: Configure Git User
         if: ${{ !inputs.dry_run }}
@@ -151,7 +152,7 @@ jobs:
       - name: Install Dependencies & Build
         working-directory: ${{ inputs.target_kit }}
         run: |
-          npm ci
+          npm ci --registry=https://registry.npmjs.org
           npm run build
 
       - name: Bump Version (Clear CHANGELOG on Stable Release Only)

--- a/.github/workflows/release-kit.yaml
+++ b/.github/workflows/release-kit.yaml
@@ -21,6 +21,11 @@ on:
           - "kits/rtdb-limit-child-nodes"
           - "kits/speech-to-text"
           - "kits/storage-resize-images"
+      target_branch:
+        description: "Branch to release from"
+        required: true
+        default: "kits"
+        type: string
       bump_level:
         description: "Version Bump Level"
         required: true
@@ -52,17 +57,19 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # zizmor: ignore[artipacked]
+        with:
+          ref: ${{ inputs.target_branch }}
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24"
 
-      - name: Install Dependencies
-        run: npm ci
-
-      - name: Run Workspace Tests
-        run: npm test --workspace=${{ inputs.target_kit }}
+      - name: Install Dependencies & Run Tests
+        working-directory: ${{ inputs.target_kit }}
+        run: |
+          npm ci
+          npm test
 
   # =========================================================
   # 2. RELEASE JOB (Elevated Permissions: Write)
@@ -77,7 +84,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # zizmor: ignore[artipacked]
         with:
-          ref: kits
+          ref: ${{ inputs.target_branch }}
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -142,11 +149,10 @@ jobs:
           echo "target_tag=$TARGET_TAG" >> $GITHUB_OUTPUT
 
       - name: Install Dependencies & Build
-        env:
-          TARGET_KIT: ${{ inputs.target_kit }}
+        working-directory: ${{ inputs.target_kit }}
         run: |
           npm ci
-          npm run build --workspace=$TARGET_KIT
+          npm run build
 
       - name: Bump Version (Clear CHANGELOG on Stable Release Only)
         id: versioning
@@ -215,7 +221,7 @@ jobs:
 
       - name: Push Version Commit & Tags to Branch
         if: ${{ !inputs.dry_run }}
-        run: git push origin kits --follow-tags
+        run: git push origin ${{ inputs.target_branch }} --follow-tags
 
       - name: Publish to NPM
         # zizmor: ignore[use-trusted-publishing]
@@ -260,5 +266,5 @@ jobs:
           gh release create "$TAG_NAME" \
             --title "$PKG_NAME v$VERSION" \
             --notes "$NOTES" \
-            --target kits \
+            --target "${{ inputs.target_branch }}" \
             $PRERELEASE_FLAG

--- a/.github/workflows/release-kit.yaml
+++ b/.github/workflows/release-kit.yaml
@@ -21,11 +21,6 @@ on:
           - "kits/rtdb-limit-child-nodes"
           - "kits/speech-to-text"
           - "kits/storage-resize-images"
-      target_branch:
-        description: "Branch to release from"
-        required: true
-        default: "kits"
-        type: string
       bump_level:
         description: "Version Bump Level"
         required: true
@@ -57,8 +52,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # zizmor: ignore[artipacked]
-        with:
-          ref: ${{ inputs.target_branch }}
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -83,8 +76,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # zizmor: ignore[artipacked]
-        with:
-          ref: ${{ inputs.target_branch }}
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -223,8 +214,8 @@ jobs:
       - name: Push Version Commit & Tags to Branch
         if: ${{ !inputs.dry_run }}
         env:
-          TARGET_BRANCH: ${{ inputs.target_branch }}
-        run: git push origin "$TARGET_BRANCH" --follow-tags
+          REF_NAME: ${{ github.ref_name }}
+        run: git push origin "$REF_NAME" --follow-tags
 
       - name: Publish to NPM
         # zizmor: ignore[use-trusted-publishing]
@@ -260,7 +251,7 @@ jobs:
           VERSION: ${{ steps.versioning.outputs.version }}
           IS_PRERELEASE: ${{ inputs.is_prerelease }}
           NOTES: ${{ steps.changelog.outputs.notes }}
-          TARGET_BRANCH: ${{ inputs.target_branch }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           PRERELEASE_FLAG=""
           if [ "$IS_PRERELEASE" = "true" ]; then
@@ -270,5 +261,5 @@ jobs:
           gh release create "$TAG_NAME" \
             --title "$PKG_NAME v$VERSION" \
             --notes "$NOTES" \
-            --target "$TARGET_BRANCH" \
+            --target "$REF_NAME" \
             $PRERELEASE_FLAG


### PR DESCRIPTION
Now that there was a baseline action, I could use the CLI to test my changes, and this worked in dry run.

The original script was designed for a workspace, but this is just a folder of packages. Fixing that also speeds up installs and testing too!

In anticipation of the kits branch merging into next, this also makes the branch from which to release a parameter.