### PR TITLE
fix(delete-user-data): resolve the RTDB client on first use

### DIFF
--- a/kits/delete-user-data/src/index.ts
+++ b/kits/delete-user-data/src/index.ts
@@ -74,7 +74,11 @@ function getContext(): HandlerContext {
   ctx = {
     firestore: getFirestore(resolved.firestoreDatabaseId),
     storage: admin.storage(),
-    database: admin.database(),
+    // Resolved on first use. Without a configured RTDB instance there is no
+    // databaseURL to initialize the app with, and admin.database() throws.
+    get database() {
+      return admin.database();
+    },
     pubsub: new PubSub({ projectId: resolved.projectId }),
     config: resolved,
   };

--- a/kits/delete-user-data/tests/context.test.ts
+++ b/kits/delete-user-data/tests/context.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 
 // Stands in for a project with no Realtime Database URL available, which is what
 // an empty SELECTED_DATABASE_INSTANCE leaves behind.
@@ -56,6 +56,10 @@ function deletionEvent(uid: string) {
 }
 
 describe("handler context", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   test("builds without resolving the RTDB client", () => {
     expect(() => clearData(deletionEvent("uid-1"))).not.toThrow();
 
@@ -64,7 +68,9 @@ describe("handler context", () => {
   });
 
   test("resolves the RTDB client when the deletion path reads it", () => {
-    const [, ctx] = vi.mocked(handleClear).mock.calls[0] as [
+    clearData(deletionEvent("uid-2"));
+
+    const [, ctx] = vi.mocked(handleClear).mock.lastCall as [
       string,
       HandlerContext
     ];

--- a/kits/delete-user-data/tests/context.test.ts
+++ b/kits/delete-user-data/tests/context.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+
+// Stands in for a project with no Realtime Database URL available, which is what
+// an empty SELECTED_DATABASE_INSTANCE leaves behind.
+const NO_DATABASE_URL = "Can't determine Firebase Database URL.";
+
+vi.mock("../src/logs");
+vi.mock("../src/handlers", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../src/handlers")>()),
+  handleClear: vi.fn(),
+}));
+vi.mock("@google-cloud/pubsub", () => ({ PubSub: vi.fn() }));
+vi.mock("firebase-admin/firestore", () => ({
+  getFirestore: vi.fn(() => ({})),
+}));
+vi.mock("firebase-admin", () => ({
+  apps: [],
+  credential: { applicationDefault: vi.fn() },
+  initializeApp: vi.fn(),
+  storage: vi.fn(() => ({})),
+  database: vi.fn(() => {
+    throw new Error(NO_DATABASE_URL);
+  }),
+}));
+
+import * as admin from "firebase-admin";
+import type { HandlerContext } from "../src/handlers";
+import { handleClear } from "../src/handlers";
+import { clearData } from "../src/index";
+
+function deletionEvent(uid: string) {
+  return {
+    specversion: "1.0",
+    id: "event-id",
+    type: "google.firebase.auth.user.v2.deleted",
+    source: "//identitytoolkit.googleapis.com/projects/test-project",
+    time: "2026-01-01T00:00:00.000Z",
+    data: { uid },
+  } as any;
+}
+
+describe("handler context", () => {
+  test("builds without resolving the RTDB client", () => {
+    expect(() => clearData(deletionEvent("uid-1"))).not.toThrow();
+
+    expect(handleClear).toHaveBeenCalledOnce();
+    expect(admin.database).not.toHaveBeenCalled();
+  });
+
+  test("resolves the RTDB client when the deletion path reads it", () => {
+    const [, ctx] = vi.mocked(handleClear).mock.calls[0] as [
+      string,
+      HandlerContext
+    ];
+
+    expect(() => ctx.database).toThrow(NO_DATABASE_URL);
+    expect(admin.database).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What was broken

`getContext` built `ctx.database` with an eager `admin.database()`. With no RTDB instance configured there is no `databaseURL` to initialize the app with, so the call threw `Can't determine Firebase Database URL` before any deletion work, on every invocation of `clearData`, `handleSearch` and `handleDeletion`. A Firestore-only configuration deleted nothing.

Explicit `initializeApp` options also suppress the `FIREBASE_CONFIG` fallback, so the project's default database URL is never picked up.

## What changed

`ctx.database` becomes a getter resolved on first use, matching where the extension calls it. `tests/context.test.ts` asserts the context builds without touching the RTDB client, and that the getter still resolves it when the deletion path reads it.

## Verification

Unit suite 89 passing, `tsc -b` clean, and reverting the getter fails both new tests.

The crash was reproduced on a live 2nd gen deploy of `0.0.2-rc.2`: all three functions threw at `lib/index.js:97` and deleted nothing. The fix was verified against the same project by driving the real `getContext`, not by redeploying.

## For the reviewer

This stops the crash. It does not settle what RTDB should do with no instance configured: skip it as in #2988, or fall back to the project default as the README promises. The two need to agree.
