### PR TITLE
fix(release-kit): registry-driven versioning, explicit release commits, v7 action pins

### DIFF
--- a/.github/workflows/release-kit.yaml
+++ b/.github/workflows/release-kit.yaml
@@ -41,6 +41,12 @@ on:
         default: true
         type: boolean
 
+# All releases push to the same branch; a concurrent run would fail its push
+# after already publishing to npm, leaving a version with no commit or tag.
+concurrency:
+  group: release-kit
+  cancel-in-progress: false
+
 jobs:
   # =========================================================
   # 1. TEST JOB (Low Permissions: Read-Only)
@@ -125,6 +131,8 @@ jobs:
           # branch can lag behind what was actually released.
           NPM_CONFIG_REGISTRY: https://registry.npmjs.org
         run: |
+          set -o pipefail
+
           PKG_NAME=$(node -p "require('./package.json').name")
           LOCAL_VER=$(node -p "require('./package.json').version")
 
@@ -141,21 +149,28 @@ jobs:
             console.log(Object.keys(data).filter(v => v !== "created" && v !== "modified").join(" "));
           ')
 
-          HIGHEST=$(npx --yes semver@7 $LOCAL_VER $TAKEN | tail -n 1)
+          HIGHEST=$(npx --yes semver@7.8.5 $LOCAL_VER $TAKEN | tail -n 1)
+          # 0.0.0 seed keeps grep from emptying the pipe when no stable exists yet.
+          HIGHEST_STABLE=$(npx --yes semver@7.8.5 0.0.0 $LOCAL_VER $TAKEN | grep -v -- - | tail -n 1)
 
+          # The bump level is applied to the highest stable version; an existing
+          # rc line continues unless the requested level opens a higher line.
           if [ "$IS_PRERELEASE" = "true" ]; then
+            NEW_VER=$(npx --yes semver@7.8.5 -i "pre${BUMP_LEVEL}" --preid rc "$HIGHEST_STABLE")
+            BUMP_TYPE="pre${BUMP_LEVEL}"
             if [[ "$HIGHEST" == *-rc.* ]]; then
-              BUMP_TYPE="prerelease"
-            else
-              BUMP_TYPE="pre${BUMP_LEVEL}"
+              CONTINUED=$(npx --yes semver@7.8.5 -i prerelease --preid rc "$HIGHEST")
+              if [ "$(npx --yes semver@7.8.5 "$NEW_VER" "$CONTINUED" | tail -n 1)" = "$CONTINUED" ]; then
+                NEW_VER="$CONTINUED"
+                BUMP_TYPE="prerelease"
+              fi
             fi
             TARGET_TAG="next"
           else
+            NEW_VER=$(npx --yes semver@7.8.5 -i "$BUMP_LEVEL" "$HIGHEST_STABLE")
             BUMP_TYPE="$BUMP_LEVEL"
             TARGET_TAG="latest (and next)"
           fi
-
-          NEW_VER=$(npx --yes semver@7 -i "$BUMP_TYPE" --preid rc "$HIGHEST")
 
           for v in $TAKEN; do
             if [ "$v" = "$NEW_VER" ]; then
@@ -166,6 +181,7 @@ jobs:
 
           echo "current_ver=$LOCAL_VER" >> $GITHUB_OUTPUT
           echo "highest_ver=$HIGHEST" >> $GITHUB_OUTPUT
+          echo "highest_stable=$HIGHEST_STABLE" >> $GITHUB_OUTPUT
           echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
           echo "target_tag=$TARGET_TAG" >> $GITHUB_OUTPUT
           echo "version=$NEW_VER" >> $GITHUB_OUTPUT
@@ -202,6 +218,8 @@ jobs:
           TAG_NAME: ${{ steps.config.outputs.tag_name }}
         run: |
           git add "$TARGET_KIT/package.json"
+          # npm version also bumps the lockfile; kits currently ship npm-shrinkwrap.json.
+          [ -f "$TARGET_KIT/npm-shrinkwrap.json" ] && git add "$TARGET_KIT/npm-shrinkwrap.json"
           [ -f "$TARGET_KIT/package-lock.json" ] && git add "$TARGET_KIT/package-lock.json"
           [ -f "$TARGET_KIT/CHANGELOG.md" ] && git add "$TARGET_KIT/CHANGELOG.md"
           # git commit exits non-zero if the bump staged no changes, so a broken
