### PR TITLE
Kits should be published from the kits branch

### DIFF
--- a/.github/workflows/release-kit.yaml
+++ b/.github/workflows/release-kit.yaml
@@ -52,6 +52,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # zizmor: ignore[artipacked]
+        with:
+          ref: "kits"
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -76,6 +78,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # zizmor: ignore[artipacked]
+        with:
+          ref: "kits"
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -214,8 +218,8 @@ jobs:
       - name: Push Version Commit & Tags to Branch
         if: ${{ !inputs.dry_run }}
         env:
-          REF_NAME: ${{ github.ref_name }}
-        run: git push origin "$REF_NAME" --follow-tags
+          TARGET_BRANCH: "kits"
+        run: git push origin "$TARGET_BRANCH" --follow-tags
 
       - name: Publish to NPM
         # zizmor: ignore[use-trusted-publishing]
@@ -251,7 +255,7 @@ jobs:
           VERSION: ${{ steps.versioning.outputs.version }}
           IS_PRERELEASE: ${{ inputs.is_prerelease }}
           NOTES: ${{ steps.changelog.outputs.notes }}
-          REF_NAME: ${{ github.ref_name }}
+          TARGET_BRANCH: "kits"
         run: |
           PRERELEASE_FLAG=""
           if [ "$IS_PRERELEASE" = "true" ]; then
@@ -261,5 +265,5 @@ jobs:
           gh release create "$TAG_NAME" \
             --title "$PKG_NAME v$VERSION" \
             --notes "$NOTES" \
-            --target "$REF_NAME" \
+            --target "$TARGET_BRANCH" \
             $PRERELEASE_FLAG


### PR DESCRIPTION
Hardcodes the release kit workflow to always work off the `kits` branch.