### PR TITLE
fix(ci): pin actions/checkout and setup-node to v7 (Node 20 deprecation)

### DIFF
--- a/.github/workflows/npm_publish_bq_scripts.yml
+++ b/.github/workflows/npm_publish_bq_scripts.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     name: publish_if_newer_version
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Setup node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
       - name: NPM install

--- a/.github/workflows/release-kit.yaml
+++ b/.github/workflows/release-kit.yaml
@@ -51,10 +51,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # zizmor: ignore[artipacked]
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
 
@@ -75,14 +77,13 @@ jobs:
       contents: write # Needed to push version commit, git tag & create GitHub Release
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # zizmor: ignore[artipacked]
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # zizmor: ignore[artipacked]
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "24"
           registry-url: "https://wombat-dressing-room.appspot.com"
-          always-auth: false
 
       - name: Configure Git User
         if: ${{ !inputs.dry_run }}


### PR DESCRIPTION
Fixes #2977.

- **Node 20 runtime deprecation warnings**: the pinned checkout/setup-node v4 SHAs declare a Node 20 runtime. Bumped to checkout v7.0.1 and setup-node v7.0.0 (both node24) in release-kit.yaml and npm_publish_bq_scripts.yml, keeping full SHA pinning.
- **Deviation from the issue**: it suggested latest v5; latest is now v7. Both SHAs verified against the actions repos.
- **always-auth removed**: setup-node v7 dropped the input; false was the default behaviour anyway.
- **setup-node v7 no longer exports a dummy NODE_AUTH_TOKEN**: verified npm 11 tolerates the unset env reference in the generated .npmrc, and npm_publish_bq_scripts.yml publishes via OIDC without relying on it.
- **Hardening**: the read-only test job in release-kit.yaml sets persist-credentials: false.

Other workflows (test.yml, validate.yml, release.yml, readmes-updated.yml) pin v3 SHAs and warn too; left out of scope here.

Verified via a green dry-run dispatch of Release Kit with these pins (run 33062266667); v3→v7 has no config-breaking changes for these workflows (package-manager-cache auto-detection is inert: no packageManager fields).