@@ -216,6 +234,7 @@ jobs:
           TARGET_KIT: ${{ inputs.target_kit }}
           CURRENT_VER: ${{ steps.config.outputs.current_ver }}
           HIGHEST_VER: ${{ steps.config.outputs.highest_ver }}
+          HIGHEST_STABLE: ${{ steps.config.outputs.highest_stable }}
           VERSION: ${{ steps.config.outputs.version }}
           BUMP_TYPE: ${{ steps.config.outputs.bump_type }}
           TARGET_TAG: ${{ steps.config.outputs.target_tag }}
@@ -230,6 +249,7 @@ jobs:
           echo " Target Directory: $TARGET_KIT"
           echo " package.json Ver: $CURRENT_VER"
           echo " Highest Known:    $HIGHEST_VER"
+          echo " Highest Stable:   $HIGHEST_STABLE"
           echo " Target Version:   $VERSION"
           echo " Version Bump:     $BUMP_TYPE"
           echo " NPM Dist-Tag:     $TARGET_TAG"
@@ -274,7 +294,9 @@ jobs:
         env:
           REF_NAME: ${{ github.ref_name }}
           TAG_NAME: ${{ steps.config.outputs.tag_name }}
-        run: git push origin "HEAD:refs/heads/$REF_NAME" "refs/tags/$TAG_NAME"
+        run:
+          git push --atomic origin "HEAD:refs/heads/$REF_NAME"
+          "refs/tags/$TAG_NAME"
 
       - name: Create GitHub Release via GitHub CLI
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/release-kit.yaml
+++ b/.github/workflows/release-kit.yaml
@@ -43,6 +43,9 @@ on:
 
 # All releases push to the same branch; a concurrent run would fail its push
 # after already publishing to npm, leaving a version with no commit or tag.
+# GitHub keeps at most ONE pending run per group: with a run in progress and
+# one queued, a third dispatch cancels the queued one. Dispatch kits one at a
+# time and check for a "Canceled" run before assuming a release happened.
 concurrency:
   group: release-kit
   cancel-in-progress: false
@@ -133,11 +136,25 @@ jobs:
         run: |
           set -o pipefail
 
+          # The push at the end of the job would create a stray branch named
+          # after the ref if this were dispatched from a tag.
+          if [ "$GITHUB_REF_TYPE" != "branch" ]; then
+            echo "::error::Release Kit must be dispatched from a branch, got $GITHUB_REF_TYPE '$GITHUB_REF_NAME'."
+            exit 1
+          fi
+
           PKG_NAME=$(node -p "require('./package.json').name")
           LOCAL_VER=$(node -p "require('./package.json').version")
 
-          # `npm view <pkg> time` keys include unpublished versions, unlike `versions`.
-          VIEW_OUT=$(npm view "$PKG_NAME" time --json || true)
+          # `npm view <pkg> time` keys include per-version-unpublished versions
+          # (unlike `versions`); a fully unpublished package keeps its reserved
+          # versions under time.unpublished.versions instead.
+          VIEW_STATUS=0
+          VIEW_OUT=$(npm view "$PKG_NAME" time --json) || VIEW_STATUS=$?
+          if [ "$VIEW_STATUS" -ne 0 ] && [ -z "$VIEW_OUT" ]; then
+            echo "::error::npm view exited $VIEW_STATUS with no output; cannot trust the version computation."
+            exit 1
+          fi
           TAKEN=$(echo "$VIEW_OUT" | node -e '
             const raw = require("fs").readFileSync(0, "utf8").trim();
             const data = raw ? JSON.parse(raw) : {};
@@ -146,7 +163,11 @@ jobs:
               console.error(data.error.summary || data.error.code);
               process.exit(1);
             }
