### PR TITLE
fix(bigquery-firestore-export): apply DISPLAY_NAME changes on update

### DIFF
--- a/kits/bigquery-firestore-export/src/dts.ts
+++ b/kits/bigquery-firestore-export/src/dts.ts
@@ -176,6 +176,11 @@ export async function constructUpdateTransferConfigRequest(
     updatedFields.partitioning_field.stringValue = newPartitioningField;
   }
 
+  if (config.displayName !== transferConfig.displayName) {
+    updateMask.push("display_name");
+    updatedConfig.displayName = config.displayName;
+  }
+
   if (config.schedule !== transferConfig.schedule) {
     updateMask.push("schedule");
     updatedConfig.schedule = config.schedule;

--- a/kits/bigquery-firestore-export/tests/dts.test.ts
+++ b/kits/bigquery-firestore-export/tests/dts.test.ts
@@ -72,6 +72,7 @@ describe("constructUpdateTransferConfigRequest", () => {
     const client = clientWithTransferConfig({
       name: "projects/p/locations/us/transferConfigs/c",
       destinationDatasetId: "analytics",
+      displayName: "Users export",
       schedule: "every 24 hours",
       notificationPubsubTopic:
         "projects/test-project/topics/kit-users-export-processMessages",
@@ -93,6 +94,63 @@ describe("constructUpdateTransferConfigRequest", () => {
     );
 
     expect(request.updateMask?.paths).toEqual(["params"]);
+  });
+
+  test("updates the display name when it changed", async () => {
+    const client = clientWithTransferConfig({
+      name: "projects/p/locations/us/transferConfigs/c",
+      destinationDatasetId: "analytics",
+      displayName: "Old export name",
+      schedule: "every 24 hours",
+      notificationPubsubTopic:
+        "projects/test-project/topics/kit-users-export-processMessages",
+      params: {
+        fields: {
+          query: { stringValue: config.queryString },
+          destination_table_name_template: {
+            stringValue: 'users_{run_time|"%H%M%S"}',
+          },
+          partitioning_field: { stringValue: "created_at" },
+        },
+      },
+    });
+
+    const request = await constructUpdateTransferConfigRequest(
+      client,
+      "projects/p/locations/us/transferConfigs/c",
+      config
+    );
+
+    expect(request.updateMask?.paths).toEqual(["display_name"]);
+    expect(request.transferConfig?.displayName).toBe("Users export");
+  });
+
+  test("leaves the display name out of the mask when unchanged", async () => {
+    const client = clientWithTransferConfig({
+      name: "projects/p/locations/us/transferConfigs/c",
+      destinationDatasetId: "analytics",
+      displayName: "Users export",
+      schedule: "every 12 hours",
+      notificationPubsubTopic:
+        "projects/test-project/topics/kit-users-export-processMessages",
+      params: {
+        fields: {
+          query: { stringValue: config.queryString },
+          destination_table_name_template: {
+            stringValue: 'users_{run_time|"%H%M%S"}',
+          },
+          partitioning_field: { stringValue: "created_at" },
+        },
+      },
+    });
+
+    const request = await constructUpdateTransferConfigRequest(
+      client,
+      "projects/p/locations/us/transferConfigs/c",
+      config
+    );
+
+    expect(request.updateMask?.paths).toEqual(["schedule"]);
   });
 
   test("rejects clearing an existing partitioning field", async () => {


### PR DESCRIPTION
## Problem

`DISPLAY_NAME` is `immutable: true` upstream but mutable in the kit, and `constructUpdateTransferConfigRequest` never adds `display_name` to the update mask. Editing it and redeploying reports success and changes nothing.

## What changed

`display_name` joins the mask when it differs, matching the `schedule` and `notification_pubsub_topic` comparisons beside it.

## Verification

Against a live transfer config: with `display_name` in the mask the rename lands, with it omitted the same request body is silently ignored. Two unit cases added, full suite 21 passed, `tsc -b` clean.

## Notes

The alternative was making the param immutable to match upstream. This keeps the kit's more flexible behaviour.

Tracked in #2974 ([parity analysis](https://github.com/firebase/extensions/issues/2974#issuecomment-5395098640)), `DISPLAY_NAME` params row.
