### PR TITLE
fix(kits): pin typescript so the release build is reproducible

### DIFF
--- a/kits/bigquery-firestore-export/npm-shrinkwrap.json
+++ b/kits/bigquery-firestore-export/npm-shrinkwrap.json
@@ -17,6 +17,7 @@
         "firebase-functions": "^7.3.2"
       },
       "devDependencies": {
+        "typescript": "^5.9.3",
         "vitest": "^4.1.10"
       },
       "engines": {
@@ -4549,6 +4550,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/kits/bigquery-firestore-export/package.json
+++ b/kits/bigquery-firestore-export/package.json
@@ -40,6 +40,7 @@
     "firebase-functions": "^7.3.2"
   },
   "devDependencies": {
+    "typescript": "^5.9.3",
     "vitest": "^4.1.10"
   },
   "overrides": {

--- a/kits/delete-user-data/npm-shrinkwrap.json
+++ b/kits/delete-user-data/npm-shrinkwrap.json
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@types/lodash.chunk": "^4.2.7",
         "@types/node-fetch": "^2.6.2",
+        "typescript": "^5.9.3",
         "vitest": "^4.1.10"
       },
       "engines": {
@@ -3790,6 +3791,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/kits/delete-user-data/package.json
+++ b/kits/delete-user-data/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@types/lodash.chunk": "^4.2.7",
     "@types/node-fetch": "^2.6.2",
+    "typescript": "^5.9.3",
     "vitest": "^4.1.10"
   }
 }

--- a/kits/firestore-bigquery-export/npm-shrinkwrap.json
+++ b/kits/firestore-bigquery-export/npm-shrinkwrap.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@types/lodash": "^4.17.0",
+        "typescript": "^5.9.3",
         "vitest": "^3.2.4"
       },
       "engines": {
@@ -5734,6 +5735,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/kits/firestore-bigquery-export/package.json
+++ b/kits/firestore-bigquery-export/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.17.0",
+    "typescript": "^5.9.3",
     "vitest": "^3.2.4"
   }
 }

--- a/kits/firestore-bundle-builder/npm-shrinkwrap.json
+++ b/kits/firestore-bundle-builder/npm-shrinkwrap.json
@@ -15,6 +15,7 @@
         "firebase-functions": "^7.3.2"
       },
       "devDependencies": {
+        "typescript": "^5.9.3",
         "vitest": "^4.1.10"
       },
       "engines": {
@@ -3625,6 +3626,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/kits/firestore-bundle-builder/package.json
+++ b/kits/firestore-bundle-builder/package.json
@@ -37,6 +37,7 @@
     "firebase-functions": "^7.3.2"
   },
   "devDependencies": {
+    "typescript": "^5.9.3",
     "vitest": "^4.1.10"
   }
 }

--- a/kits/firestore-counter/npm-shrinkwrap.json
+++ b/kits/firestore-counter/npm-shrinkwrap.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@types/deep-equal": "^1.0.1",
+        "typescript": "^5.9.3",
         "vitest": "^4.1.10"
       },
       "engines": {
@@ -4465,6 +4466,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/kits/firestore-counter/package.json
+++ b/kits/firestore-counter/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@types/deep-equal": "^1.0.1",
+    "typescript": "^5.9.3",
     "vitest": "^4.1.10"
   }
 }

--- a/kits/firestore-genai-chatbot/npm-shrinkwrap.json
+++ b/kits/firestore-genai-chatbot/npm-shrinkwrap.json
@@ -20,6 +20,7 @@
         "zod": "^3.23.0"
       },
       "devDependencies": {
+        "typescript": "^5.9.3",
         "vitest": "^4.1.10"
       },
       "engines": {
@@ -7450,6 +7451,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uglify-js": {

--- a/kits/firestore-genai-chatbot/package.json
+++ b/kits/firestore-genai-chatbot/package.json
@@ -42,6 +42,7 @@
     "zod": "^3.23.0"
   },
   "devDependencies": {
+    "typescript": "^5.9.3",
     "vitest": "^4.1.10"
   }
 }

--- a/kits/firestore-incremental-capture/npm-shrinkwrap.json
+++ b/kits/firestore-incremental-capture/npm-shrinkwrap.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@types/node": "^26.2.0",
+        "typescript": "^5.9.3",
         "vitest": "^3.2.4"
       },
       "engines": {
@@ -4681,6 +4682,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/kits/firestore-incremental-capture/package.json
+++ b/kits/firestore-incremental-capture/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@types/node": "^26.2.0",
+    "typescript": "^5.9.3",
     "vitest": "^3.2.4"
   }
 }

--- a/kits/firestore-send-email/npm-shrinkwrap.json
+++ b/kits/firestore-send-email/npm-shrinkwrap.json
@@ -17,6 +17,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
+        "typescript": "^5.9.3",
         "vitest": "^4.1.10"
       },
       "engines": {
@@ -4439,6 +4440,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uglify-js": {

--- a/kits/firestore-send-email/package.json
+++ b/kits/firestore-send-email/package.json
@@ -39,6 +39,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "typescript": "^5.9.3",
     "vitest": "^4.1.10"
   }
 }