-            console.log(Object.keys(data).filter(v => v !== "created" && v !== "modified").join(" "));
+            const meta = ["created", "modified", "unpublished"];
+            const keys = Object.keys(data).filter(v => !meta.includes(v));
+            const unpub = (data.unpublished && data.unpublished.versions) || [];
+            const unpubList = Array.isArray(unpub) ? unpub : Object.keys(unpub);
+            console.log(keys.concat(unpubList).join(" "));
           ')
 
           HIGHEST=$(npx --yes semver@7.8.5 $LOCAL_VER $TAKEN | tail -n 1)
@@ -294,9 +315,8 @@ jobs:
         env:
           REF_NAME: ${{ github.ref_name }}
           TAG_NAME: ${{ steps.config.outputs.tag_name }}
-        run:
-          git push --atomic origin "HEAD:refs/heads/$REF_NAME"
-          "refs/tags/$TAG_NAME"
+        run: |
+          git push --atomic origin "HEAD:refs/heads/$REF_NAME" "refs/tags/$TAG_NAME"
 
       - name: Create GitHub Release via GitHub CLI
         if: ${{ !inputs.dry_run }}
@@ -312,6 +332,13 @@ jobs:
           PRERELEASE_FLAG=""
           if [ "$IS_PRERELEASE" = "true" ]; then
             PRERELEASE_FLAG="--prerelease"
+          fi
+
+          # A re-run after a transient gh failure must not mint a new version
+          # just to get a release page, so creation is skipped if it exists.
+          if gh release view "$TAG_NAME" > /dev/null 2>&1; then
+            echo "Release $TAG_NAME already exists; skipping creation."
+            exit 0
           fi
 
           gh release create "$TAG_NAME" \

--- a/.github/workflows/release-kit.yaml
+++ b/.github/workflows/release-kit.yaml
@@ -146,29 +146,29 @@ jobs:
           PKG_NAME=$(node -p "require('./package.json').name")
           LOCAL_VER=$(node -p "require('./package.json').version")
 
-          # `npm view <pkg> time` keys include per-version-unpublished versions
-          # (unlike `versions`); a fully unpublished package keeps its reserved
-          # versions under time.unpublished.versions instead.
-          VIEW_STATUS=0
-          VIEW_OUT=$(npm view "$PKG_NAME" time --json) || VIEW_STATUS=$?
-          if [ "$VIEW_STATUS" -ne 0 ] && [ -z "$VIEW_OUT" ]; then
-            echo "::error::npm view exited $VIEW_STATUS with no output; cannot trust the version computation."
+          # The packument is fetched directly rather than via `npm view`: npm
+          # hides a fully unpublished package behind E404 (dropping its reserved
+          # versions in time.unpublished) and its --json output shape changes
+          # across npm majors. The registry itself 404s only for never-published
+          # names. time keys include per-version-unpublished versions.
+          PACKUMENT="$RUNNER_TEMP/packument.json"
+          HTTP_STATUS=$(curl -sS --retry 3 -o "$PACKUMENT" -w '%{http_code}' "$NPM_CONFIG_REGISTRY/$PKG_NAME")
+          if [ "$HTTP_STATUS" = "404" ]; then
+            TAKEN=""
+          elif [ "$HTTP_STATUS" != "200" ]; then
+            echo "::error::Registry returned HTTP $HTTP_STATUS for $PKG_NAME; cannot trust the version computation."
             exit 1
