### PR TITLE
fix(bq-scripts): use full git URL in repository.url

### DIFF
--- a/firestore-bigquery-export/scripts/gen-schema-view/package.json
+++ b/firestore-bigquery-export/scripts/gen-schema-view/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "repository": {
     "type": "git",
-    "url": "github.com/firebase/extensions.git",
+    "url": "git+https://github.com/firebase/extensions.git",
     "directory": "firestore-bigquery-export/scripts/gen-schema-view"
   },
   "scripts": {

--- a/firestore-bigquery-export/scripts/import/package.json
+++ b/firestore-bigquery-export/scripts/import/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "repository": {
     "type": "git",
-    "url": "github.com/firebase/extensions.git",
+    "url": "git+https://github.com/firebase/extensions.git",
     "directory": "firestore-bigquery-export/scripts/import"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

`npm publish --provenance` requires `repository.url` to resolve to the GitHub repo that built the package. Two BigQuery script packages declared a bare `github.com/firebase/extensions.git` — no scheme, so npm can't normalise it and provenance fails.

Prefixed both with `git+https://`, matching `firestore-bigquery-change-tracker`, which already publishes fine:

- `@firebaseextensions/fs-bq-schema-views`
- `@firebaseextensions/fs-bq-import-collection`

Broken since `--provenance` was added in March 2026. No other `package.json` on `next` is affected.
