### PR TITLE
chore(delete-user-data): replace node-fetch with the Node global fetch

### DIFF
--- a/kits/delete-user-data/npm-shrinkwrap.json
+++ b/kits/delete-user-data/npm-shrinkwrap.json
@@ -12,12 +12,10 @@
         "@google-cloud/pubsub": "^4.3.3",
         "firebase-admin": "^13.2.0",
         "firebase-functions": "^7.3.2",
-        "lodash.chunk": "^4.2.0",
-        "node-fetch": "^2.6.2"
+        "lodash.chunk": "^4.2.0"
       },
       "devDependencies": {
         "@types/lodash.chunk": "^4.2.7",
-        "@types/node-fetch": "^2.6.2",
         "typescript": "^5.9.3",
         "vitest": "^4.1.10"
       },
@@ -849,17 +847,6 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/qs": {
@@ -1928,46 +1915,6 @@
         "graphql": {
           "optional": true
         }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.4",
-        "mime-types": "^2.1.35"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/form-data/node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/formdata-polyfill": {

--- a/kits/delete-user-data/package.json
+++ b/kits/delete-user-data/package.json
@@ -34,12 +34,10 @@
     "@google-cloud/pubsub": "^4.3.3",
     "firebase-admin": "^13.2.0",
     "firebase-functions": "^7.3.2",
-    "lodash.chunk": "^4.2.0",
-    "node-fetch": "^2.6.2"
+    "lodash.chunk": "^4.2.0"
   },
   "devDependencies": {
     "@types/lodash.chunk": "^4.2.7",
-    "@types/node-fetch": "^2.6.2",
     "typescript": "^5.9.3",
     "vitest": "^4.1.10"
   }

--- a/kits/delete-user-data/src/runCustomSearchFunction.ts
+++ b/kits/delete-user-data/src/runCustomSearchFunction.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import fetch from "node-fetch";
 import * as logs from "./logs";
 import type { PublisherContext } from "./runBatchPubSubDeletions";
 import { runBatchPubSubDeletions } from "./runBatchPubSubDeletions";

--- a/kits/delete-user-data/tests/handlers.test.ts
+++ b/kits/delete-user-data/tests/handlers.test.ts
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => ({ fetch: vi.fn() }));
 
 vi.mock("../src/logs");
 vi.mock("../src/events");
-vi.mock("node-fetch", () => ({ default: mocks.fetch }));
+vi.stubGlobal("fetch", mocks.fetch);
 
 import * as events from "../src/events";
 import { handleClear, handleDeletion, handleSearch } from "../src/handlers";

--- a/kits/delete-user-data/tests/runCustomSearchFunction.test.ts
+++ b/kits/delete-user-data/tests/runCustomSearchFunction.test.ts
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => ({ fetch: vi.fn() }));
 
 vi.mock("../src/logs");
 vi.mock("../src/events");
-vi.mock("node-fetch", () => ({ default: mocks.fetch }));
+vi.stubGlobal("fetch", mocks.fetch);
 
 import * as logs from "../src/logs";
 import { runCustomSearchFunction } from "../src/runCustomSearchFunction";


### PR DESCRIPTION
Drops the node-fetch@2 dependency from the delete-user-data kit in favor of the Node built-in global fetch (the kit's engine is Node >=22), matching the legacy extension. Removes the import, the node-fetch and @types/node-fetch entries from package.json, and regenerates npm-shrinkwrap.json via npm (removals only); the tests that mocked the node-fetch module now stub the global with vi.stubGlobal. The call site only uses response.ok/text()/json(), so no node-fetch-specific behavior (streams, agents, FetchError) needed handling. Two known semantic deltas, both benign here: a network failure now rejects with a TypeError instead of node-fetch's FetchError (nothing inspects the error class), and undici rejects a searchFunction URL with embedded credentials up front with a TypeError where node-fetch would have sent the request (spec-correct, and not a supported configuration). Rebased onto kits after #3060; full suite is green (98 tests), tsc and prettier clean. Part of #3036.