### PR TITLE
chore(firestore-bigquery-export): drop unused config parameter from logs.start

### DIFF
--- a/kits/firestore-bigquery-export/src/logs.ts
+++ b/kits/firestore-bigquery-export/src/logs.ts
@@ -180,8 +180,8 @@ export const init = (config?: unknown) => {
   logger.info("Initializing with configuration", config);
 };
 
-export const start = (config?: unknown) => {
-  logger.info("Started execution with configuration", config);
+export const start = () => {
+  logger.info("Started execution of extension");
 };
 
 export const timestampMissingValue = (fieldName: string) => {


### PR DESCRIPTION
logs.start() declared an optional config parameter but the only call site (handlers.ts handleDocumentWrite) passes nothing, so every invocation logged "Started execution with configuration undefined". The kit logs the full config once at startup via logs.init(config), so per-invocation config logging is intentionally gone; this drops the unused parameter and rewords the message to "Started execution of extension", matching the plain style of complete(). No test added: the kit's existing tests do not assert on log helper output, and this is pure log-text cleanup. tsc, prettier, and the kit's full vitest suite (45 tests) pass; not verified against a live deployment. Part of #3036.