### PR TITLE
Add missing node types dev dependency to firestore-incremental-capture

### DIFF
--- a/kits/firestore-incremental-capture/npm-shrinkwrap.json
+++ b/kits/firestore-incremental-capture/npm-shrinkwrap.json
@@ -8,9 +8,29 @@
       "name": "@firebase-function-kits/firestore-incremental-capture",
       "version": "0.0.1",
       "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^26.2.0"
+      },
       "engines": {
         "node": ">=22"
       }
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/kits/firestore-incremental-capture/package.json
+++ b/kits/firestore-incremental-capture/package.json
@@ -28,5 +28,8 @@
     "build": "tsc -b",
     "clean": "tsc -b --clean",
     "test": "echo \"Warning: tests are not implemented for this package\""
+  },
+  "devDependencies": {
+    "@types/node": "^26.2.0"
   }
 }


### PR DESCRIPTION
I know the package is totally empty still, but at least now it'll publish. The tsconfig.json was adding a package dependency that wasn't fulfilled.