### PR TITLE
fix(firestore-genai-chatbot): restore the extension's 540s timeout

### DIFF
--- a/kits/firestore-genai-chatbot/src/config.ts
+++ b/kits/firestore-genai-chatbot/src/config.ts
@@ -242,5 +242,8 @@ export function envDeployOptions(): DeployTimeOptions {
     // `.env`, the `{messageId}` wildcard stays literal (matches extension.yaml's
     // `${COLLECTION_NAME}/{messageId}` trigger resource).
     document: expr`${params.collectionName}/{messageId}`,
+    // extension.yaml sets `timeout: 540s`; without this the function takes
+    // the 60s default and long generations time out.
+    timeoutSeconds: 540,
   };
 }

--- a/kits/firestore-genai-chatbot/src/export-config.ts
+++ b/kits/firestore-genai-chatbot/src/export-config.ts
@@ -127,6 +127,8 @@ export interface ResolvedGenaiChatbotConfig {
 export interface DeployTimeOptions {
   /** Watched Firestore document/collection path for the trigger. */
   document: string | Expression<string>;
+  /** Function timeout in seconds; extension.yaml sets `timeout: 540s`. */
+  timeoutSeconds: number;
 }
 
 /**

--- a/kits/firestore-genai-chatbot/src/index.ts
+++ b/kits/firestore-genai-chatbot/src/index.ts
@@ -86,6 +86,7 @@ export const generateMessage = onDocumentWritten(
   {
     document: deployOptions.document,
     secrets: [apiKeySecret],
+    timeoutSeconds: deployOptions.timeoutSeconds,
   },
   (event) => handleDocumentWrite(event, getContext())
 );

--- a/kits/firestore-genai-chatbot/src/lib.ts
+++ b/kits/firestore-genai-chatbot/src/lib.ts
@@ -27,12 +27,16 @@
 
 // Config types + helpers
 export {
+  type DeployTimeOptions,
   type GenaiChatbotConfig,
   GenerativeAIProvider,
   type ResolvedGenaiChatbotConfig,
   resolveConfig,
   type SafetySetting,
 } from "./export-config";
+// Deploy-time trigger options (document CEL + the extension's 540s timeout)
+// for consumers wiring their own trigger from the params-driven config.
+export { envDeployOptions } from "./config";
 // Generative client (for custom pipelines)
 export { getGenerativeClient } from "./generative-client";
 // Handlers

--- a/kits/firestore-genai-chatbot/tests/deploy-options.test.ts
+++ b/kits/firestore-genai-chatbot/tests/deploy-options.test.ts
@@ -45,6 +45,10 @@ describe("envDeployOptions", () => {
     expect(options).not.toHaveProperty("region");
   });
 
+  test("declares the extension's 540s timeout", () => {
+    expect(options.timeoutSeconds).toBe(540);
+  });
+
   test("document expression is not a frozen undefined/empty literal", () => {
     expect(options.document).toBeInstanceOf(Expression);
     expect(cel(options.document)).not.toContain("undefined");


### PR DESCRIPTION
## Summary

- Restores the extension's `timeout: 540s` on `generateMessage`, tracked as the kit's highest-priority gap in #2974: the kit set no `timeoutSeconds`, so the function took the 60s default and long generations timed out mid-stream.
- The timeout is declared in `envDeployOptions()` / `DeployTimeOptions` rather than inline, so library consumers get it too and the deploy-options suite asserts it.

## Testing

- New deploy-options assertion: `timeoutSeconds === 540`.
- `tsc --noEmit` clean; all 22 tests pass.
- End-to-end against a consumer project: kit rebuilt from this branch, `npm pack`ed, re-vendored into its function-kits source; discovery endpoint spec carries `timeoutSeconds: 540` (with the `API_KEY` secret binding intact).
- Live deploy of all three genai codebases (`a91f6c2e`, `overrides`, `vertex`) — successful updates, 0 failures.
- Cloud-side verification via `firebase functions:list`: all three deployed `generateMessage` functions report `timeoutSeconds: 540`.
