### PR TITLE
fix(kits/firestore-incremental-capture): deploy the restoration endpoint IAM-gated

### DIFF
--- a/kits/firestore-incremental-capture/README.md
+++ b/kits/firestore-incremental-capture/README.md
@@ -136,6 +136,13 @@ firebase deploy --only functions
 
 Deploy a single instance with `firebase deploy --only functions:<instance id>`.
 
+A non-interactive deploy needs a value in the instance `.env` for every param,
+defaults included - the CLI applies param defaults only when prompting
+interactively. `DATAFLOW_REGION` is the one most easily missed because it is
+optional at runtime: without a value the deploy fails with "no value for the
+following environment variables: DATAFLOW_REGION". Set it explicitly, for
+example `DATAFLOW_REGION=us-east1`.
+
 ## Configuration
 
 Set these values in a `.env` (or `.env.<projectId>`) file. The Firebase CLI

--- a/kits/firestore-incremental-capture/README.md
+++ b/kits/firestore-incremental-capture/README.md
@@ -76,12 +76,15 @@ curl -X POST https://<onHttpRunRestoration URL printed by firebase deploy> \
   -d '{"timestamp": 1700000000}'
 ```
 
-> **`onHttpRunRestoration` requires an authenticated caller.** Unlike the
-> extension it was migrated from, a kit deploy does not grant `allUsers` the
-> invoker role, so the URL rejects anonymous calls with a 403. Grant
-> `roles/run.invoker` on the function to the principals allowed to start a
-> restoration - a restoration batch-writes over the backup database, so keep
-> that set small. Making it public re-creates the extension's exposure; don't.
+> **`onHttpRunRestoration` requires an authenticated caller.** The kit deploys
+> it with `invoker: "private"`, so the URL rejects anonymous calls with a 403.
+> Callers need `roles/run.invoker` on the function's Cloud Run service and must
+> send an identity token, as in the `curl` above. Grant that role only to the
+> principals allowed to start a restoration - a restoration batch-writes over
+> the backup database, so keep that set small. An operator who truly wants the
+> endpoint public can grant `roles/run.invoker` to `allUsers` on the service
+> after deploy, but that lets anyone on the internet overwrite the backup
+> database; don't.
 
 ## Deploy
 

--- a/kits/firestore-incremental-capture/npm-shrinkwrap.json
+++ b/kits/firestore-incremental-capture/npm-shrinkwrap.json
@@ -19,7 +19,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": ">=22"
+        "node": "22"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/kits/firestore-incremental-capture/package.json
+++ b/kits/firestore-incremental-capture/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": ">=22"
+    "node": "22"
   },
   "scripts": {
     "build": "tsc -b",

--- a/kits/firestore-incremental-capture/src/index.ts
+++ b/kits/firestore-incremental-capture/src/index.ts
@@ -202,15 +202,15 @@ export const syncChangelogTask = onTaskDispatched<ChangelogRow>(
 /**
  * Starts a restoration of the backup database to a point in time.
  *
- * SECURITY: this endpoint is intentionally unauthenticated, matching the
- * firestore-incremental-capture extension it was migrated from. Anyone who can
- * reach the URL can trigger a Dataflow job that batch-writes over the backup
- * database. Restrict it before deploying to production - with Cloud Run ingress
- * settings, an IAM invoker policy, or by fronting it with your own authorized
- * endpoint that enqueues `runRestorationTask` directly.
+ * SECURITY: deployed IAM-gated. `invoker: "private"` is set explicitly rather
+ * than relying on the CLI's default invoker policy, which has been observed to
+ * grant `allUsers` on the deployed Cloud Run service. Callers need
+ * `roles/run.invoker` on the service and must send an identity token; anyone
+ * who can invoke it can trigger a Dataflow job that batch-writes over the
+ * backup database.
  */
 export const onHttpRunRestoration = onRequest(
-  functionOptions,
+  { ...functionOptions, invoker: "private" },
   async (request, response) => {
     const result = await handleRestorationRequest(
       request.body,

--- a/kits/firestore-incremental-capture/tests/index.test.ts
+++ b/kits/firestore-incremental-capture/tests/index.test.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from "vitest";
+import { onHttpRunRestoration } from "../src/index";
+
+test("onHttpRunRestoration deploys with a private invoker", () => {
+  expect(onHttpRunRestoration.__endpoint.httpsTrigger).toMatchObject({
+    invoker: ["private"],
+  });
+});


### PR DESCRIPTION
A live E2E deploy of the firestore-incremental-capture kit granted allUsers roles/run.invoker on the onHttpRunRestoration Cloud Run service: an anonymous POST returned 200 and launched a real Dataflow restoration job that batch-writes over the backup database, while the README and docstring claimed the endpoint rejects anonymous calls. The function now sets invoker: "private" explicitly instead of relying on the CLI's default invoker policy, and the docstring and README are corrected: callers need roles/run.invoker plus an identity token (the README curl shows gcloud auth print-identity-token), with a warned-against path for operators who deliberately open it. The other functions are task or event triggers and are not deployed public. A unit test pins the private invoker via the function's __endpoint manifest.

Also pins engines to "22" - the CLI rejects ">=22" with "Valid versions are 20, 22, 24" (other kits still carry ">=22") - and documents that a non-interactive deploy needs DATAFLOW_REGION in the instance .env, since the CLI only applies param defaults interactively.

All 67 unit tests pass and tsc compiles clean. The private-invoker behavior was confirmed live by removing the allUsers grant on the test deploy (anonymous calls then got 403), but this exact code change has not itself been redeployed.