### PR TITLE
Update TSConfig to have non-deprecated module resolution

### DIFF
--- a/kits/bigquery-firestore-export/tsconfig.json
+++ b/kits/bigquery-firestore-export/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "target": "ES2022",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/kits/bigquery-firestore-export/tsconfig.json
+++ b/kits/bigquery-firestore-export/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,

--- a/kits/delete-user-data/tsconfig.json
+++ b/kits/delete-user-data/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "target": "ES2022",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/kits/delete-user-data/tsconfig.json
+++ b/kits/delete-user-data/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,

--- a/kits/firestore-bigquery-export/tsconfig.json
+++ b/kits/firestore-bigquery-export/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "target": "ES2022",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/kits/firestore-bigquery-export/tsconfig.json
+++ b/kits/firestore-bigquery-export/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,

--- a/kits/firestore-bundle-builder/tsconfig.json
+++ b/kits/firestore-bundle-builder/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "target": "ES2022",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/kits/firestore-bundle-builder/tsconfig.json
+++ b/kits/firestore-bundle-builder/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,

--- a/kits/firestore-counter/tsconfig.json
+++ b/kits/firestore-counter/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "target": "ES2022",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/kits/firestore-counter/tsconfig.json
+++ b/kits/firestore-counter/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,

--- a/kits/firestore-genai-chatbot/tsconfig.json
+++ b/kits/firestore-genai-chatbot/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "target": "ES2022",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/kits/firestore-genai-chatbot/tsconfig.json
+++ b/kits/firestore-genai-chatbot/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,

--- a/kits/firestore-incremental-capture/tsconfig.json
+++ b/kits/firestore-incremental-capture/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "target": "ES2022",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/kits/firestore-incremental-capture/tsconfig.json
+++ b/kits/firestore-incremental-capture/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,

--- a/kits/firestore-send-email/tsconfig.json
+++ b/kits/firestore-send-email/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "target": "ES2022",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/kits/firestore-send-email/tsconfig.json
+++ b/kits/firestore-send-email/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,

--- a/kits/firestore-translate-text/tsconfig.json
+++ b/kits/firestore-translate-text/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "target": "ES2022",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/kits/firestore-translate-text/tsconfig.json
+++ b/kits/firestore-translate-text/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,

--- a/kits/firestore-vector-search/tsconfig.json
+++ b/kits/firestore-vector-search/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "target": "ES2022",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/kits/firestore-vector-search/tsconfig.json
+++ b/kits/firestore-vector-search/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,

--- a/kits/rtdb-limit-child-nodes/tsconfig.json
+++ b/kits/rtdb-limit-child-nodes/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "target": "ES2022",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/kits/rtdb-limit-child-nodes/tsconfig.json
+++ b/kits/rtdb-limit-child-nodes/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,

--- a/kits/speech-to-text/tsconfig.json
+++ b/kits/speech-to-text/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "target": "ES2022",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/kits/speech-to-text/tsconfig.json
+++ b/kits/speech-to-text/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,

--- a/kits/storage-resize-images/tsconfig.json
+++ b/kits/storage-resize-images/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "target": "ES2022",
     "module": "commonjs",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/kits/storage-resize-images/tsconfig.json
+++ b/kits/storage-resize-images/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "target": "ES2022",
-    "module": "commonjs",
+    "module": "nodenext",
     "moduleResolution": "nodenext",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
Updates tsconfig.json files in subdirectories of kits to use moduleResolution: nodenext.