### PR TITLE
fix(storage-resize-images): reject BLOCK_NONE and treat empty Cache-Control as unset

### DIFF
--- a/kits/storage-resize-images/src/export-config.ts
+++ b/kits/storage-resize-images/src/export-config.ts
@@ -22,7 +22,7 @@ export type SafetyThreshold =
   | "BLOCK_ONLY_HIGH"
   | "BLOCK_NONE";
 
-export type ContentFilterLevel = SafetyThreshold | "OFF";
+export type ContentFilterLevel = Exclude<SafetyThreshold, "BLOCK_NONE"> | "OFF";
 export type DeleteOriginalFile = "true" | "false" | "on_success";
 
 export const DELETE_IMAGE = {
@@ -93,7 +93,6 @@ const HARM_BLOCK_THRESHOLD_MAP = {
   BLOCK_LOW_AND_ABOVE: "BLOCK_LOW_AND_ABOVE",
   BLOCK_MEDIUM_AND_ABOVE: "BLOCK_MEDIUM_AND_ABOVE",
   BLOCK_ONLY_HIGH: "BLOCK_ONLY_HIGH",
-  BLOCK_NONE: "BLOCK_NONE",
   OFF: null,
 } as const satisfies Record<ContentFilterLevel, SafetyThreshold | null>;
 

--- a/kits/storage-resize-images/src/resize-image.ts
+++ b/kits/storage-resize-images/src/resize-image.ts
@@ -198,7 +198,7 @@ export const constructMetadata = (
   const customMetadata = metadata.metadata as Record<string, string>;
   customMetadata.resizedImage = "true";
   metadata.cacheControl =
-    config.cacheControlHeader ?? objectMetadata.cacheControl;
+    config.cacheControlHeader || objectMetadata.cacheControl;
 
   if (config.regenerateToken && customMetadata.firebaseStorageDownloadTokens) {
     customMetadata.firebaseStorageDownloadTokens = uuidv4();

--- a/kits/storage-resize-images/tests/export-config.test.ts
+++ b/kits/storage-resize-images/tests/export-config.test.ts
@@ -205,11 +205,21 @@ describe("convertHarmBlockThreshold", () => {
       "BLOCK_LOW_AND_ABOVE",
       "BLOCK_MEDIUM_AND_ABOVE",
       "BLOCK_ONLY_HIGH",
-      // The extension has no BLOCK_NONE entry and throws for it.
-      "BLOCK_NONE",
     ] as const) {
       expect(convertHarmBlockThreshold(level)).toBe(level);
     }
+  });
+
+  test("rejects BLOCK_NONE like the extension", () => {
+    expect(() => convertHarmBlockThreshold("BLOCK_NONE" as never)).toThrow(
+      "Invalid HarmBlockThreshold: BLOCK_NONE"
+    );
+    expect(() =>
+      resolveResizeImagesConfig({
+        ...baseConfig,
+        contentFilterLevel: "BLOCK_NONE" as never,
+      })
+    ).toThrow("Invalid HarmBlockThreshold: BLOCK_NONE");
   });
 
   test("an unset level disables filtering", () => {

--- a/kits/storage-resize-images/tests/resize-image.test.ts
+++ b/kits/storage-resize-images/tests/resize-image.test.ts
@@ -198,6 +198,17 @@ describe("constructMetadata", () => {
     expect(metadata.cacheControl).toBe("max-age=60");
   });
 
+  test("treats an empty cacheControlHeader as unset", () => {
+    const metadata = constructMetadata(
+      "test_200x200.png",
+      "image/png",
+      { ...objectMetadata, cacheControl: "max-age=60" },
+      makeConfig({ cacheControlHeader: "" })
+    );
+
+    expect(metadata.cacheControl).toBe("max-age=60");
+  });
+
   test("regenerates an existing download token", () => {
     const metadata = constructMetadata(
       "test_200x200.png",


### PR DESCRIPTION
Two parity fixes for the storage-resize-images kit against the legacy extension (parity ledger items 4 and 7). First, the kit's HARM_BLOCK_THRESHOLD_MAP had a BLOCK_NONE entry, so convertHarmBlockThreshold accepted BLOCK_NONE as a configured filter level; the extension's map has no such entry and throws "Invalid HarmBlockThreshold: BLOCK_NONE", and the kit now does the same (BLOCK_NONE remains in SafetyThreshold, which the internal filter still uses when a null level plus a custom prompt resolves to BLOCK_NONE). Second, constructMetadata used ?? for cacheControlHeader, so an empty string was set literally as the Cache-Control header on resized uploads; it now uses the extension's truthiness check and falls back to the original object's Cache-Control. Both fixes were reproduced with failing unit tests first; the full kit suite passes (181 passed, 3 skipped - the skipped ones are the live/emulator integration tests, which I did not run). Part of #3036.