--- a/kits/firestore-send-email/src/nodemailer-sendgrid/index.ts
+++ b/kits/firestore-send-email/src/nodemailer-sendgrid/index.ts
@@ -165,7 +165,7 @@ export class SendGridTransport {
       }
 
       sgMail
-        .send(msg as sgMail.MailDataRequired)
+        .send(msg as Parameters<typeof sgMail.send>[0])
         .then(([response]) => {
           const rawQueueId = (response.headers["x-message-id"] ||
             response.headers["X-Message-Id"]) as string | undefined;

--- a/kits/firestore-translate-text/npm-shrinkwrap.json
+++ b/kits/firestore-translate-text/npm-shrinkwrap.json
@@ -16,6 +16,7 @@
         "genkit": "^1.31.0"
       },
       "devDependencies": {
+        "typescript": "^5.9.3",
         "vitest": "^4.1.10"
       },
       "engines": {
@@ -7735,6 +7736,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uglify-js": {

--- a/kits/firestore-translate-text/package.json
+++ b/kits/firestore-translate-text/package.json
@@ -38,6 +38,7 @@
     "genkit": "^1.31.0"
   },
   "devDependencies": {
+    "typescript": "^5.9.3",
     "vitest": "^4.1.10"
   }
 }

--- a/kits/firestore-vector-search/npm-shrinkwrap.json
+++ b/kits/firestore-vector-search/npm-shrinkwrap.json
@@ -19,6 +19,7 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
+        "typescript": "^5.9.3",
         "vitest": "^4.1.10"
       },
       "engines": {
@@ -7840,6 +7841,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uglify-js": {

--- a/kits/firestore-vector-search/package.json
+++ b/kits/firestore-vector-search/package.json
@@ -41,6 +41,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "typescript": "^5.9.3",
     "vitest": "^4.1.10"
   }
 }

--- a/kits/rtdb-limit-child-nodes/npm-shrinkwrap.json
+++ b/kits/rtdb-limit-child-nodes/npm-shrinkwrap.json
@@ -13,6 +13,7 @@
         "firebase-functions": "^7.3.2"
       },
       "devDependencies": {
+        "typescript": "^5.9.3",
         "vitest": "^4.1.10"
       },
       "engines": {
@@ -4206,6 +4207,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/kits/rtdb-limit-child-nodes/package.json
+++ b/kits/rtdb-limit-child-nodes/package.json
@@ -35,6 +35,7 @@
     "firebase-functions": "^7.3.2"
   },
   "devDependencies": {
+    "typescript": "^5.9.3",
     "vitest": "^4.1.10"
   }
 }

--- a/kits/speech-to-text/npm-shrinkwrap.json
+++ b/kits/speech-to-text/npm-shrinkwrap.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@types/fluent-ffmpeg": "^2.1.27",
+        "typescript": "^5.9.3",
         "vitest": "^4.1.10"
       },
       "engines": {
@@ -4252,6 +4253,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/kits/speech-to-text/package.json
+++ b/kits/speech-to-text/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@types/fluent-ffmpeg": "^2.1.27",
+    "typescript": "^5.9.3",
     "vitest": "^4.1.10"
   }
 }

--- a/kits/storage-resize-images/npm-shrinkwrap.json
+++ b/kits/storage-resize-images/npm-shrinkwrap.json
@@ -20,6 +20,7 @@
         "uuid": "^11.0.5"
       },
       "devDependencies": {
+        "typescript": "^5.9.3",
         "vitest": "^4.1.10"
       },
       "engines": {
@@ -8490,6 +8491,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uglify-js": {

--- a/kits/storage-resize-images/package.json
+++ b/kits/storage-resize-images/package.json
@@ -42,6 +42,7 @@
     "uuid": "^11.0.5"
   },
   "devDependencies": {
+    "typescript": "^5.9.3",
     "vitest": "^4.1.10"
   }
 }


### PR DESCRIPTION
Fixes #2999.

No kit declares `typescript`, but every kit builds with `tsc -b`. With nothing in `node_modules`, npm falls through to the `tsc` preinstalled on the GitHub runner image, which the image installs unpinned. That has rolled over to TypeScript 7, which rejects `msg as sgMail.MailDataRequired`: `@sendgrid/mail` exports a value, not a namespace, so using the import in type position was never valid and TypeScript 5 just tolerated it. The test job passed because vitest does not typecheck.

### Fix

Pin `typescript@^5.9.3` in all 13 kits, and derive the SendGrid argument type from the function instead of the import.

### Testing

Holding `node_modules` fixed and varying only the compiler, 5.0.4 to 5.9.3 and 6.0.0-beta compile clean and 7.0.2 reproduces the CI error at the exact line and column. After the change all 13 kits `npm ci` and `npm run build` against the pinned 5.9.3, and the firestore-send-email suite passes.