### PR TITLE
fix(kits): restore extension param validation regexes

### DIFF
--- a/kits/bigquery-firestore-export/src/config.ts
+++ b/kits/bigquery-firestore-export/src/config.ts
@@ -43,6 +43,12 @@ const params = {
   schedule: defineString("SCHEDULE"),
   firestoreCollection: defineString("COLLECTION_PATH", {
     default: "transferConfigs",
+    input: {
+      text: {
+        validationRegex: /^[^\/]+(\/[^\/]+\/[^\/]+)*$/,
+        validationErrorMessage: "Must be a valid Cloud Firestore Collection",
+      },
+    },
   }),
   logLevel: defineString("LOG_LEVEL", {
     default: "info",

--- a/kits/delete-user-data/src/config.ts
+++ b/kits/delete-user-data/src/config.ts
@@ -37,7 +37,17 @@ const params = {
     default: "shallow",
     input: select(["recursive", "shallow"]),
   }),
-  rtdbInstance: defineString("SELECTED_DATABASE_INSTANCE", { default: "" }),
+  rtdbInstance: defineString("SELECTED_DATABASE_INSTANCE", {
+    default: "",
+    input: {
+      text: {
+        // Extension regex, with an empty branch added: the param is optional.
+        validationRegex: /^(?:[^\.\$\#\]\[\/\x00-\x1F\x7F]+|)$/,
+        validationErrorMessage:
+          "Invalid database instance. Make sure that you have entered just the instance ID, and not the entire database URL.",
+      },
+    },
+  }),
   rtdbLocation: defineString("SELECTED_DATABASE_LOCATION", {
     default: "us-central1",
     input: select(["us-central1", "europe-west1", "asia-southeast1"]),
@@ -45,6 +55,12 @@ const params = {
   rtdbPaths: defineString("RTDB_PATHS", { default: "" }),
   storageBucket: defineString("CLOUD_STORAGE_BUCKET", {
     default: storageBucket,
+    input: {
+      text: {
+        validationRegex: /^([0-9a-z_.-]*)$/,
+        validationErrorMessage: "Invalid storage bucket",
+      },
+    },
   }),
   storagePaths: defineString("STORAGE_PATHS", { default: "" }),
   enableAutoDiscovery: defineBoolean("ENABLE_AUTO_DISCOVERY", {

--- a/kits/firestore-bigquery-export/src/config.ts
+++ b/kits/firestore-bigquery-export/src/config.ts
@@ -166,9 +166,36 @@ const params = {
   databaseRegion: defineString("DATABASE_REGION", {
     input: select([...DATABASE_REGION_OPTIONS]),
   }),
-  collectionPath: defineString("COLLECTION_PATH", { default: "posts" }),
-  datasetId: defineString("DATASET_ID", { default: "firestore_export" }),
-  tableId: defineString("TABLE_ID", { default: "posts" }),
+  collectionPath: defineString("COLLECTION_PATH", {
+    default: "posts",
+    input: {
+      text: {
+        validationRegex: /^[^\/]+(\/[^\/]+\/[^\/]+)*$/,
+        validationErrorMessage:
+          'Firestore collection paths must be an odd number of segments separated by slashes, e.g. "path/to/collection".',
+      },
+    },
+  }),
+  datasetId: defineString("DATASET_ID", {
+    default: "firestore_export",
+    input: {
+      text: {
+        validationRegex: /^[a-zA-Z0-9_]+$/,
+        validationErrorMessage:
+          "BigQuery dataset IDs must be alphanumeric (plus underscores) and must be no more than 1024 characters.",
+      },
+    },
+  }),
+  tableId: defineString("TABLE_ID", {
+    default: "posts",
+    input: {
+      text: {
+        validationRegex: /^[a-zA-Z0-9_]+$/,
+        validationErrorMessage:
+          "BigQuery table IDs must be alphanumeric (plus underscores) and must be no more than 1024 characters.",
+      },
+    },
+  }),
   datasetLocation: defineString("DATASET_LOCATION", {
     default: "us",
     input: select([...DATASET_LOCATION_OPTIONS]),
@@ -190,7 +217,17 @@ const params = {
     "TIME_PARTITIONING_FIRESTORE_FIELD",
     { default: "" }
   ),
-  clustering: defineString("CLUSTERING", { default: "" }),
+  clustering: defineString("CLUSTERING", {
+    default: "",
+    input: {
+      text: {
+        // Extension regex, with an empty branch added: the param is optional.
+        validationRegex: /^(?:[^,\s]+(?:,[^,\s]+){0,3}|)$/,
+        validationErrorMessage:
+          "No whitespaces. Max 4 fields. e.g. `data,timestamp,event_id,operation`",
+      },
+    },
+  }),
   wildcardIds: defineBoolean("WILDCARD_IDS", {
     default: false,
   }),
@@ -207,8 +244,27 @@ const params = {
   maxStaleness: defineString("MAX_STALENESS", { default: "" }),
   refreshIntervalMinutes: defineString("REFRESH_INTERVAL_MINUTES", {
     default: "",
+    input: {
+      text: {
+        // Extension regex, with an empty branch added: the param is optional.
+        validationRegex: /^(?:[1-9][0-9]*|)$/,
+        validationErrorMessage: "Must be a positive integer",
+      },
+    },
   }),
-  kmsKeyName: defineString("KMS_KEY_NAME", { default: "" }),
+  kmsKeyName: defineString("KMS_KEY_NAME", {
+    default: "",
+    input: {
+      text: {
+        // Extension regex (unanchored, as upstream), with an empty branch
+        // added: the param is optional.
+        validationRegex:
+          /projects\/([^\/]+)\/locations\/([^\/]+)\/keyRings\/([^\/]+)\/cryptoKeys\/([^\/]+)|^$/,
+        validationErrorMessage:
+          "The key name must be of the format 'projects/PROJECT_NAME/locations/KEY_RING_LOCATION/keyRings/KEY_RING_ID/cryptoKeys/KEY_ID'.",
+      },
+    },
+  }),
   logLevel: defineString("LOG_LEVEL", {
     default: "info",
     input: select([...LOG_LEVEL_OPTIONS]),

--- a/kits/firestore-counter/src/config.ts
+++ b/kits/firestore-counter/src/config.ts
@@ -32,7 +32,7 @@ const params = {
       text: {
         validationRegex: /^[^\/]+\/[^\/]+(\/[^\/]+\/[^\/]+)*$/,
         validationErrorMessage:
-          "Enter a document path, not a collection path. The path must have an even number of segments.",
+          "Enter a document path, not a collection path. The path must have an even number of segments, for example, `my_collection/doc` or `my_collection/doc/subcollection/doc`, but not `my_collection`.",
       },
     },
   }),

--- a/kits/firestore-counter/src/config.ts
+++ b/kits/firestore-counter/src/config.ts
@@ -28,9 +28,23 @@ export interface ConfigExpressions {
 const params = {
   internalStatePath: defineString("INTERNAL_STATE_PATH", {
     default: "_firebase_ext_/sharded_counter",
+    input: {
+      text: {
+        validationRegex: /^[^\/]+\/[^\/]+(\/[^\/]+\/[^\/]+)*$/,
+        validationErrorMessage:
+          "Enter a document path, not a collection path. The path must have an even number of segments.",
+      },
+    },
   }),
   scheduleFrequencyMinutes: defineString("SCHEDULE_FREQUENCY", {
     default: "1",
+    input: {
+      text: {
+        validationRegex: /^[1-9][0-9]*$/,
+        validationErrorMessage:
+          "The number of minutes must be an integer value greater than zero.",
+      },
+    },
   }),
 };
 

--- a/kits/firestore-counter/tests/config.test.ts
+++ b/kits/firestore-counter/tests/config.test.ts
@@ -38,7 +38,7 @@ class FakeStringParam extends FakeExpression<string> {
 }
 
 const defineString = vi.fn(
-  (name: string, opts?: { default?: string }) =>
+  (name: string, opts?: { default?: string; input?: unknown }) =>
     new FakeStringParam(name, opts?.default)
 );
 
@@ -81,12 +81,28 @@ describe("configFromEnv", () => {
     });
     expect(defineString.mock.calls).toContainEqual([
       "INTERNAL_STATE_PATH",
-      { default: "_firebase_ext_/sharded_counter" },
+      expect.objectContaining({ default: "_firebase_ext_/sharded_counter" }),
     ]);
     expect(defineString.mock.calls).toContainEqual([
       "SCHEDULE_FREQUENCY",
-      { default: "1" },
+      expect.objectContaining({ default: "1" }),
     ]);
+  });
+
+  test("restores the extension's validation regexes", async () => {
+    await importConfig();
+
+    const options = new Map(
+      defineString.mock.calls.map(([name, opts]) => [name, opts])
+    );
+    expect(options.get("INTERNAL_STATE_PATH")).toMatchObject({
+      input: {
+        text: { validationRegex: /^[^\/]+\/[^\/]+(\/[^\/]+\/[^\/]+)*$/ },
+      },
+    });
+    expect(options.get("SCHEDULE_FREQUENCY")).toMatchObject({
+      input: { text: { validationRegex: /^[1-9][0-9]*$/ } },
+    });
   });
 
   test("coerces the schedule frequency to a number", async () => {

--- a/kits/firestore-genai-chatbot/src/config.ts
+++ b/kits/firestore-genai-chatbot/src/config.ts
@@ -87,12 +87,12 @@ const ZERO_TO_ONE_VALIDATION = {
   },
 };
 
-// The extension regex was unanchored (^[1-9][0-9]*), so trailing junk like
-// "5abc" passed validation. Anchor it, and allow empty: the params are
+// Extension regex, kept unanchored for strict parity (trailing junk like
+// "5abc" passes, as upstream), with an empty branch added: the params are
 // optional.
 const POSITIVE_INT_VALIDATION = {
   text: {
-    validationRegex: /^(?:[1-9][0-9]*|)$/,
+    validationRegex: /^[1-9][0-9]*|^$/,
     validationErrorMessage: "Please specify a positive integer.",
   },
 };

--- a/kits/firestore-genai-chatbot/src/config.ts
+++ b/kits/firestore-genai-chatbot/src/config.ts
@@ -78,6 +78,25 @@ const SAFETY_THRESHOLD_OPTIONS = [
  *
  * @see https://firebase.google.com/docs/functions/config-env
  */
+
+const ZERO_TO_ONE_VALIDATION = {
+  text: {
+    validationRegex: /^(?:0*(?:\.\d+)?|1(\.0*)?)$/,
+    validationErrorMessage:
+      "Please specify a decimal representation of a number between 0 and 1.",
+  },
+};
+
+// The extension regex was unanchored (^[1-9][0-9]*), so trailing junk like
+// "5abc" passed validation. Anchor it, and allow empty: the params are
+// optional.
+const POSITIVE_INT_VALIDATION = {
+  text: {
+    validationRegex: /^(?:[1-9][0-9]*|)$/,
+    validationErrorMessage: "Please specify a positive integer.",
+  },
+};
+
 const params = {
   provider: defineString("GENERATIVE_AI_PROVIDER", {
     default: "google-ai",
@@ -89,7 +108,15 @@ const params = {
     default: "null",
     input: select([...VERTEX_MODEL_LOCATION_OPTIONS]),
   }),
-  collectionName: defineString("COLLECTION_NAME", { default: "generate" }),
+  collectionName: defineString("COLLECTION_NAME", {
+    default: "generate",
+    input: {
+      text: {
+        validationRegex: /^[^\/]+(\/[^\/]+\/[^\/]+)*$/,
+        validationErrorMessage: "Must be a valid Cloud Firestore Collection",
+      },
+    },
+  }),
   promptField: defineString("PROMPT_FIELD", { default: "prompt" }),
   responseField: defineString("RESPONSE_FIELD", { default: "response" }),
   orderField: defineString("ORDER_FIELD", { default: "createTime" }),
@@ -97,11 +124,26 @@ const params = {
     default: "candidates",
   }),
   context: defineString("CONTEXT", { default: "" }),
-  temperature: defineString("TEMPERATURE", { default: "" }),
-  topP: defineString("TOP_P", { default: "" }),
-  topK: defineString("TOP_K", { default: "" }),
-  candidateCount: defineString("CANDIDATE_COUNT", { default: "1" }),
-  maxOutputTokens: defineString("MAX_OUTPUT_TOKENS", { default: "" }),
+  temperature: defineString("TEMPERATURE", {
+    default: "",
+    input: ZERO_TO_ONE_VALIDATION,
+  }),
+  topP: defineString("TOP_P", {
+    default: "",
+    input: ZERO_TO_ONE_VALIDATION,
+  }),
+  topK: defineString("TOP_K", {
+    default: "",
+    input: POSITIVE_INT_VALIDATION,
+  }),
+  candidateCount: defineString("CANDIDATE_COUNT", {
+    default: "1",
+    input: POSITIVE_INT_VALIDATION,
+  }),
+  maxOutputTokens: defineString("MAX_OUTPUT_TOKENS", {
+    default: "",
+    input: POSITIVE_INT_VALIDATION,
+  }),
   enableOverrides: defineBoolean("ENABLE_DISCUSSION_OPTION_OVERRIDES", {
     default: false,
   }),

--- a/kits/firestore-send-email/src/config.ts
+++ b/kits/firestore-send-email/src/config.ts
@@ -104,7 +104,7 @@ const params = {
         validationRegex:
           /^(smtp[s]*:\/\/(.*?(:[^:@]*)?@)?[^:@]+:[0-9]+(\?[^ ]*)?)|^$/,
         validationErrorMessage:
-          "Invalid SMTP connection URI. Must be in the form `smtp(s)://username:password@hostname:port` or `smtp(s)://username@hostname:port`.",
+          "Invalid SMTP connection URI. Must be in the form `smtp(s)://username:password@hostname:port` or `smtp(s)://username@hostname:port` or to be left blank.",
       },
     },
   }),

--- a/kits/firestore-send-email/src/config.ts
+++ b/kits/firestore-send-email/src/config.ts
@@ -97,7 +97,17 @@ const params = {
       AuthenticatonType.OAuth2,
     ]),
   }),
-  smtpConnectionUri: defineString("SMTP_CONNECTION_URI", { default: "" }),
+  smtpConnectionUri: defineString("SMTP_CONNECTION_URI", {
+    default: "",
+    input: {
+      text: {
+        validationRegex:
+          /^(smtp[s]*:\/\/(.*?(:[^:@]*)?@)?[^:@]+:[0-9]+(\?[^ ]*)?)|^$/,
+        validationErrorMessage:
+          "Invalid SMTP connection URI. Must be in the form `smtp(s)://username:password@hostname:port` or `smtp(s)://username@hostname:port`.",
+      },
+    },
+  }),
   smtpPassword: defineSecret("SMTP_PASSWORD"),
   host: defineString("HOST", { default: "" }),
   oauthPort: defineInt("OAUTH_PORT", { default: 465 }),
@@ -108,8 +118,25 @@ const params = {
   clientSecret: defineSecret("CLIENT_SECRET"),
   refreshToken: defineSecret("REFRESH_TOKEN"),
   user: defineString("USER", { default: "" }),
-  mailCollection: defineString("MAIL_COLLECTION", { default: "mail" }),
-  defaultFrom: defineString("DEFAULT_FROM"),
+  mailCollection: defineString("MAIL_COLLECTION", {
+    default: "mail",
+    input: {
+      text: {
+        validationRegex: /^[^\/]+(\/[^\/]+\/[^\/]+)*$/,
+        validationErrorMessage: "Must be a valid Cloud Firestore collection",
+      },
+    },
+  }),
+  defaultFrom: defineString("DEFAULT_FROM", {
+    input: {
+      text: {
+        validationRegex:
+          /^(([^<>()\[\]\.,;:\s@"]+(\.[^<>()\[\]\.,;:\s@"]+)*)|(".+"))@(([^<>()[\]\.,;:\s@"]+\.)+[^<>()[\]\.,;:\s@"]{2,})$|^.*<(([^<>()\[\]\.,;:\s@"]+(\.[^<>()\[\]\.,;:\s@"]+)*)|(".+"))@(([^<>()[\]\.,;:\s@"]+\.)+[^<>()[\]\.,;:\s@"]{2,})>$/,
+        validationErrorMessage:
+          "Must be a valid email address or valid name plus email address",
+      },
+    },
+  }),
   defaultReplyTo: defineString("DEFAULT_REPLY_TO", { default: "" }),
   usersCollection: defineString("USERS_COLLECTION", { default: "" }),
   templatesCollection: defineString("TEMPLATES_COLLECTION", { default: "" }),
@@ -117,7 +144,16 @@ const params = {
     default: "never",
     input: select([...TTL_EXPIRE_TYPE_OPTIONS]),
   }),
-  ttlExpireValue: defineInt("TTL_EXPIRE_VALUE", { default: 1 }),
+  ttlExpireValue: defineInt("TTL_EXPIRE_VALUE", {
+    default: 1,
+    input: {
+      text: {
+        validationRegex: /^[1-9][0-9]*$/,
+        validationErrorMessage:
+          "The value must be an integer value greater than zero.",
+      },
+    },
+  }),
   tlsOptions: defineString("TLS_OPTIONS", { default: "{}" }),
 };
 

--- a/kits/firestore-translate-text/src/config.ts
+++ b/kits/firestore-translate-text/src/config.ts
@@ -43,10 +43,27 @@ const GEMINI_MODEL_OPTIONS = [
 ] as const;
 
 const params = {
-  collectionPath: defineString("COLLECTION_PATH", { default: "translations" }),
+  collectionPath: defineString("COLLECTION_PATH", {
+    default: "translations",
+    input: {
+      text: {
+        validationRegex: /^[^\/]+(\/[^\/]+\/[^\/]+)*$/,
+        validationErrorMessage: "Must be a valid Cloud Firestore Collection",
+      },
+    },
+  }),
   inputFieldName: defineString("INPUT_FIELD_NAME", { default: "input" }),
   outputFieldName: defineString("OUTPUT_FIELD_NAME", { default: "translated" }),
-  languages: defineString("LANGUAGES", { default: "en,es,de,fr" }),
+  languages: defineString("LANGUAGES", {
+    default: "en,es,de,fr",
+    input: {
+      text: {
+        validationRegex: /^[a-zA-Z,-]*[a-zA-Z-]{2,}$/,
+        validationErrorMessage:
+          "Languages must be a comma-separated list of ISO-639-1 language codes.",
+      },
+    },
+  }),
   languagesFieldName: defineString("LANGUAGES_FIELD_NAME", {
     default: "languages",
   }),

--- a/kits/firestore-translate-text/tests/config.test.ts
+++ b/kits/firestore-translate-text/tests/config.test.ts
@@ -168,7 +168,7 @@ describe("configFromEnv", () => {
 
     expect(defineString.mock.calls).toContainEqual([
       "COLLECTION_PATH",
-      { default: "translations" },
+      expect.objectContaining({ default: "translations" }),
     ]);
     expect(defineString.mock.calls).toContainEqual([
       "INPUT_FIELD_NAME",
@@ -180,12 +180,26 @@ describe("configFromEnv", () => {
     ]);
     expect(defineString.mock.calls).toContainEqual([
       "LANGUAGES",
-      { default: "en,es,de,fr" },
+      expect.objectContaining({ default: "en,es,de,fr" }),
     ]);
     expect(defineString.mock.calls).toContainEqual([
       "LANGUAGES_FIELD_NAME",
       { default: "languages" },
     ]);
+  });
+
+  test("restores the extension's validation regexes", async () => {
+    await importConfig();
+
+    const options = new Map(
+      defineString.mock.calls.map(([name, opts]) => [name, opts])
+    );
+    expect(options.get("LANGUAGES")).toMatchObject({
+      input: { text: { validationRegex: /^[a-zA-Z,-]*[a-zA-Z-]{2,}$/ } },
+    });
+    expect(options.get("COLLECTION_PATH")).toMatchObject({
+      input: { text: { validationRegex: /^[^\/]+(\/[^\/]+\/[^\/]+)*$/ } },
+    });
   });
 
   test("offers the supported providers and gemini models as a select", async () => {

--- a/kits/firestore-translate-text/tests/index.test.ts
+++ b/kits/firestore-translate-text/tests/index.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { TranslateConfig } from "../src/export-config";
 import { resolveTranslateConfig } from "../src/export-config";
@@ -97,6 +97,14 @@ async function importIndex(config: TranslateConfig = baseConfig) {
 }
 
 describe("index", () => {
+  // Importing `../src/index` pulls in genkit and `@google-cloud/translate`, and
+  // every test re-imports it after `vi.resetModules()`. Warm the module graph
+  // once here so the first test does not race the default test timeout while
+  // paying the cold load cost.
+  beforeAll(async () => {
+    await importIndex();
+  }, 60_000);
+
   beforeEach(() => {
     vi.clearAllMocks();
     getApp.mockImplementation(() => {

--- a/kits/firestore-vector-search/src/config.ts
+++ b/kits/firestore-vector-search/src/config.ts
@@ -74,14 +74,14 @@ const params = {
       },
     },
   }),
-  // The extension's error message here was a copy-paste mistake ("Must be a
-  // valid Cloud Firestore Collection"); its regex was also unanchored.
+  // Extension regex and error message, kept verbatim for strict parity: the
+  // regex is unanchored and the message is upstream's copy-paste mistake.
   defaultQueryLimit: defineInt("DEFAULT_QUERY_LIMIT", {
     default: 3,
     input: {
       text: {
-        validationRegex: /^[1-9][0-9]*$/,
-        validationErrorMessage: "Must be a positive integer.",
+        validationRegex: /^[1-9][0-9]*/,
+        validationErrorMessage: "Must be a valid Cloud Firestore Collection",
       },
     },
   }),

--- a/kits/firestore-vector-search/src/config.ts
+++ b/kits/firestore-vector-search/src/config.ts
@@ -65,8 +65,26 @@ const params = {
   customEmbeddingsDimension: defineString("CUSTOM_EMBEDDINGS_DIMENSION", {
     default: "",
   }),
-  collectionPath: defineString("COLLECTION_NAME", { default: "products" }),
-  defaultQueryLimit: defineInt("DEFAULT_QUERY_LIMIT", { default: 3 }),
+  collectionPath: defineString("COLLECTION_NAME", {
+    default: "products",
+    input: {
+      text: {
+        validationRegex: /^[^\/]+(\/[^\/]+\/[^\/]+)*$/,
+        validationErrorMessage: "Must be a valid Cloud Firestore Collection",
+      },
+    },
+  }),
+  // The extension's error message here was a copy-paste mistake ("Must be a
+  // valid Cloud Firestore Collection"); its regex was also unanchored.
+  defaultQueryLimit: defineInt("DEFAULT_QUERY_LIMIT", {
+    default: 3,
+    input: {
+      text: {
+        validationRegex: /^[1-9][0-9]*$/,
+        validationErrorMessage: "Must be a positive integer.",
+      },
+    },
+  }),
   distanceMeasure: defineString("DISTANCE_MEASURE", {
     default: "COSINE",
     input: select([...DISTANCE_MEASURE_OPTIONS]),

--- a/kits/rtdb-limit-child-nodes/src/config.ts
+++ b/kits/rtdb-limit-child-nodes/src/config.ts
@@ -51,13 +51,13 @@ const params = {
       },
     },
   }),
-  // The extension regex was ^\d+$, which accepted 0 -- and a MAX_COUNT of 0
-  // deletes every child on every write. Require a positive integer instead,
-  // matching what resolveRtdbLimitConfig enforces at runtime.
+  // Extension regex, kept verbatim for strict parity. It accepts 0 even
+  // though a MAX_COUNT of 0 would delete every child on every write;
+  // resolveRtdbLimitConfig still rejects non-positive values at runtime.
   maxCount: defineInt("MAX_COUNT", {
     input: {
       text: {
-        validationRegex: /^[1-9][0-9]*$/,
+        validationRegex: /^\d+$/,
         validationErrorMessage:
           "Invalid MAX_COUNT, must be a positive integer.",
       },

--- a/kits/rtdb-limit-child-nodes/src/config.ts
+++ b/kits/rtdb-limit-child-nodes/src/config.ts
@@ -33,16 +33,44 @@ function defaultDatabaseInstance(): string | undefined {
 
 const databaseInstanceDefault = defaultDatabaseInstance();
 
+const DATABASE_INSTANCE_VALIDATION = {
+  text: {
+    validationRegex: /^([0-9a-z_.-]*)$/,
+    validationErrorMessage: "Invalid database instance",
+  },
+};
+
 const params = {
   // Do not use NODE_PATH: Node.js reserves it for module resolution and will
   // overwrite the param at runtime (and can freeze a bad ref at deploy).
-  nodePath: defineString("RTDB_NODE_PATH"),
-  maxCount: defineInt("MAX_COUNT"),
+  nodePath: defineString("RTDB_NODE_PATH", {
+    input: {
+      text: {
+        validationRegex: /^\S+$/,
+        validationErrorMessage: "Path cannot have spaces.",
+      },
+    },
+  }),
+  // The extension regex was ^\d+$, which accepted 0 -- and a MAX_COUNT of 0
+  // deletes every child on every write. Require a positive integer instead,
+  // matching what resolveRtdbLimitConfig enforces at runtime.
+  maxCount: defineInt("MAX_COUNT", {
+    input: {
+      text: {
+        validationRegex: /^[1-9][0-9]*$/,
+        validationErrorMessage:
+          "Invalid MAX_COUNT, must be a positive integer.",
+      },
+    },
+  }),
   databaseInstance: databaseInstanceDefault
     ? defineString("SELECTED_DATABASE_INSTANCE", {
         default: databaseInstanceDefault,
+        input: DATABASE_INSTANCE_VALIDATION,
       })
-    : defineString("SELECTED_DATABASE_INSTANCE"),
+    : defineString("SELECTED_DATABASE_INSTANCE", {
+        input: DATABASE_INSTANCE_VALIDATION,
+      }),
 };
 
 export function configFromEnv(): RtdbLimitConfig {

--- a/kits/rtdb-limit-child-nodes/src/config.ts
+++ b/kits/rtdb-limit-child-nodes/src/config.ts
@@ -36,8 +36,8 @@ const databaseInstanceDefault = defaultDatabaseInstance();
 const params = {
   // Do not use NODE_PATH: Node.js reserves it for module resolution and will
   // overwrite the param at runtime (and can freeze a bad ref at deploy).
-  nodePath: defineString("RTDB_NODE_PATH", { default: "messages" }),
-  maxCount: defineInt("MAX_COUNT", { default: 100 }),
+  nodePath: defineString("RTDB_NODE_PATH"),
+  maxCount: defineInt("MAX_COUNT"),
   databaseInstance: databaseInstanceDefault
     ? defineString("SELECTED_DATABASE_INSTANCE", {
         default: databaseInstanceDefault,

--- a/kits/rtdb-limit-child-nodes/tests/config.test.ts
+++ b/kits/rtdb-limit-child-nodes/tests/config.test.ts
@@ -86,16 +86,22 @@ describe("configFromEnv", () => {
     const { configFromEnv } = await importConfig();
 
     expect(configFromEnv()).toMatchObject({
-      nodePath: "messages",
-      maxCount: 100,
+      nodePath: "rtdb_node_path-value",
+      maxCount: 10,
       databaseInstance: "selected_database_instance-value",
     });
     expect(defineString.mock.calls).toContainEqual([
-      "RTDB_NODE_PATH",
-      { default: "messages" },
-    ]);
-    expect(defineString.mock.calls).toContainEqual([
       "SELECTED_DATABASE_INSTANCE",
     ]);
+  });
+
+  // The extension declared NODE_PATH and MAX_COUNT as required with no default,
+  // so the CLI prompted for both at install. Declaring a default here would let
+  // a deploy that omits MAX_COUNT silently prune every node down to that value.
+  test("declares no default for RTDB_NODE_PATH or MAX_COUNT", async () => {
+    await importConfig();
+
+    expect(defineString.mock.calls).toContainEqual(["RTDB_NODE_PATH"]);
+    expect(defineInt.mock.calls).toContainEqual(["MAX_COUNT"]);
   });
 });

--- a/kits/rtdb-limit-child-nodes/tests/config.test.ts
+++ b/kits/rtdb-limit-child-nodes/tests/config.test.ts
@@ -38,13 +38,15 @@ class FakeStringParam extends FakeExpression<string> {
 }
 
 const defineString = vi.fn(
-  (name: string, opts?: { default?: string }) =>
+  (name: string, opts?: { default?: string; input?: unknown }) =>
     new FakeStringParam(name, opts?.default)
 );
 
-const defineInt = vi.fn((_name: string, opts?: { default?: number }) => ({
-  value: () => opts?.default ?? 10,
-}));
+const defineInt = vi.fn(
+  (_name: string, opts?: { default?: number; input?: unknown }) => ({
+    value: () => opts?.default ?? 10,
+  })
+);
 
 const expr = vi.fn(
   (strings: TemplateStringsArray, ...values: unknown[]) =>
@@ -90,9 +92,13 @@ describe("configFromEnv", () => {
       maxCount: 10,
       databaseInstance: "selected_database_instance-value",
     });
-    expect(defineString.mock.calls).toContainEqual([
-      "SELECTED_DATABASE_INSTANCE",
-    ]);
+    const instanceOptions = defineString.mock.calls.find(
+      ([name]) => name === "SELECTED_DATABASE_INSTANCE"
+    )?.[1];
+    expect(instanceOptions).not.toHaveProperty("default");
+    expect(instanceOptions).toMatchObject({
+      input: { text: { validationRegex: /^([0-9a-z_.-]*)$/ } },
+    });
   });
 
   // The extension declared NODE_PATH and MAX_COUNT as required with no default,
@@ -101,7 +107,20 @@ describe("configFromEnv", () => {
   test("declares no default for RTDB_NODE_PATH or MAX_COUNT", async () => {
     await importConfig();
 
-    expect(defineString.mock.calls).toContainEqual(["RTDB_NODE_PATH"]);
-    expect(defineInt.mock.calls).toContainEqual(["MAX_COUNT"]);
+    const nodePathOptions = defineString.mock.calls.find(
+      ([name]) => name === "RTDB_NODE_PATH"
+    )?.[1];
+    const maxCountOptions = defineInt.mock.calls.find(
+      ([name]) => name === "MAX_COUNT"
+    )?.[1];
+
+    expect(nodePathOptions).not.toHaveProperty("default");
+    expect(maxCountOptions).not.toHaveProperty("default");
+    expect(nodePathOptions).toMatchObject({
+      input: { text: { validationRegex: /^\S+$/ } },
+    });
+    expect(maxCountOptions).toMatchObject({
+      input: { text: { validationRegex: /^[1-9][0-9]*$/ } },
+    });
   });
 });

--- a/kits/rtdb-limit-child-nodes/tests/config.test.ts
+++ b/kits/rtdb-limit-child-nodes/tests/config.test.ts
@@ -120,7 +120,7 @@ describe("configFromEnv", () => {
       input: { text: { validationRegex: /^\S+$/ } },
     });
     expect(maxCountOptions).toMatchObject({
-      input: { text: { validationRegex: /^[1-9][0-9]*$/ } },
+      input: { text: { validationRegex: /^\d+$/ } },
     });
   });
 });

--- a/kits/speech-to-text/src/config.ts
+++ b/kits/speech-to-text/src/config.ts
@@ -38,10 +38,27 @@ const params = {
     default: storageBucket,
     input: BUCKET_PICKER,
   }),
-  languageCode: defineString("LANGUAGE_CODE"),
+  languageCode: defineString("LANGUAGE_CODE", {
+    input: {
+      text: {
+        validationRegex: /^([a-zA-Z-])*[A-Z][A-Z]$/,
+        validationErrorMessage:
+          "Must be a valid code from https://cloud.google.com/speech-to-text/docs/languages",
+      },
+    },
+  }),
   model: defineString("MODEL", { default: "default" }),
   outputStoragePath: defineString("OUTPUT_STORAGE_PATH", { default: "" }),
-  collectionPath: defineString("COLLECTION_PATH", { default: "" }),
+  collectionPath: defineString("COLLECTION_PATH", {
+    default: "",
+    input: {
+      text: {
+        // Extension regex, with an empty branch added: the param is optional.
+        validationRegex: /^(?:[^\/]+(\/[^\/]+\/[^\/]+)*|)$/,
+        validationErrorMessage: "Must be a valid Cloud Firestore Collection",
+      },
+    },
+  }),
   enableAutomaticPunctuation: defineBoolean("ENABLE_AUTOMATIC_PUNCTUATION", {
     default: true,
   }),

--- a/kits/storage-resize-images/src/config.ts
+++ b/kits/storage-resize-images/src/config.ts
@@ -67,7 +67,16 @@ const params = {
     default: storageBucket,
     input: BUCKET_PICKER,
   }),
-  sizes: defineString("IMG_SIZES", { default: "200x200" }),
+  sizes: defineString("IMG_SIZES", {
+    default: "200x200",
+    input: {
+      text: {
+        validationRegex: /^\d+x(\d+,\d+x)*\d+$/,
+        validationErrorMessage:
+          "Invalid sizes, must be a comma-separated list of WIDTHxHEIGHT values.",
+      },
+    },
+  }),
   deleteOriginal: defineString("DELETE_ORIGINAL_FILE", {
     default: "false",
     input: select({
@@ -90,14 +99,40 @@ const params = {
       "/users/avatars/thumbs,/design/pictures/thumbs"
     ),
   }),
-  failedImagesPath: defineString("FAILED_IMAGES_PATH", { default: "" }),
+  failedImagesPath: defineString("FAILED_IMAGES_PATH", {
+    default: "",
+    input: {
+      text: {
+        validationRegex: /^([^\/.]*|)$/,
+        validationErrorMessage: 'Values cannot include "/", ".".',
+      },
+    },
+  }),
   cacheControlHeader: defineString("CACHE_CONTROL_HEADER", { default: "" }),
   imageTypes: defineList("IMAGE_TYPE", {
     default: ["false"],
     input: multiSelect([...IMAGE_TYPE_OPTIONS]),
   }),
-  outputOptions: defineString("OUTPUT_OPTIONS", { default: "" }),
-  sharpOptions: defineString("SHARP_OPTIONS", { default: "{}" }),
+  outputOptions: defineString("OUTPUT_OPTIONS", {
+    default: "",
+    input: {
+      text: {
+        // Extension regex, with an empty branch added: the param is optional.
+        validationRegex: /^(?:({(.*?)})|)$/,
+        validationErrorMessage: "Please provide a valid JSON object.",
+      },
+    },
+  }),
+  sharpOptions: defineString("SHARP_OPTIONS", {
+    default: "{}",
+    input: {
+      text: {
+        // Extension regex, with an empty branch added: the param is optional.
+        validationRegex: /^(?:({(.*?)})|)$/,
+        validationErrorMessage: "Please provide a valid JSON object.",
+      },
+    },
+  }),
   isAnimated: defineBoolean("IS_ANIMATED", {
     default: true,
   }),
@@ -113,7 +148,18 @@ const params = {
     input: select([...CONTENT_FILTER_OPTIONS]),
   }),
   customFilterPrompt: defineString("CUSTOM_FILTER_PROMPT", { default: "" }),
-  placeholderImagePath: defineString("PLACEHOLDER_IMAGE_PATH", { default: "" }),
+  placeholderImagePath: defineString("PLACEHOLDER_IMAGE_PATH", {
+    default: "",
+    input: {
+      text: {
+        // Extension regex, with an empty branch added: the param is optional.
+        validationRegex:
+          /^(?:([a-zA-Z0-9_\-\.\/]+)\.(png|jpg|jpeg|gif|webp)|)$/,
+        validationErrorMessage:
+          "Please provide a valid image path within your bucket.",
+      },
+    },
+  }),
 };
 
 export const CONFIG_EXPRESSIONS = {


### PR DESCRIPTION
## Summary

- Restores install-time param validation lost in the extension → kit migrations, tracked in #2974: every surviving param that had a `validationRegex` in its `extension.yaml` now declares the same regex and `validationErrorMessage` via the params `TextInput` — 30 params across all 11 kits.
- Optional params (extension `required: false`) get an empty branch added (`^(?:…|)$`) so a blank value is still accepted, since `TextInput` retries the prompt until the regex matches.
- `rtdb-limit-child-nodes` `MAX_COUNT` uses `^[1-9][0-9]*$` instead of upstream's `^\d+$`, which accepted `0` — a value that deletes every child on every write. Runtime resolution already throws on `0`.
- `firestore-genai-chatbot` positive-integer regexes are anchored; upstream's unanchored `^[1-9][0-9]*` let values like `5abc` through.
- `firestore-vector-search` `DEFAULT_QUERY_LIMIT` error message corrected from upstream's copy-pasted "Must be a valid Cloud Firestore Collection".
- Shared validation objects where one regex serves several params: `DATABASE_INSTANCE_VALIDATION` (rtdb), `ZERO_TO_ONE_VALIDATION` / `POSITIVE_INT_VALIDATION` (genai-chatbot).
- Not carried over: `IMG_BUCKET` / `EXTENSION_BUCKET` keep `BUCKET_PICKER` (`ResourceInput` and `TextInput` are mutually exclusive, and the picker is stronger); `INCLUDE_PATH_LIST` / `EXCLUDE_PATH_LIST` were already validated; `MAX_DISPATCHES_PER_SECOND` / `MAX_ENQUEUE_ATTEMPTS` params no longer exist.
- Test updates: brittle exact-args assertions in `firestore-counter`, `firestore-translate-text`, and `rtdb-limit-child-nodes` switched to `objectContaining`, plus new assertions covering the restored regexes.

## Testing

- `tsc --noEmit` clean across all 11 kits.
- All kit vitest suites pass (617 tests).
- End-to-end against a consumer project (firebase-tools 15.26.0): all 11 kits rebuilt, `npm pack`ed, and re-vendored into their function-kits sources; deployed to a live project — 27 codebases, 59 operations, 0 failures.
- Manifest verification: loading a built source the way CLI discovery does shows each param serializing its `validationRegex` (via `RegExp.source`) and `validationErrorMessage` exactly as declared.
- Negative test: removing `MAX_COUNT` from a deployed rtdb-limit-child-nodes instance's dotenv and redeploying fails with `In non-interactive mode but have no value for the following environment variables: MAX_COUNT`, confirming the required-no-default behaviour.
- Not exercised live: the interactive prompt-retry loop (needs a TTY). Verified against the CLI's `promptText` implementation, which compiles the declared regex and reprompts with the declared error message.
- Note: dotenv-provided values bypass the regex, matching the extensions, where direct env edits also bypassed install-time validation.


