### PR TITLE
fix(firestore-genai-chatbot): stop importing a non-exported subpath

### DIFF
--- a/kits/firestore-genai-chatbot/src/generative-client/genkit.ts
+++ b/kits/firestore-genai-chatbot/src/generative-client/genkit.ts
@@ -20,7 +20,6 @@ import {
   googleAI,
   vertexAI,
 } from "@genkit-ai/google-genai";
-import type { VertexPluginOptions } from "@genkit-ai/google-genai/lib/vertexai";
 import {
   type MessageData as ApiMessage,
   type GenerateOptions,
@@ -37,6 +36,9 @@ import {
   DiscussionClient,
   type Message,
 } from "./base_class";
+
+// @genkit-ai/google-genai does not re-export this type from its package root.
+type VertexPluginOptions = NonNullable<Parameters<typeof vertexAI>[0]>;
 
 genkitLogger.setLogLevel("info");
 


### PR DESCRIPTION
The `node.js_22_test` job fails for every PR targeting `kits`. The repo-wide build runs in postinstall, so one kit failing to compile kills the job regardless of what the PR touches:

```
kits/firestore-genai-chatbot/src/generative-client/genkit.ts(23,42): error TS2307:
Cannot find module '@genkit-ai/google-genai/lib/vertexai' or its corresponding type declarations.
```

`@genkit-ai/google-genai` only declares `"."` in its `exports` map. The old `node` resolution ignored `exports`, so the deep `lib/vertexai` import resolved; `nodenext` honours it, so the subpath no longer resolves. The package does not re-export `VertexPluginOptions` from its root, so this derives the type from the exported `vertexAI` plugin instead.

Verified: `tsc -b --force` on the kit goes from the error above to clean, 21 tests pass, and `prettier --check` is clean on the changed file.