### PR TITLE
chore(firestore-translate-text): delete dead backfill remnants from the kit

### DIFF
--- a/kits/firestore-translate-text/src/logs/index.ts
+++ b/kits/firestore-translate-text/src/logs/index.ts
@@ -29,14 +29,6 @@ export const documentCreatedWithInput = () => {
   logger.log(messages.documentCreatedWithInput());
 };
 
-export const documentFoundWithInput = () => {
-  logger.log(messages.documentFoundWithInput());
-};
-
-export const documentFoundNoInput = () => {
-  logger.log(messages.documentFoundNoInput());
-};
-
 export const documentDeleted = () => {
   logger.log(messages.documentDeleted());
 };
@@ -77,10 +69,6 @@ export const start = (config) => {
   logger.log(...messages.start(config));
 };
 
-export const translateInputString = (string: string, language: string) => {
-  logger.log(messages.translateInputString(string, language));
-};
-
 export const translateStringComplete = (
   string: string,
   language: string,
@@ -110,14 +98,6 @@ export const translateInputToAllLanguagesComplete = (string: string) => {
   logger.log(messages.translateInputToAllLanguagesComplete(string));
 };
 
-export const partialTranslateError = (
-  input: string,
-  reasons: string[],
-  numLanguages: number
-) => {
-  logger.error(messages.partialTranslateError(input, reasons, numLanguages));
-};
-
 export const translateInputToAllLanguagesError = (
   string: string,
   err: Error
@@ -131,16 +111,4 @@ export const updateDocument = (path: string) => {
 
 export const updateDocumentComplete = (path: string) => {
   logger.log(messages.updateDocumentComplete(path));
-};
-
-export const backfillComplete = (successCount: number, errorCount: number) => {
-  logger.log(messages.backfillComplete(successCount, errorCount));
-};
-
-export const skippingLanguage = (language: string) => {
-  logger.log(messages.skippingLanguage(language));
-};
-
-export const enqueueNext = (offset: number) => {
-  logger.log(messages.enqueueNext(offset));
 };

--- a/kits/firestore-translate-text/src/logs/messages.ts
+++ b/kits/firestore-translate-text/src/logs/messages.ts
@@ -15,15 +15,10 @@
  */
 
 export const messages = {
-  backfillComplete: (successCount: number, errorCount: number) =>
-    `Finshed backfilling translations. ${successCount} translations succeeded, ${errorCount} errors.`,
   complete: () => "Completed execution of extension",
   documentCreatedNoInput: () =>
     "Document was created without an input string, no processing is required",
   documentCreatedWithInput: () => "Document was created with an input string",
-  documentFoundWithInput: () => "Backfill found document with an input string",
-  documentFoundNoInput: () =>
-    "Backfill found document without an input string, no processing is required",
   documentDeleted: () => "Document was deleted, no processing is required",
   documentUpdatedChangedInput: () =>
     "Document was updated, input string has changed",
@@ -34,8 +29,6 @@ export const messages = {
   documentUpdatedUnchangedInput: () =>
     "Document was updated, input string has not changed, no processing is required",
   error: (err: Error) => ["Failed execution of extension", err],
-  enqueueNext: (offset: number) =>
-    `About to enqueue next task, starting at offset ${offset}`,
   fieldNamesNotDifferent: () =>
     "The `Input` and `Output` field names must be different for this extension to function correctly",
   init: (config = {}) => [
@@ -44,20 +37,10 @@ export const messages = {
   ],
   inputFieldNameIsOutputPath: () =>
     "The `Input` field name must not be the same as an `Output` path for this extension to function correctly",
-  partialTranslateError: (input: string, reasons: string[], numLanguages) =>
-    `Failed to translate ${input} to ${
-      reasons.length
-    } languages of the requested ${numLanguages}. Reasons: ${reasons.join(
-      "\n"
-    )}`,
-  skippingLanguage: (lang: string) =>
-    `Found existing translation to ${lang}, skipping.`,
   start: (config = {}) => [
     "Started execution of extension with configuration",
     config,
   ],
-  translateInputString: (string: string, language: string) =>
-    `Translating string: '${string}' into language(s): '${language}'`,
   translateStringComplete: (
     string: string,
     language: string,

--- a/kits/firestore-translate-text/src/translate/common.ts
+++ b/kits/firestore-translate-text/src/translate/common.ts
@@ -146,18 +146,6 @@ export class TranslationService {
     );
   }
 
-  filterLanguagesFn(
-    existingTranslations: Record<string, unknown>
-  ): (targetLanguage: string) => boolean {
-    return (targetLanguage: string) => {
-      if (existingTranslations[targetLanguage] !== undefined) {
-        logs.skippingLanguage(targetLanguage);
-        return false;
-      }
-      return true;
-    };
-  }
-
   async updateTranslations(
     snapshot: DocumentSnapshot,
     translations: unknown

--- a/kits/firestore-translate-text/tests/translation-service.test.ts
+++ b/kits/firestore-translate-text/tests/translation-service.test.ts
@@ -227,14 +227,6 @@ describe("TranslationService", () => {
     );
   });
 
-  test("filters out languages that already have a translation", () => {
-    const { service } = build();
-    const filter = service.filterLanguagesFn({ en: "hello" });
-
-    expect(defaultLanguages.filter(filter)).toEqual(["es", "de", "fr"]);
-    expect(logger.log).toHaveBeenCalledWith(messages.skippingLanguage("en"));
-  });
-
   test("writes translations in a transaction and records success", async () => {
     const { firestore, service } = build();
     const snapshot = makeSnapshot({ input: "hello" });


### PR DESCRIPTION
Deletes dead code left over from the extension's backfill feature, which the kit does not have (the backfill redesign is tracked in #3032): the unused TranslationService.filterLanguagesFn method, the log helpers with no call sites (backfillComplete, documentFoundWithInput, documentFoundNoInput, enqueueNext, partialTranslateError, skippingLanguage, translateInputString), their messages entries, and the test that exercised filterLanguagesFn directly. Pure deletion, 69 lines, no behavior change; suite green before and after (90 tests down to 89, the removed one only covered filterLanguagesFn), tsc and prettier clean. One caveat: TranslationService is exported via the public ./lib surface, so removing filterLanguagesFn narrows that class's public shape, but the method had no callers anywhere in the kit src or tests and only made sense for backfill. Part of #3036.