### PR TITLE
fix(firestore-vector-search): bind provider secrets to task functions

### DIFF
--- a/kits/firestore-vector-search/src/index.ts
+++ b/kits/firestore-vector-search/src/index.ts
@@ -79,9 +79,9 @@ const REQUIRED_APIS = [
   },
 ] as const;
 const FUNCTION_SECRETS = [geminiApiKey, openAiApiKey];
-// The task and trigger functions reach getSingleEmbedding, so they need the
-// provider API keys bound like the Firestore and callable functions do --
-// without them a gemini/openai backfill reads an undefined key.
+// Only the task functions reach getSingleEmbedding, but every function here
+// resolves the same config (which reads the provider keys), and the extension
+// bound its secrets to all functions in the instance -- so bind them uniformly.
 const DEFAULT_TASK_OPTIONS = {
   memory: "512MiB",
   timeoutSeconds: FUNCTION_TIMEOUT_SECONDS,

--- a/kits/firestore-vector-search/src/index.ts
+++ b/kits/firestore-vector-search/src/index.ts
@@ -79,14 +79,19 @@ const REQUIRED_APIS = [
   },
 ] as const;
 const FUNCTION_SECRETS = [geminiApiKey, openAiApiKey];
+// The task and trigger functions reach getSingleEmbedding, so they need the
+// provider API keys bound like the Firestore and callable functions do --
+// without them a gemini/openai backfill reads an undefined key.
 const DEFAULT_TASK_OPTIONS = {
   memory: "512MiB",
   timeoutSeconds: FUNCTION_TIMEOUT_SECONDS,
+  secrets: FUNCTION_SECRETS,
 } as const;
 const EMBEDDING_TASK_OPTIONS = {
   memory: "1GiB",
   timeoutSeconds: FUNCTION_TIMEOUT_SECONDS,
   retryConfig: { maxAttempts: TASK_MAX_ATTEMPTS },
+  secrets: FUNCTION_SECRETS,
 } as const;
 const FIRESTORE_FUNCTION_OPTIONS = {
   memory: "512MiB",
@@ -191,10 +196,7 @@ export const queryCallable = onCall(CALLABLE_FUNCTION_OPTIONS, (request) =>
 );
 
 export const initVectorSearch = onTaskDispatched(
-  {
-    ...DEFAULT_TASK_OPTIONS,
-    secrets: FUNCTION_SECRETS,
-  },
+  DEFAULT_TASK_OPTIONS,
   async () => {
     await handleInit(getContext());
   }


### PR DESCRIPTION
## Summary

- Binds `GEMINI_API_KEY` / `OPENAI_API_KEY` to `updateTask`, `backfillTask`, `updateTrigger`, and `backfillTrigger` — tracked in #2974 (ranked #4): these all reach `getSingleEmbedding`, so a gemini/openai backfill previously read an undefined key.
- Secrets ride on `DEFAULT_TASK_OPTIONS` / `EMBEDDING_TASK_OPTIONS`, matching the existing Firestore/callable bindings.
- `initVectorSearch`'s explicit `secrets` spread becomes redundant and is simplified to `DEFAULT_TASK_OPTIONS`.

## Testing

- `tsc --noEmit` clean; all 49 tests pass.
- Wire-level verification (endpoint `secretEnvironmentVariables` on the task functions) is covered by the consumer-project repack/deploy pass.
- End-to-end against a consumer project: kit rebuilt from this branch, `npm pack`ed, re-vendored; discovery endpoint specs show both secrets on all 8 endpoints, including the four previously-unbound task/trigger functions.
- Live deploy of all three vector-search codebases (`a91f6c2e`, `euclid`, `openai`) — successful updates, secret versions validated, lifecycle `initVectorSearch` tasks queued, 0 failures.
- Cloud-side verification via `firebase functions:list`: 24/24 vector-search functions across the three instances carry both `GEMINI_API_KEY` and `OPENAI_API_KEY`, pinned to real Secret Manager versions.
