### PR TITLE
chore(bigquery-firestore-export): restore dropped log helper and MAX_STALENESS doc example

### DIFF
--- a/kits/bigquery-firestore-export/src/helper.ts
+++ b/kits/bigquery-firestore-export/src/helper.ts
@@ -227,6 +227,7 @@ export async function writeRunResultsToFirestore(
     message.json.destinationDatasetId,
     tableName
   );
+  logs.writeRunResultsToFirestore(runId);
   const collection = db.collection(
     `${config.firestoreCollection}/${transferConfigId}/runs/${runId}/output`
   );

--- a/kits/bigquery-firestore-export/src/logs.ts
+++ b/kits/bigquery-firestore-export/src/logs.ts
@@ -70,6 +70,10 @@ export function bigqueryQueryFailed(
   });
 }
 
+export function writeRunResultsToFirestore(runId: string): void {
+  logger.debug("Writing BigQuery results to Firestore", { runId });
+}
+
 export function runResultsWrittenToFirestore(
   runId: string,
   successCount: number,

--- a/kits/bigquery-firestore-export/tests/helper.test.ts
+++ b/kits/bigquery-firestore-export/tests/helper.test.ts
@@ -14,14 +14,21 @@
  * limitations under the License.
  */
 
-import { Geography } from "@google-cloud/bigquery";
-import { Timestamp } from "firebase-admin/firestore";
-import { describe, expect, test } from "vitest";
+import { type BigQuery, Geography } from "@google-cloud/bigquery";
+import { type Firestore, Timestamp } from "firebase-admin/firestore";
+import { describe, expect, test, vi } from "vitest";
+import { resolveConfig } from "../src/export-config";
 import {
   convertUnsupportedDataTypes,
   parseTransferConfigName,
   parseTransferRunName,
+  type ResultHandlerContext,
+  writeRunResultsToFirestore,
 } from "../src/helper";
+import * as logs from "../src/logs";
+import type { TransferRunMessage } from "../src/types";
+
+vi.mock("../src/logs", { spy: true });
 
 describe("transfer resource parsing", () => {
   test("parses config and run resource names", () => {
@@ -70,5 +77,59 @@ describe("convertUnsupportedDataTypes", () => {
     expect(converted.bytes).toBeInstanceOf(Uint8Array);
     expect(converted.geography).toBe("POINT(1 2)");
     expect(converted.nested).toEqual([{ value: true }]);
+  });
+});
+
+describe("writeRunResultsToFirestore", () => {
+  test("logs the run id after reading results and before writing rows", async () => {
+    const add = vi.fn().mockResolvedValue({});
+    const set = vi.fn().mockResolvedValue({});
+    const db = {
+      collection: vi.fn(() => ({ add, doc: vi.fn(() => ({ set })) })),
+      runTransaction: vi.fn(
+        async (fn: (transaction: unknown) => Promise<void>) =>
+          fn({
+            get: vi.fn().mockResolvedValue({ data: () => undefined }),
+            set: vi.fn(),
+          })
+      ),
+    } as unknown as Firestore;
+    const bigquery = {
+      createQueryJob: vi.fn().mockResolvedValue([
+        {
+          id: "job-1",
+          getQueryResults: vi.fn().mockResolvedValue([[{ value: 1 }]]),
+        },
+      ]),
+    } as unknown as BigQuery;
+    const config = resolveConfig({
+      bigqueryDatasetLocation: "US",
+      projectId: "test-project",
+      instanceId: "users-export",
+      datasetId: "analytics",
+      tableName: "out",
+      queryString: "SELECT * FROM source.users",
+      displayName: "Users export",
+      schedule: "every 24 hours",
+    });
+    const message = {
+      json: {
+        name: "projects/test-project/locations/us/transferConfigs/config-1/runs/run-1",
+        runTime: "2026-08-20T10:05:39Z",
+        state: "SUCCEEDED",
+        destinationDatasetId: "analytics",
+        params: { destination_table_name_template: 'out_{run_time|"%H%M%S"}' },
+      },
+    } as TransferRunMessage;
+    const ctx = { db, bigquery, config } as ResultHandlerContext;
+
+    await writeRunResultsToFirestore(ctx, message);
+
+    const logSpy = vi.mocked(logs.writeRunResultsToFirestore);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith("run-1");
+    expect(logSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      add.mock.invocationCallOrder[0]
+    );
   });
 });

--- a/kits/bigquery-firestore-export/tests/helper.test.ts
+++ b/kits/bigquery-firestore-export/tests/helper.test.ts
@@ -94,13 +94,11 @@ describe("writeRunResultsToFirestore", () => {
           })
       ),
     } as unknown as Firestore;
+    const getQueryResults = vi.fn().mockResolvedValue([[{ value: 1 }]]);
     const bigquery = {
-      createQueryJob: vi.fn().mockResolvedValue([
-        {
-          id: "job-1",
-          getQueryResults: vi.fn().mockResolvedValue([[{ value: 1 }]]),
-        },
-      ]),
+      createQueryJob: vi
+        .fn()
+        .mockResolvedValue([{ id: "job-1", getQueryResults }]),
     } as unknown as BigQuery;
     const config = resolveConfig({
       bigqueryDatasetLocation: "US",
@@ -128,6 +126,9 @@ describe("writeRunResultsToFirestore", () => {
     const logSpy = vi.mocked(logs.writeRunResultsToFirestore);
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith("run-1");
+    expect(logSpy.mock.invocationCallOrder[0]).toBeGreaterThan(
+      getQueryResults.mock.invocationCallOrder[0]
+    );
     expect(logSpy.mock.invocationCallOrder[0]).toBeLessThan(
       add.mock.invocationCallOrder[0]
     );

--- a/kits/firestore-bigquery-export/src/export-config.ts
+++ b/kits/firestore-bigquery-export/src/export-config.ts
@@ -71,7 +71,10 @@ export interface ExportConfig {
   partitioning?: ChangeTrackerConfig["partitioning"];
   /** Clustering columns (max 4). */
   clustering?: string[] | null;
-  /** Materialized-view max staleness interval, e.g. `0-0 0 4:0:0`. */
+  /**
+   * Materialized-view max staleness interval, e.g.
+   * `INTERVAL "8:0:0" HOUR TO SECOND`.
+   */
   maxStaleness?: ConfigValue<string>;
   /** Incremental materialized-view refresh interval in minutes. */
   refreshIntervalMinutes?: ConfigValue<number>;


### PR DESCRIPTION
Restores two parity items from the #2974 ledger. The bigquery-firestore-export kit gets back the extension's `logs.writeRunResultsToFirestore(runId)` helper, called after the BigQuery results are read and before the row writes, with a test pinning the call and its ordering on both sides (mutation-checked: hoisting the call above the read fails); the kit's full suite, tsc, and prettier pass. The other two dropped helpers, `logs.start()` and `logs.invalidResourceName()`, are deliberately skipped: neither has a call site in the upstream extension (both are defined and never called), and the kit already has its own `start()`/`init(config)` logging, so restoring them would add dead code. The MAX_STALENESS doc example is restored to the extension's `INTERVAL "8:0:0" HOUR TO SECOND`; the ledger and #3036 mislabeled which kit owns this param - it actually lives in firestore-bigquery-export, so that is where the fix lands, and it is a JSDoc comment only, so no tests were added for it. Checked #2983, #2980, #2960, #2963 for collisions: none add or rename `writeRunResultsToFirestore` in logs.ts, though #2963 also extends helper.test.ts and may need a trivial merge. Part of #3036.
