### PR TITLE
test(kits/firestore-incremental-capture): pin the array element wire format

### DIFF
--- a/kits/firestore-incremental-capture/tests/wire-format.test.ts
+++ b/kits/firestore-incremental-capture/tests/wire-format.test.ts
@@ -195,6 +195,76 @@ describe("changelog wire format", () => {
     });
   });
 
+  test("tags a null array element as 'null'", () => {
+    // Not `{ type: "object" }`: the original extension tagged null elements
+    // with `typeof null`, which the pipeline cannot tell from a map.
+    expect(serializeDocument({ arrayValue: [null] })).toEqual({
+      arrayValue: {
+        type: "array",
+        value: [{ type: "null", value: null }],
+      },
+    });
+  });
+
+  test("tags a Buffer, DocumentReference or Timestamp array element", () => {
+    const timestampValue = Timestamp.fromDate(
+      new Date("2026-01-02T03:04:05.000Z")
+    );
+
+    expect(
+      serializeDocument({
+        arrayValue: [Buffer.from("hi"), ref, timestampValue],
+      })
+    ).toEqual({
+      arrayValue: {
+        type: "array",
+        value: [
+          { type: "binary", value: "aGk=" },
+          { type: "reference", value: "products/abc" },
+          { type: "timestamp", value: "2026-01-02T03:04:05.000Z" },
+        ],
+      },
+    });
+  });
+
+  test("tags a nested array element as 'array'", () => {
+    expect(serializeDocument({ arrayValue: [["a", 1]] })).toEqual({
+      arrayValue: {
+        type: "array",
+        value: [
+          {
+            type: "array",
+            value: [
+              { type: "string", value: "a" },
+              { type: "number", value: 1 },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  test("keeps a map element's own 'type' key distinct from a type tag", () => {
+    // The pipeline reads an element as a tagged value only when its `type` is
+    // a string. A user map's `type` field is serialized to an object, so a map
+    // element carrying `type` and `value` keys stays unambiguous.
+    const serialized = serializeDocument({
+      arrayValue: [{ type: "invoice", value: 10 }],
+    });
+
+    expect(serialized).toEqual({
+      arrayValue: {
+        type: "array",
+        value: [
+          {
+            type: { type: "string", value: "invoice" },
+            value: { type: "number", value: 10 },
+          },
+        ],
+      },
+    });
+  });
+
   test("base64-encodes a Buffer", () => {
     expect(serializeDocument({ binaryValue: Buffer.from("hi") })).toEqual({
       binaryValue: { type: "binary", value: "aGk=" },


### PR DESCRIPTION
The pipeline-side fix for GoogleCloudPlatform/firebase-extensions#1147 (GoogleCloudPlatform/firebase-extensions#1150) tells an array element that is a tagged value from one that is a bare field map by requiring the tag to be a string. These tests pin the element encoding that rule reads: tagged scalars, a null element tagged `null` rather than the legacy `object`, binary, reference and timestamp elements, nested arrays tagged `array`, and a user map element whose own keys are `type` and `value`, which stays unambiguous because its `type` serializes to an object.

Tests only, no behavior change. The kit still pins pipeline release v0.1.0, which lacks the fix, so the known issue documented in the README stands until that pin moves to a release containing it.