+          else
+            TAKEN=$(node -e '
+              const data = JSON.parse(require("fs").readFileSync(0, "utf8"));
+              const time = data.time || {};
+              const meta = ["created", "modified", "unpublished"];
+              const keys = Object.keys(time).filter(v => !meta.includes(v));
+              const unpub = (time.unpublished && time.unpublished.versions) || [];
+              const unpubList = Array.isArray(unpub) ? unpub : Object.keys(unpub);
+              console.log(keys.concat(unpubList).join(" "));
+            ' < "$PACKUMENT")
           fi
-          TAKEN=$(echo "$VIEW_OUT" | node -e '
-            const raw = require("fs").readFileSync(0, "utf8").trim();
-            const data = raw ? JSON.parse(raw) : {};
-            if (data.error) {
-              if (data.error.code === "E404") process.exit(0);
-              console.error(data.error.summary || data.error.code);
-              process.exit(1);
-            }
-            const meta = ["created", "modified", "unpublished"];
-            const keys = Object.keys(data).filter(v => !meta.includes(v));
-            const unpub = (data.unpublished && data.unpublished.versions) || [];
-            const unpubList = Array.isArray(unpub) ? unpub : Object.keys(unpub);
-            console.log(keys.concat(unpubList).join(" "));
-          ')
 
           HIGHEST=$(npx --yes semver@7.8.5 $LOCAL_VER $TAKEN | tail -n 1)
           # 0.0.0 seed keeps grep from emptying the pipe when no stable exists yet.

--- a/.github/workflows/release-kit.yaml
+++ b/.github/workflows/release-kit.yaml
@@ -114,31 +114,63 @@ jobs:
           echo "$NOTES" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
 
-      - name: Determine Version Bump Type
+      - name: Determine Next Version
         id: config
         working-directory: ${{ inputs.target_kit }}
         env:
           BUMP_LEVEL: ${{ inputs.bump_level }}
           IS_PRERELEASE: ${{ inputs.is_prerelease }}
+          # The registry is the source of truth for versions: npm reserves every
+          # version ever published (even after unpublish), and package.json on the
+          # branch can lag behind what was actually released.
+          NPM_CONFIG_REGISTRY: https://registry.npmjs.org
         run: |
-          CURRENT_VER=$(node -p "require('./package.json').version")
-          BUMP="$BUMP_LEVEL"
+          PKG_NAME=$(node -p "require('./package.json').name")
+          LOCAL_VER=$(node -p "require('./package.json').version")
+
+          # `npm view <pkg> time` keys include unpublished versions, unlike `versions`.
+          VIEW_OUT=$(npm view "$PKG_NAME" time --json || true)
+          TAKEN=$(echo "$VIEW_OUT" | node -e '
+            const raw = require("fs").readFileSync(0, "utf8").trim();
+            const data = raw ? JSON.parse(raw) : {};
+            if (data.error) {
+              if (data.error.code === "E404") process.exit(0);
+              console.error(data.error.summary || data.error.code);
+              process.exit(1);
+            }
+            console.log(Object.keys(data).filter(v => v !== "created" && v !== "modified").join(" "));
+          ')
+
+          HIGHEST=$(npx --yes semver@7 $LOCAL_VER $TAKEN | tail -n 1)
 
           if [ "$IS_PRERELEASE" = "true" ]; then
-            if [[ "$CURRENT_VER" =~ -rc\.[0-9]+$ ]]; then
+            if [[ "$HIGHEST" == *-rc.* ]]; then
               BUMP_TYPE="prerelease"
             else
-              BUMP_TYPE="pre${BUMP}"
+              BUMP_TYPE="pre${BUMP_LEVEL}"
             fi
             TARGET_TAG="next"
           else
-            BUMP_TYPE="$BUMP"
+            BUMP_TYPE="$BUMP_LEVEL"
             TARGET_TAG="latest (and next)"
           fi
 
-          echo "current_ver=$CURRENT_VER" >> $GITHUB_OUTPUT
+          NEW_VER=$(npx --yes semver@7 -i "$BUMP_TYPE" --preid rc "$HIGHEST")
+
+          for v in $TAKEN; do
+            if [ "$v" = "$NEW_VER" ]; then
+              echo "::error::Computed version $NEW_VER already exists on the registry."
+              exit 1
+            fi
+          done
+
+          echo "current_ver=$LOCAL_VER" >> $GITHUB_OUTPUT
+          echo "highest_ver=$HIGHEST" >> $GITHUB_OUTPUT
           echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
           echo "target_tag=$TARGET_TAG" >> $GITHUB_OUTPUT
+          echo "version=$NEW_VER" >> $GITHUB_OUTPUT
+          echo "pkg_name=$PKG_NAME" >> $GITHUB_OUTPUT
+          echo "tag_name=${PKG_NAME}@${NEW_VER}" >> $GITHUB_OUTPUT
 
       - name: Install Dependencies & Build
         working-directory: ${{ inputs.target_kit }}
@@ -146,52 +178,49 @@ jobs:
           npm ci --registry=https://registry.npmjs.org
           npm run build
 
-      - name: Bump Version (Clear CHANGELOG on Stable Release Only)
-        id: versioning
+      - name: Apply Version Bump (Clear CHANGELOG on Stable Release Only)
         working-directory: ${{ inputs.target_kit }}
         env:
-          BUMP_TYPE: ${{ steps.config.outputs.bump_type }}
+          NEW_VER: ${{ steps.config.outputs.version }}
           IS_PRERELEASE: ${{ inputs.is_prerelease }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          if [ "$DRY_RUN" = "true" ]; then
-            npm version $BUMP_TYPE --preid=rc --no-git-tag-version
-          else
-            # Only truncate CHANGELOG.md if this is a STABLE release (not a prerelease)
-            if [ "$IS_PRERELEASE" != "true" ]; then
-              echo "Stable release detected: clearing CHANGELOG.md..."
-              > CHANGELOG.md
-              git add CHANGELOG.md
-            else
-              echo "Prerelease detected: preserving CHANGELOG.md content."
-            fi
+          # npm version only performs git operations when .git sits next to
+          # package.json; kits live in kits/<name>/ with .git at the repo root,
+          # so git commit/tag are done explicitly in the next step.
+          npm version "$NEW_VER" --no-git-tag-version
 
-            # Create version bump commit and git tag
-            if [[ "$BUMP_TYPE" == pre* ]] || [[ "$BUMP_TYPE" == "prerelease" ]]; then
-              npm version $BUMP_TYPE --preid=rc -m "chore(release): %s [skip ci]"
-            else
-              npm version $BUMP_TYPE -m "chore(release): %s [skip ci]"
-            fi
+          if [ "$DRY_RUN" != "true" ] && [ "$IS_PRERELEASE" != "true" ]; then
+            echo "Stable release detected: clearing CHANGELOG.md..."
+            > CHANGELOG.md
           fi
 
-          NEW_VER=$(node -p "require('./package.json').version")
-          PKG_NAME=$(node -p "require('./package.json').name")
-
-          echo "version=$NEW_VER" >> $GITHUB_OUTPUT
-          echo "pkg_name=$PKG_NAME" >> $GITHUB_OUTPUT
-          echo "tag_name=${PKG_NAME}@${NEW_VER}" >> $GITHUB_OUTPUT
+      - name: Commit & Tag Release
+        if: ${{ !inputs.dry_run }}
+        env:
+          TARGET_KIT: ${{ inputs.target_kit }}
+          TAG_NAME: ${{ steps.config.outputs.tag_name }}
+        run: |
+          git add "$TARGET_KIT/package.json"
+          [ -f "$TARGET_KIT/package-lock.json" ] && git add "$TARGET_KIT/package-lock.json"
+          [ -f "$TARGET_KIT/CHANGELOG.md" ] && git add "$TARGET_KIT/CHANGELOG.md"
+          # git commit exits non-zero if the bump staged no changes, so a broken
+          # bump fails the release instead of publishing without a release commit.
+          git commit -m "chore(release): $TAG_NAME [skip ci]"
+          git tag -a "$TAG_NAME" -m "$TAG_NAME"
 
       - name: Dry Run Summary
         if: ${{ inputs.dry_run }}
         env:
-          PKG_NAME: ${{ steps.versioning.outputs.pkg_name }}
+          PKG_NAME: ${{ steps.config.outputs.pkg_name }}
           TARGET_KIT: ${{ inputs.target_kit }}
           CURRENT_VER: ${{ steps.config.outputs.current_ver }}
-          VERSION: ${{ steps.versioning.outputs.version }}
+          HIGHEST_VER: ${{ steps.config.outputs.highest_ver }}
+          VERSION: ${{ steps.config.outputs.version }}
           BUMP_TYPE: ${{ steps.config.outputs.bump_type }}
           TARGET_TAG: ${{ steps.config.outputs.target_tag }}
           IS_PRERELEASE: ${{ inputs.is_prerelease }}
-          TAG_NAME: ${{ steps.versioning.outputs.tag_name }}
+          TAG_NAME: ${{ steps.config.outputs.tag_name }}
           NOTES: ${{ steps.changelog.outputs.notes }}
         run: |
           echo "=========================================================="
@@ -199,7 +228,8 @@ jobs:
           echo "=========================================================="
           echo " Package Name:     $PKG_NAME"
           echo " Target Directory: $TARGET_KIT"
-          echo " Current Version:  $CURRENT_VER"
+          echo " package.json Ver: $CURRENT_VER"
+          echo " Highest Known:    $HIGHEST_VER"
           echo " Target Version:   $VERSION"
           echo " Version Bump:     $BUMP_TYPE"
           echo " NPM Dist-Tag:     $TARGET_TAG"
@@ -211,12 +241,6 @@ jobs:
           echo "$NOTES"
           echo "=========================================================="
 
-      - name: Push Version Commit & Tags to Branch
-        if: ${{ !inputs.dry_run }}
-        env:
-          REF_NAME: ${{ github.ref_name }}
-        run: git push origin "$REF_NAME" --follow-tags
-
       - name: Publish to NPM
         # zizmor: ignore[use-trusted-publishing]
         working-directory: ${{ inputs.target_kit }}
@@ -224,8 +248,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           IS_PRERELEASE: ${{ inputs.is_prerelease }}
           DRY_RUN: ${{ inputs.dry_run }}
-          PKG_NAME: ${{ steps.versioning.outputs.pkg_name }}
-          VERSION: ${{ steps.versioning.outputs.version }}
+          PKG_NAME: ${{ steps.config.outputs.pkg_name }}
+          VERSION: ${{ steps.config.outputs.version }}
         run: |
           DRY_RUN_FLAG=""
           if [ "$DRY_RUN" = "true" ]; then
@@ -242,13 +266,23 @@ jobs:
             fi
           fi
 
+      # Pushed only after a successful publish: a failed publish leaves the
+      # branch untouched, and the next run recomputes the version from the
+      # registry either way.
+      - name: Push Version Commit & Tag to Branch
+        if: ${{ !inputs.dry_run }}
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          TAG_NAME: ${{ steps.config.outputs.tag_name }}
+        run: git push origin "HEAD:refs/heads/$REF_NAME" "refs/tags/$TAG_NAME"
+
       - name: Create GitHub Release via GitHub CLI
         if: ${{ !inputs.dry_run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ steps.versioning.outputs.tag_name }}
-          PKG_NAME: ${{ steps.versioning.outputs.pkg_name }}
-          VERSION: ${{ steps.versioning.outputs.version }}
+          TAG_NAME: ${{ steps.config.outputs.tag_name }}
+          PKG_NAME: ${{ steps.config.outputs.pkg_name }}
+          VERSION: ${{ steps.config.outputs.version }}
           IS_PRERELEASE: ${{ inputs.is_prerelease }}
           NOTES: ${{ steps.changelog.outputs.notes }}
           REF_NAME: ${{ github.ref_name }}


### PR DESCRIPTION
Fixes #2978.

- **npm version silently skipped git commit/tag** (.git not next to kit's package.json): bump now uses --no-git-tag-version, with explicit commit + annotated per-kit tag (`<pkg>@<version>`) from repo root. Commit fails loudly if nothing staged.
- **Re-runs recomputed the same version from package.json and 403'd**: next version now derived from the registry (`npm view <pkg> time`, includes unpublished versions) unioned with package.json.
- **Bump level silently ignored when an rc existed**: level now applied to the highest stable version; an rc line continues only if the requested level doesn't open a higher one.
- **npm-shrinkwrap.json bumped but not committed**: now staged in the release commit.
- **Concurrent runs raced the branch push**: workflow-level concurrency group; push is atomic and happens only after a successful publish.

Action pin bumps for #2977 split out into #2991; the two merge independently (non-overlapping hunks).

Verified: dry-run dispatch green, computes 0.0.2-rc.1 for rtdb (the version #2978 requires); version logic passed 10 synthetic registry scenarios locally. The non-dry-run commit/tag/push path has not been exercised live.