### PR TITLE
docs(kits/firestore-incremental-capture): add known issues and the invoker change to the changelog

### DIFF
--- a/kits/firestore-incremental-capture/CHANGELOG.md
+++ b/kits/firestore-incremental-capture/CHANGELOG.md
@@ -1,2 +1,10 @@
 - Full implementation, replacing the skeleton package: Firestore capture to a BigQuery changelog, Dataflow-based point-in-time restoration, and first-deploy provisioning. See the README for differences between the legacy extension and this kit.
 - The restoration pipeline is consumed as a pinned, digest-verified release of GoogleCloudPlatform/firebase-extensions (`firestore-incremental-capture-pipeline-v0.1.0`) downloaded by `scripts/setup.sh`; Maven is no longer required.
+- `onHttpRunRestoration` deploys IAM-gated: `invoker: "private"` is set explicitly, so callers need `roles/run.invoker` on the function's Cloud Run service and must send an identity token. The legacy extension deployed this endpoint publicly invocable.
+
+## Known issues
+
+Both are pre-existing in the legacy extension and its pipeline; neither is new in this kit.
+
+- Array fields do not survive restore: scalar arrays restore as arrays of empty maps, and reference, binary and null elements are corrupted or dropped, while the Dataflow job reports success (GoogleCloudPlatform/firebase-extensions#1147).
+- The restoration pipeline's `adjustDate` shifts the restore point by the JVM's timezone offset on a non-UTC JVM. Dataflow workers run UTC, so deployed jobs are unaffected (GoogleCloudPlatform/firebase-extensions#1149).

--- a/kits/firestore-incremental-capture/CHANGELOG.md
+++ b/kits/firestore-incremental-capture/CHANGELOG.md
@@ -1,10 +1,10 @@
 - Full implementation, replacing the skeleton package: Firestore capture to a BigQuery changelog, Dataflow-based point-in-time restoration, and first-deploy provisioning. See the README for differences between the legacy extension and this kit.
 - The restoration pipeline is consumed as a pinned, digest-verified release of GoogleCloudPlatform/firebase-extensions (`firestore-incremental-capture-pipeline-v0.1.0`) downloaded by `scripts/setup.sh`; Maven is no longer required.
-- `onHttpRunRestoration` deploys IAM-gated: `invoker: "private"` is set explicitly, so callers need `roles/run.invoker` on the function's Cloud Run service and must send an identity token. The legacy extension deployed this endpoint publicly invocable.
+- `onHttpRunRestoration` is deployed IAM-gated: `invoker: "private"` is set explicitly, so callers need `roles/run.invoker` on the function's Cloud Run service and must send an identity token. The legacy extension deployed this endpoint publicly invocable.
 
 ## Known issues
 
 Both are pre-existing in the legacy extension and its pipeline; neither is new in this kit.
 
-- Array fields do not survive restore: scalar arrays restore as arrays of empty maps, and reference, binary and null elements are corrupted or dropped, while the Dataflow job reports success (GoogleCloudPlatform/firebase-extensions#1147).
-- The restoration pipeline's `adjustDate` shifts the restore point by the JVM's timezone offset on a non-UTC JVM. Dataflow workers run UTC, so deployed jobs are unaffected (GoogleCloudPlatform/firebase-extensions#1149).
+- Array fields do not survive restore: scalar arrays restore as arrays of empty maps, and reference, binary and null elements are corrupted or dropped, while the Dataflow job reports success ([GoogleCloudPlatform/firebase-extensions#1147](https://github.com/GoogleCloudPlatform/firebase-extensions/issues/1147)).
+- The restoration pipeline's `adjustDate` shifts the restore point by the JVM's timezone offset on a non-UTC JVM. Dataflow workers run UTC, so deployed jobs are unaffected ([GoogleCloudPlatform/firebase-extensions#1149](https://github.com/GoogleCloudPlatform/firebase-extensions/issues/1149)).


### PR DESCRIPTION
The 0.0.2-rc.2 release notes did not disclose the two known restore-path issues or name the endpoint security change. This adds a Known issues section covering GoogleCloudPlatform/firebase-extensions#1147 (array fields silently corrupted on restore - scalar arrays become arrays of empty maps while the Dataflow job reports success) and #1149 (restore point shifts on non-UTC JVMs; Dataflow workers run UTC so deployed jobs are unaffected), noting both are pre-existing in the legacy extension rather than new in the kit. It also adds a bullet for onHttpRunRestoration deploying IAM-gated with invoker: "private", since the legacy extension deployed that endpoint publicly invocable. Docs-only; the published rc.2 GitHub release body will be edited to match.