### PR TITLE
fix(storage-resize-images): failed resize can delete the original image

### DIFF
--- a/kits/storage-resize-images/src/handlers.ts
+++ b/kits/storage-resize-images/src/handlers.ts
@@ -153,10 +153,12 @@ export async function generateResizedImageHandler(
         },
       });
 
-      resizeFailed = resizeResults.some(
-        (result) =>
-          result.status === "rejected" || result.value.success === false
-      );
+      resizeFailed =
+        resizeResults.length === 0 ||
+        resizeResults.some(
+          (result) =>
+            result.status === "rejected" || result.value.success === false
+        );
     }
 
     const failed = filterErrored || resizeFailed;

--- a/kits/storage-resize-images/tests/handlers.test.ts
+++ b/kits/storage-resize-images/tests/handlers.test.ts
@@ -310,6 +310,29 @@ describe("generateResizedImageHandler", () => {
     expect(handleFailedImage).toHaveBeenCalledTimes(1);
   });
 
+  test("treats zero resize outputs as a failure", async () => {
+    const ctx = makeCtx();
+    mock(resizeImages).mockResolvedValue([]);
+
+    await generateResizedImageHandler(mockObject, ctx, false);
+
+    expect(logs.failed).toHaveBeenCalled();
+    expect(handleFailedImage).toHaveBeenCalledTimes(1);
+  });
+
+  test("keeps the original under on_success when no resize was produced", async () => {
+    mock(downloadOriginalFile).mockResolvedValue([
+      "/tmp/test.jpg",
+      { delete: vi.fn() },
+    ]);
+    mock(resizeImages).mockResolvedValue([]);
+    const ctx = makeCtx({ deleteOriginalFile: DELETE_IMAGE.onSuccess });
+
+    await generateResizedImageHandler(mockObject, ctx, false);
+
+    expect(deleteRemoteFile).not.toHaveBeenCalled();
+  });
+
   test("deletes the original only after a successful run under on_success", async () => {
     const remoteFile = { delete: vi.fn() };
     mock(downloadOriginalFile).mockResolvedValue(["/tmp/test.jpg", remoteFile]);


### PR DESCRIPTION
In the kit, an empty `imageTypes` (or empty `sizes`) yields zero resize tasks, `resizeResults.some(...)` is false, and the run counts as success, so under `deleteOriginal: on_success` the original is deleted with nothing produced. The legacy extension avoided this through param validation (`IMAGE_TYPE` is `required: true` in extension.yaml, unset `IMG_SIZES` crashed at module load), not in code: an unset `IMAGE_TYPE` reaching its handler would hit the same zero-task deletion, and an empty-string type actually resizes successfully. Kits have no such install-time gate, so the handler must guard.

The fix treats zero resize outputs as a failed run in `generateResizedImageHandler`: `logs.failed()` fires, `handleFailedImage` runs (a no-op without `failedImagesPath`), and deletion only happens when at least one resize actually succeeded. No config-time validation was added, keeping clear of #3002's config changes.

Two new vitest cases pin the behavior; the kit's full suite passes (179 passed, 3 skipped). No live Storage E2E was run.

Fixes #3007