### PR TITLE
chore(ci): print inputs at start of release-kit workflow

### DIFF
--- a/.github/workflows/release-kit.yaml
+++ b/.github/workflows/release-kit.yaml
@@ -60,6 +60,12 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Print inputs
+        env:
+          INPUTS: ${{ toJSON(inputs) }}
+        run: |
+          echo "$INPUTS"
+
       # Kits live only on the kits branch; the ref is pinned so dispatching
       # from any branch (including next, which lists the workflow in the UI)
       # releases the same content.


### PR DESCRIPTION
Restores the input printing step at the start of the release-kit workflow.