### PR TITLE
fix(firestore-vector-search): reject non-JSON responses from the custom embeddings endpoint

### DIFF
--- a/kits/firestore-vector-search/src/embeddings/client/text/custom_function.ts
+++ b/kits/firestore-vector-search/src/embeddings/client/text/custom_function.ts
@@ -57,12 +57,18 @@ export class CustomEndpointClient extends BaseEmbedClient {
     }
 
     const data = await response.json();
-    const parsed = z
-      .object({ embeddings: z.array(z.array(z.number())) })
-      .parse(data);
+    const schema = z.object({ embeddings: z.array(z.array(z.number())) });
+    let parsed: z.infer<typeof schema>;
+    try {
+      parsed = schema.parse(data);
+    } catch {
+      throw new Error(
+        "Error getting embeddings from custom endpoint: response does not match expected schema"
+      );
+    }
     if (parsed.embeddings.length !== inputs.length) {
       throw new Error(
-        "Error getting embeddings from custom endpoint: response does not contain embeddings for all inputs"
+        "Error getting embeddings from custom endpoint: response does not contain embeddings"
       );
     }
     return parsed.embeddings;

--- a/kits/firestore-vector-search/src/embeddings/client/text/custom_function.ts
+++ b/kits/firestore-vector-search/src/embeddings/client/text/custom_function.ts
@@ -50,6 +50,12 @@ export class CustomEndpointClient extends BaseEmbedClient {
       );
     }
 
+    if (!response.headers.get("content-type")?.includes("application/json")) {
+      throw new Error(
+        "Error getting embeddings from custom endpoint: response is not JSON"
+      );
+    }
+
     const data = await response.json();
     const parsed = z
       .object({ embeddings: z.array(z.array(z.number())) })

--- a/kits/firestore-vector-search/tests/embeddings.test.ts
+++ b/kits/firestore-vector-search/tests/embeddings.test.ts
@@ -206,6 +206,40 @@ describe("CustomEndpointClient", () => {
     await expect(client.getEmbeddings(["input"])).resolves.toEqual([[1, 2, 3]]);
   });
 
+  test("throws a clear error when the JSON does not match the expected schema", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ foo: "bar" }), {
+            headers: { "content-type": "application/json" },
+          })
+      )
+    );
+
+    const client = new CustomEndpointClient(customConfig());
+    await expect(client.getEmbeddings(["input"])).rejects.toThrow(
+      "Error getting embeddings from custom endpoint: response does not match expected schema"
+    );
+  });
+
+  test("throws a clear error when embeddings are missing for some inputs", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ embeddings: [[1, 2, 3]] }), {
+            headers: { "content-type": "application/json" },
+          })
+      )
+    );
+
+    const client = new CustomEndpointClient(customConfig());
+    await expect(client.getEmbeddings(["input1", "input2"])).rejects.toThrow(
+      /Error getting embeddings from custom endpoint: response does not contain embeddings$/
+    );
+  });
+
   test("throws a clear error when the response is not JSON", async () => {
     vi.stubGlobal(
       "fetch",

--- a/kits/firestore-vector-search/tests/embeddings.test.ts
+++ b/kits/firestore-vector-search/tests/embeddings.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const { embedMany } = vi.hoisted(() => ({ embedMany: vi.fn() }));
 
@@ -35,6 +35,7 @@ import { googleAI, vertexAI } from "@genkit-ai/google-genai";
 import { genkit } from "genkit";
 
 import { GenkitEmbedClient } from "../src/embeddings/client/genkit";
+import { CustomEndpointClient } from "../src/embeddings/client/text/custom_function";
 import {
   type ResolvedVectorSearchConfig,
   resolveVectorSearchConfig,
@@ -174,5 +175,51 @@ describe("GenkitEmbedClient", () => {
         "Embedding failed"
       );
     });
+  });
+});
+
+describe("CustomEndpointClient", () => {
+  const customConfig = () =>
+    config({
+      embeddingProvider: "custom",
+      customEmbeddingsEndpoint: "https://example.com/embed",
+      customEmbeddingsBatchSize: 2,
+      customEmbeddingsDimension: 3,
+    });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("returns embeddings from a JSON response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify({ embeddings: [[1, 2, 3]] }), {
+            headers: { "content-type": "application/json; charset=utf-8" },
+          })
+      )
+    );
+
+    const client = new CustomEndpointClient(customConfig());
+    await expect(client.getEmbeddings(["input"])).resolves.toEqual([[1, 2, 3]]);
+  });
+
+  test("throws a clear error when the response is not JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response("<html>ok</html>", {
+            headers: { "content-type": "text/html" },
+          })
+      )
+    );
+
+    const client = new CustomEndpointClient(customConfig());
+    await expect(client.getEmbeddings(["input"])).rejects.toThrow(
+      "Error getting embeddings from custom endpoint: response is not JSON"
+    );
   });
 });


### PR DESCRIPTION
The legacy extension (firestore-vector-search v0.1.3) checked the custom embeddings endpoint's content-type header and rejected non-JSON responses with a clear error; the kit dropped that check, so a non-JSON response (for example an HTML error page) surfaced as a raw `Unexpected token` parse error. This restores the check in `CustomEndpointClient.getEmbeddings`, throwing "Error getting embeddings from custom endpoint: response is not JSON" before parsing, matching the legacy wording. Following review, it also restores two more legacy behaviors in the same method: the schema parse is wrapped so valid JSON of the wrong shape throws "Error getting embeddings from custom endpoint: response does not match expected schema" instead of a raw ZodError, and the length-mismatch message reverts to legacy's exact "response does not contain embeddings" wording. Adds four vitest cases (JSON success with charset parameter, non-JSON content-type, wrong-shape JSON, missing embeddings) - each failing case was written and verified red before its fix. Full kit suite passes (53 tests) and `tsc -b` is clean; note `npx prettier --check src` already fails on origin/kits because prettier 2.7.1 cannot parse `satisfies` in `src/config.ts` (pre-existing, untouched). Part of #3036.