### PR TITLE
fix(firestore-send-email): restore the invalid_string branch in formatZodError

### DIFF
--- a/kits/firestore-send-email/src/validation.ts
+++ b/kits/firestore-send-email/src/validation.ts
@@ -134,7 +134,13 @@ const payloadSchema = z
       "Email configuration must include either a 'message', 'template', or 'sendGrid' object",
   });
 
-function formatZodError(
+/**
+ * Formats a Zod validation error into the extension's human-readable message.
+ * @param error - The Zod error to format
+ * @param context - The context or field name where the error occurred
+ * @returns A formatted error message string
+ */
+export function formatZodError(
   error: z.ZodError,
   context = "email configuration"
 ): string {
@@ -148,6 +154,10 @@ function formatZodError(
           return `Field '${path}' must be an array`;
         if (issue.expected === "object") return `Field '${path}' must be a map`;
         return `Field '${path}' must be ${issue.expected}`;
+      case "invalid_string":
+        if (issue.validation === "email")
+          return `Field '${path}' must be a valid email address`;
+        return `Field '${path}' is invalid`;
       case "too_small":
         return issue.minimum === 1
           ? `Field '${path}' cannot be empty`

--- a/kits/firestore-send-email/tests/validation.test.ts
+++ b/kits/firestore-send-email/tests/validation.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+import { formatZodError } from "../src/validation";
+
+function zodErrorFrom(schema: z.ZodSchema, value: unknown): z.ZodError {
+  const result = schema.safeParse(value);
+  if (result.success) {
+    throw new Error("expected schema to reject value");
+  }
+  return result.error;
+}
+
+describe("formatZodError", () => {
+  test("formats invalid_string email issues as a valid email address error", () => {
+    const error = zodErrorFrom(z.object({ replyTo: z.string().email() }), {
+      replyTo: "not-an-email",
+    });
+    expect(formatZodError(error)).toBe(
+      "Invalid email configuration: Field 'replyTo' must be a valid email address"
+    );
+  });
+
+  test("formats other invalid_string issues as an invalid field error", () => {
+    const error = zodErrorFrom(z.object({ href: z.string().url() }), {
+      href: "not-a-url",
+    });
+    expect(formatZodError(error)).toBe(
+      "Invalid email configuration: Field 'href' is invalid"
+    );
+  });
+});


### PR DESCRIPTION
The kit's formatZodError dropped the invalid_string branch the legacy extension has, so string-validation failures (e.g. a failed .email() check) fell through to zod's raw default message instead of the extension's "Field 'x' must be a valid email address" / "Field 'x' is invalid" shape. This restores the branch; the kit pins zod ^3.25.76 (same major as the extension's ^3.24.4), so the issue code and its validation field carry over unchanged. formatZodError is now exported so the new vitest tests can drive it with real zod errors; note the kit's current schemas do not yet use string validators, so this path is only reachable if a schema adds one, matching the extension's defensive intent. Full kit suite, tsc, and prettier pass; no live/e2e run.

Part of #3036.