### PR TITLE
fix(bigquery-firestore-export): drop the dead serviceAccount option

### DIFF
--- a/kits/bigquery-firestore-export/src/dts.ts
+++ b/kits/bigquery-firestore-export/src/dts.ts
@@ -65,10 +65,15 @@ function stringField(value: string | undefined): { stringValue: string } {
   return { stringValue: value ?? "" };
 }
 
-/** Creates the protobuf-shaped request used for a scheduled query. */
+/**
+ * Creates the protobuf-shaped request used for a scheduled query.
+ *
+ * The query runs as the caller, so the kit cannot name an owner here. Doing so
+ * means `serviceAccountName` on the request, not on `transferConfig`, and takes
+ * a `roles/iam.serviceAccountUser` dependency for `actAs`.
+ */
 export function createTransferConfigRequest(
-  config: ResolvedBigqueryFirestoreExportConfig,
-  serviceAccountEmail?: string
+  config: ResolvedBigqueryFirestoreExportConfig
 ): bigqueryDataTransfer.protos.google.cloud.bigquery.datatransfer.v1.ICreateTransferConfigRequest {
   return {
     parent: `projects/${config.projectId}`,
@@ -88,9 +93,6 @@ export function createTransferConfigRequest(
       },
       schedule: config.schedule,
       notificationPubsubTopic: `projects/${config.projectId}/topics/${config.pubSubTopic}`,
-      ...(serviceAccountEmail
-        ? { serviceAccountName: serviceAccountEmail }
-        : {}),
     },
   };
 }
@@ -120,7 +122,7 @@ export async function createTransferConfig(
 ): Promise<TransferConfig> {
   logs.createTransferConfig();
   const [created] = await client.createTransferConfig(
-    createTransferConfigRequest(config, config.serviceAccount)
+    createTransferConfigRequest(config)
   );
   if (!created.name) {
     throw new Error("BigQuery API returned a transfer config without a name");

--- a/kits/bigquery-firestore-export/src/export-config.ts
+++ b/kits/bigquery-firestore-export/src/export-config.ts
@@ -45,8 +45,6 @@ export interface BigqueryFirestoreExportConfig {
   pubSubTopic?: string;
   /** Root Firestore collection for configs and run output. */
   firestoreCollection?: string;
-  /** Runtime identity used when creating a DTS config. */
-  serviceAccount?: string;
   /** Log verbosity. Defaults to `info`. */
   logLevel?: LogLevel;
 }
@@ -65,7 +63,6 @@ export interface ResolvedBigqueryFirestoreExportConfig {
   schedule: string;
   pubSubTopic: string;
   firestoreCollection: string;
-  serviceAccount?: string;
   logLevel: LogLevel;
 }
 
@@ -117,7 +114,6 @@ export function resolveConfig(
       optional(config.pubSubTopic) ?? `kit-${instanceId}-processMessages`,
     firestoreCollection:
       optional(config.firestoreCollection) ?? "transferConfigs",
-    serviceAccount: optional(config.serviceAccount),
     logLevel,
   };
 }

--- a/kits/bigquery-firestore-export/tests/dts.test.ts
+++ b/kits/bigquery-firestore-export/tests/dts.test.ts
@@ -43,10 +43,7 @@ function clientWithTransferConfig(transferConfig: object): DataTransferClient {
 
 describe("createTransferConfigRequest", () => {
   test("creates the scheduled-query request", () => {
-    const request = createTransferConfigRequest(
-      config,
-      "runtime@test-project.iam.gserviceaccount.com"
-    );
+    const request = createTransferConfigRequest(config);
 
     expect(request).toMatchObject({
       parent: "projects/test-project",
@@ -57,13 +54,18 @@ describe("createTransferConfigRequest", () => {
         schedule: "every 24 hours",
         notificationPubsubTopic:
           "projects/test-project/topics/kit-users-export-processMessages",
-        serviceAccountName: "runtime@test-project.iam.gserviceaccount.com",
       },
     });
     expect(
       request.transferConfig?.params?.fields?.destination_table_name_template
         ?.stringValue
     ).toBe('users_{run_time|"%H%M%S"}');
+  });
+
+  test("names no owner for the scheduled query", () => {
+    const request = createTransferConfigRequest(config);
+
+    expect(JSON.stringify(request)).not.toContain("serviceAccountName");
   });
 });
 

--- a/kits/bigquery-firestore-export/tests/export-config.test.ts
+++ b/kits/bigquery-firestore-export/tests/export-config.test.ts
@@ -46,16 +46,12 @@ describe("resolveConfig", () => {
       ...minimal,
       transferConfigName: "  projects/p/locations/us/transferConfigs/c  ",
       partitioningField: "  created_at  ",
-      serviceAccount: "  runtime@test-project.iam.gserviceaccount.com  ",
     });
 
     expect(resolved.transferConfigName).toBe(
       "projects/p/locations/us/transferConfigs/c"
     );
     expect(resolved.partitioningField).toBe("created_at");
-    expect(resolved.serviceAccount).toBe(
-      "runtime@test-project.iam.gserviceaccount.com"
-    );
   });
 
   test.each(["instanceId", "datasetId", "tableName", "queryString"] as const)(


### PR DESCRIPTION
The kit accepted a `serviceAccount` option and spread it into the nested `transferConfig` as `serviceAccountName`. That field belongs to `CreateTransferConfigRequest`, not `TransferConfig`, so it was silently discarded (no type error, because it arrived through a spread) and Data Transfer fell back to the calling identity. `configFromEnv()` never set it, so deploys were unaffected. The harm was to a caller importing from `./lib`, who could name a dedicated least-privilege account, get no error, and run as the function's own runtime account. Upstream has the same misplacement, so this is not a regression.

Removes the option from both config interfaces, `resolveConfig`, `createTransferConfigRequest` and `createTransferConfig`, with a note on the request builder naming the constraint.

`vitest run` (6 files, 20 tests) and `tsc -b` pass, and the built `lib/` no longer carries the field. The new case fails if the field returns, checked by reintroducing the spread. The two removed assertions pinned only the discarded field; `transferConfigName` and `partitioningField` still cover the same trimming in `resolveConfig`.

Wiring it properly means `serviceAccountName` on the request plus `roles/iam.serviceAccountUser` for `actAs`, a larger change with a new IAM requirement, so this PR removes the option instead.
