### PR TITLE
fix(delete-user-data): gate RTDB deletion on a configured instance

### DIFF
--- a/kits/delete-user-data/src/handlers.ts
+++ b/kits/delete-user-data/src/handlers.ts
@@ -19,6 +19,7 @@ import type { DocumentReference } from "firebase-admin/firestore";
 import { FieldPath } from "firebase-admin/firestore";
 import chunk from "lodash.chunk";
 import * as events from "./events";
+import { getDatabaseUrl } from "./export-config";
 import { extractUserPaths, hasValidUserPath } from "./helpers";
 import * as logs from "./logs";
 import { recursiveDelete } from "./recursiveDelete";
@@ -156,7 +157,13 @@ export async function handleClear(
   } else {
     logs.firestoreNotConfigured();
   }
-  if (ctx.config.rtdbPaths) {
+  // Parity with the extension: RTDB deletion runs only when a database URL
+  // can be derived from the configured instance. Without this, the paths
+  // would be deleted against whatever default instance the app resolves.
+  if (
+    ctx.config.rtdbPaths &&
+    getDatabaseUrl(ctx.config.rtdbInstance, ctx.config.rtdbLocation)
+  ) {
     promises.push(clearDatabaseData(ctx.config.rtdbPaths, uid, ctx));
   } else {
     logs.rtdbNotConfigured();

--- a/kits/delete-user-data/src/handlers.ts
+++ b/kits/delete-user-data/src/handlers.ts
@@ -157,9 +157,6 @@ export async function handleClear(
   } else {
     logs.firestoreNotConfigured();
   }
-  // Parity with the extension: RTDB deletion runs only when a database URL
-  // can be derived from the configured instance. Without this, the paths
-  // would be deleted against whatever default instance the app resolves.
   if (
     ctx.config.rtdbPaths &&
     getDatabaseUrl(ctx.config.rtdbInstance, ctx.config.rtdbLocation)

--- a/kits/delete-user-data/tests/handlers.test.ts
+++ b/kits/delete-user-data/tests/handlers.test.ts
@@ -406,7 +406,11 @@ describe("handleClear", () => {
 
   test("deletes the configured rtdb paths", async () => {
     const ctx = makeContext({
-      config: { rtdbPaths: "users/{UID},admins/{UID}" },
+      config: {
+        rtdbPaths: "users/{UID},admins/{UID}",
+        rtdbInstance: "test-rtdb-instance",
+        rtdbLocation: "us-central1",
+      },
     });
 
     await handleClear(UID, ctx);
@@ -416,6 +420,20 @@ describe("handleClear", () => {
       uid: UID,
       paths: [`users/${UID}`, `admins/${UID}`],
     });
+  });
+
+  // Parity: the extension gates RTDB deletion on `rtdbPaths && databaseURL`,
+  // so paths without a configured instance must be skipped, not deleted
+  // against whatever default RTDB the app resolves.
+  test("skips rtdb deletion when no database instance is configured", async () => {
+    const ctx = makeContext({
+      config: { rtdbPaths: "users/{UID}" },
+    });
+
+    await handleClear(UID, ctx);
+
+    expect(ctx.rtdbRemovals).toEqual([]);
+    expect(log.rtdbNotConfigured).toHaveBeenCalled();
   });
 
   test("deletes the configured storage paths", async () => {
@@ -463,7 +481,11 @@ describe("handleClear", () => {
   test("logs rtdb errors without failing", async () => {
     const error = new Error("boom");
     const ctx = makeContext({
-      config: { rtdbPaths: "users/{UID}" },
+      config: {
+        rtdbPaths: "users/{UID}",
+        rtdbInstance: "test-rtdb-instance",
+        rtdbLocation: "us-central1",
+      },
       rtdbError: error,
     });
 

--- a/kits/delete-user-data/tests/handlers.test.ts
+++ b/kits/delete-user-data/tests/handlers.test.ts
@@ -422,9 +422,6 @@ describe("handleClear", () => {
     });
   });
 
-  // Parity: the extension gates RTDB deletion on `rtdbPaths && databaseURL`,
-  // so paths without a configured instance must be skipped, not deleted
-  // against whatever default RTDB the app resolves.
   test("skips rtdb deletion when no database instance is configured", async () => {
     const ctx = makeContext({
       config: { rtdbPaths: "users/{UID}" },


### PR DESCRIPTION
## Summary

- Restores the extension's RTDB deletion gate, tracked in #2974 as the kit's deletion risk: the extension deletes only when `rtdbPaths && databaseURL`; the kit gated on `rtdbPaths` alone and deleted against whatever default RTDB instance the app resolved.
- `handleClear` now requires `getDatabaseUrl(rtdbInstance, rtdbLocation)` to resolve before scheduling RTDB deletion, logging `rtdbNotConfigured` otherwise — matching the extension's behaviour with `RTDB_PATHS` set and `SELECTED_DATABASE_INSTANCE` empty.
- Existing rtdb deletion tests gain explicit `rtdbInstance` / `rtdbLocation` config; a new test asserts paths are skipped (not deleted) when no instance is configured.

## Testing

- `tsc --noEmit` clean; all 85 tests pass (84 existing + 1 new skip-assertion).
- End-to-end against a consumer project: kit rebuilt from this branch, `npm pack`ed, re-vendored into its function-kits source.
- Runtime gate test against the shipped artifact (the packed `lib`, via the consumer install): `rtdbPaths` set with no instance → zero removals and the "Realtime Database paths are not configured, skipping" log; instance + location configured → deletes the expected path.
- Live deploy of both delete-user-data codebases (`a91f6c2e`, `recursive`) — all 6 functions updated, 0 failures.
