### PR TITLE
fix(firestore-genai-chatbot): type safety settings against the SDK enums and restore the PROJECT_ID error text

### DIFF
--- a/kits/firestore-genai-chatbot/src/config.ts
+++ b/kits/firestore-genai-chatbot/src/config.ts
@@ -335,9 +335,13 @@ function buildSafetySettings(): SafetySetting[] {
     ["HARM_CATEGORY_HARASSMENT", params.harmHarassment.value()],
     ["HARM_CATEGORY_SEXUALLY_EXPLICIT", params.harmSexual.value()],
   ];
+  // The select params only offer SDK enum values, so the cast is sound.
   return entries
     .filter(([, threshold]) => threshold.length > 0)
-    .map(([category, threshold]) => ({ category, threshold }));
+    .map(([category, threshold]) => ({
+      category,
+      threshold,
+    })) as SafetySetting[];
 }
 
 /**

--- a/kits/firestore-genai-chatbot/src/config.ts
+++ b/kits/firestore-genai-chatbot/src/config.ts
@@ -329,19 +329,20 @@ function num(value: string): number | undefined {
 }
 
 function buildSafetySettings(): SafetySetting[] {
-  const entries: Array<[string, string]> = [
+  const entries: Array<[SafetySetting["category"], string]> = [
     ["HARM_CATEGORY_HATE_SPEECH", params.harmHateSpeech.value()],
     ["HARM_CATEGORY_DANGEROUS_CONTENT", params.harmDangerous.value()],
     ["HARM_CATEGORY_HARASSMENT", params.harmHarassment.value()],
     ["HARM_CATEGORY_SEXUALLY_EXPLICIT", params.harmSexual.value()],
   ];
-  // The select params only offer SDK enum values, so the cast is sound.
+  // select() constrains only the CLI prompt; the runtime env value is an
+  // unchecked string, forwarded to the model backend as-is.
   return entries
     .filter(([, threshold]) => threshold.length > 0)
     .map(([category, threshold]) => ({
       category,
-      threshold,
-    })) as SafetySetting[];
+      threshold: threshold as SafetySetting["threshold"],
+    }));
 }
 
 /**

--- a/kits/firestore-genai-chatbot/src/export-config.ts
+++ b/kits/firestore-genai-chatbot/src/export-config.ts
@@ -14,6 +14,16 @@
  * limitations under the License.
  */
 
+import {
+  HarmBlockThreshold as VertexAIHarmBlockThreshold,
+  HarmCategory as VertexAIHarmCategory,
+  type SafetySetting as VertexAISafetySetting,
+} from "@google/genai";
+import {
+  HarmBlockThreshold as GoogleAIHarmBlockThreshold,
+  HarmCategory as GoogleAIHarmCategory,
+  type SafetySetting as GoogleAISafetySetting,
+} from "@google/generative-ai";
 import type { Expression } from "firebase-functions/params";
 
 /** The type returned by `defineSecret` (not exported by name from the module). */
@@ -27,10 +37,37 @@ export enum GenerativeAIProvider {
   VERTEX_AI = "vertex-ai",
 }
 
-/** A model safety setting (`{ category, threshold }`), accepted by both SDKs. */
-export interface SafetySetting {
-  category: string;
-  threshold: string;
+/** A model safety setting, typed with the SDKs' own category/threshold enums. */
+export type SafetySetting = GoogleAISafetySetting | VertexAISafetySetting;
+
+const HARM_ENUMS: Record<
+  GenerativeAIProvider,
+  { categories: Set<string>; thresholds: Set<string> }
+> = {
+  [GenerativeAIProvider.GOOGLE_AI]: {
+    categories: new Set(Object.values(GoogleAIHarmCategory)),
+    thresholds: new Set(Object.values(GoogleAIHarmBlockThreshold)),
+  },
+  [GenerativeAIProvider.VERTEX_AI]: {
+    categories: new Set(Object.values(VertexAIHarmCategory)),
+    thresholds: new Set(Object.values(VertexAIHarmBlockThreshold)),
+  },
+};
+
+function validateSafetySettings(
+  settings: SafetySetting[],
+  provider: GenerativeAIProvider
+): void {
+  const enums =
+    HARM_ENUMS[provider] ?? HARM_ENUMS[GenerativeAIProvider.GOOGLE_AI];
+  for (const { category, threshold } of settings) {
+    if (category !== undefined && !enums.categories.has(category)) {
+      throw new Error(`Invalid safety setting category: ${category}`);
+    }
+    if (threshold !== undefined && !enums.thresholds.has(threshold)) {
+      throw new Error(`Invalid safety setting threshold: ${threshold}`);
+    }
+  }
 }
 
 /**
@@ -140,12 +177,13 @@ export interface DeployTimeOptions {
  */
 export function getProjectId(): string {
   const config = process.env.FIREBASE_CONFIG;
+  const projectId = config ? JSON.parse(config).projectId : undefined;
 
-  if (!config) {
-    throw new Error("FIREBASE_CONFIG is not set");
+  if (!projectId) {
+    throw new Error("Missing required environment variables: PROJECT_ID");
   }
 
-  return JSON.parse(config).projectId;
+  return projectId;
 }
 
 const DEFAULT_COLLECTION = "generate";
@@ -162,6 +200,8 @@ export function resolveConfig(
 ): ResolvedGenaiChatbotConfig {
   const provider =
     (config.provider as GenerativeAIProvider) ?? GenerativeAIProvider.GOOGLE_AI;
+  const safetySettings = config.safetySettings ?? [];
+  validateSafetySettings(safetySettings, provider);
   return {
     provider,
     vertex: {
@@ -187,7 +227,7 @@ export function resolveConfig(
     topK: config.topK,
     candidateCount: config.candidateCount ?? 1,
     maxOutputTokens: config.maxOutputTokens,
-    safetySettings: config.safetySettings ?? [],
+    safetySettings,
     secrets: config.secrets,
   };
 }

--- a/kits/firestore-genai-chatbot/src/export-config.ts
+++ b/kits/firestore-genai-chatbot/src/export-config.ts
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-import {
+import type {
   HarmBlockThreshold as VertexAIHarmBlockThreshold,
   HarmCategory as VertexAIHarmCategory,
-  type SafetySetting as VertexAISafetySetting,
 } from "@google/genai";
-import {
+import type {
   HarmBlockThreshold as GoogleAIHarmBlockThreshold,
   HarmCategory as GoogleAIHarmCategory,
-  type SafetySetting as GoogleAISafetySetting,
 } from "@google/generative-ai";
 import type { Expression } from "firebase-functions/params";
 
@@ -37,35 +35,31 @@ export enum GenerativeAIProvider {
   VERTEX_AI = "vertex-ai",
 }
 
-/** A model safety setting, typed with the SDKs' own category/threshold enums. */
-export type SafetySetting = GoogleAISafetySetting | VertexAISafetySetting;
+/**
+ * A model safety setting. Category and threshold are typed against both pinned
+ * SDKs' enums as string-literal unions, so enum members and plain string
+ * literals both compile.
+ */
+export interface SafetySetting {
+  category: `${GoogleAIHarmCategory}` | `${VertexAIHarmCategory}`;
+  threshold: `${GoogleAIHarmBlockThreshold}` | `${VertexAIHarmBlockThreshold}`;
+}
 
-const HARM_ENUMS: Record<
-  GenerativeAIProvider,
-  { categories: Set<string>; thresholds: Set<string> }
-> = {
-  [GenerativeAIProvider.GOOGLE_AI]: {
-    categories: new Set(Object.values(GoogleAIHarmCategory)),
-    thresholds: new Set(Object.values(GoogleAIHarmBlockThreshold)),
-  },
-  [GenerativeAIProvider.VERTEX_AI]: {
-    categories: new Set(Object.values(VertexAIHarmCategory)),
-    thresholds: new Set(Object.values(VertexAIHarmBlockThreshold)),
-  },
-};
-
-function validateSafetySettings(
-  settings: SafetySetting[],
-  provider: GenerativeAIProvider
-): void {
-  const enums =
-    HARM_ENUMS[provider] ?? HARM_ENUMS[GenerativeAIProvider.GOOGLE_AI];
-  for (const { category, threshold } of settings) {
-    if (category !== undefined && !enums.categories.has(category)) {
-      throw new Error(`Invalid safety setting category: ${category}`);
-    }
-    if (threshold !== undefined && !enums.thresholds.has(threshold)) {
-      throw new Error(`Invalid safety setting threshold: ${threshold}`);
+// Structural only: the SDK enums lag the live API's accepted values, so
+// membership is left to the model backend.
+function validateSafetySettings(settings: SafetySetting[]): void {
+  for (const setting of settings) {
+    if (
+      typeof setting !== "object" ||
+      setting === null ||
+      typeof setting.category !== "string" ||
+      typeof setting.threshold !== "string"
+    ) {
+      throw new Error(
+        `Invalid safety setting: ${JSON.stringify(
+          setting
+        )}. Expected an object with string category and threshold.`
+      );
     }
   }
 }
@@ -200,8 +194,11 @@ export function resolveConfig(
 ): ResolvedGenaiChatbotConfig {
   const provider =
     (config.provider as GenerativeAIProvider) ?? GenerativeAIProvider.GOOGLE_AI;
+  if (!Object.values(GenerativeAIProvider).includes(provider)) {
+    throw new Error(`Invalid Provider: ${provider}`);
+  }
   const safetySettings = config.safetySettings ?? [];
-  validateSafetySettings(safetySettings, provider);
+  validateSafetySettings(safetySettings);
   return {
     provider,
     vertex: {

--- a/kits/firestore-genai-chatbot/tests/export-config.test.ts
+++ b/kits/firestore-genai-chatbot/tests/export-config.test.ts
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
-import { describe, expect, test } from "vitest";
-import { GenerativeAIProvider, resolveConfig } from "../src/export-config";
+import { HarmBlockThreshold, HarmCategory } from "@google/generative-ai";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  GenerativeAIProvider,
+  getProjectId,
+  resolveConfig,
+} from "../src/export-config";
 
 describe("resolveConfig", () => {
   const base = { projectId: "p", model: "gemini-2.5-flash" };
@@ -61,5 +66,95 @@ describe("resolveConfig", () => {
     expect(c.enableDiscussionOptionOverrides).toBe(true);
     expect(c.candidateCount).toBe(3);
     expect(c.temperature).toBe(0.5);
+  });
+
+  test("accepts safety settings built from the SDK enums", () => {
+    const c = resolveConfig({
+      ...base,
+      safetySettings: [
+        {
+          category: HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+          threshold: HarmBlockThreshold.BLOCK_ONLY_HIGH,
+        },
+      ],
+    });
+    expect(c.safetySettings).toEqual([
+      {
+        category: "HARM_CATEGORY_HATE_SPEECH",
+        threshold: "BLOCK_ONLY_HIGH",
+      },
+    ]);
+  });
+
+  test("rejects a safety setting category the SDK does not define", () => {
+    expect(() =>
+      resolveConfig({
+        ...base,
+        safetySettings: [
+          { category: "HARM_CATEGORY_TYPO", threshold: "BLOCK_NONE" },
+        ],
+      })
+    ).toThrow("Invalid safety setting category: HARM_CATEGORY_TYPO");
+  });
+
+  test("rejects a safety setting threshold the SDK does not define", () => {
+    expect(() =>
+      resolveConfig({
+        ...base,
+        safetySettings: [
+          {
+            category: HarmCategory.HARM_CATEGORY_HATE_SPEECH,
+            threshold: "BLOCK_EVERYTHING",
+          },
+        ],
+      })
+    ).toThrow("Invalid safety setting threshold: BLOCK_EVERYTHING");
+  });
+
+  test("validates against the Vertex AI enums when the provider is vertex-ai", () => {
+    const vertexOnly = [
+      { category: "HARM_CATEGORY_HATE_SPEECH", threshold: "OFF" },
+    ];
+    expect(
+      resolveConfig({
+        ...base,
+        provider: "vertex-ai",
+        safetySettings: vertexOnly,
+      }).safetySettings
+    ).toEqual(vertexOnly);
+    expect(() =>
+      resolveConfig({ ...base, safetySettings: vertexOnly })
+    ).toThrow("Invalid safety setting threshold: OFF");
+  });
+});
+
+describe("getProjectId", () => {
+  const savedFirebaseConfig = process.env.FIREBASE_CONFIG;
+
+  afterEach(() => {
+    if (savedFirebaseConfig === undefined) {
+      delete process.env.FIREBASE_CONFIG;
+    } else {
+      process.env.FIREBASE_CONFIG = savedFirebaseConfig;
+    }
+  });
+
+  test("reads the project id from FIREBASE_CONFIG", () => {
+    process.env.FIREBASE_CONFIG = JSON.stringify({ projectId: "my-project" });
+    expect(getProjectId()).toBe("my-project");
+  });
+
+  test("throws the extension's missing-var error when FIREBASE_CONFIG is not set", () => {
+    delete process.env.FIREBASE_CONFIG;
+    expect(getProjectId).toThrow(
+      "Missing required environment variables: PROJECT_ID"
+    );
+  });
+
+  test("throws the extension's missing-var error when FIREBASE_CONFIG has no project id", () => {
+    process.env.FIREBASE_CONFIG = JSON.stringify({});
+    expect(getProjectId).toThrow(
+      "Missing required environment variables: PROJECT_ID"
+    );
   });
 });

--- a/kits/firestore-genai-chatbot/tests/export-config.test.ts
+++ b/kits/firestore-genai-chatbot/tests/export-config.test.ts
@@ -20,6 +20,7 @@ import {
   GenerativeAIProvider,
   getProjectId,
   resolveConfig,
+  type SafetySetting,
 } from "../src/export-config";
 
 describe("resolveConfig", () => {
@@ -86,45 +87,40 @@ describe("resolveConfig", () => {
     ]);
   });
 
-  test("rejects a safety setting category the SDK does not define", () => {
-    expect(() =>
-      resolveConfig({
-        ...base,
-        safetySettings: [
-          { category: "HARM_CATEGORY_TYPO", threshold: "BLOCK_NONE" },
-        ],
-      })
-    ).toThrow("Invalid safety setting category: HARM_CATEGORY_TYPO");
-  });
-
-  test("rejects a safety setting threshold the SDK does not define", () => {
-    expect(() =>
-      resolveConfig({
-        ...base,
-        safetySettings: [
-          {
-            category: HarmCategory.HARM_CATEGORY_HATE_SPEECH,
-            threshold: "BLOCK_EVERYTHING",
-          },
-        ],
-      })
-    ).toThrow("Invalid safety setting threshold: BLOCK_EVERYTHING");
-  });
-
-  test("validates against the Vertex AI enums when the provider is vertex-ai", () => {
-    const vertexOnly = [
-      { category: "HARM_CATEGORY_HATE_SPEECH", threshold: "OFF" },
+  test("accepts string-literal safety settings, including values newer than the older SDK's enums", () => {
+    const settings: SafetySetting[] = [
+      { category: "HARM_CATEGORY_HATE_SPEECH", threshold: "BLOCK_NONE" },
+      { category: "HARM_CATEGORY_CIVIC_INTEGRITY", threshold: "OFF" },
     ];
     expect(
+      resolveConfig({ ...base, safetySettings: settings }).safetySettings
+    ).toEqual(settings);
+  });
+
+  test("rejects a safety setting that is not a category/threshold string pair", () => {
+    expect(() =>
       resolveConfig({
         ...base,
-        provider: "vertex-ai",
-        safetySettings: vertexOnly,
-      }).safetySettings
-    ).toEqual(vertexOnly);
+        safetySettings: ["BLOCK_NONE"] as unknown as SafetySetting[],
+      })
+    ).toThrow("Invalid safety setting");
     expect(() =>
-      resolveConfig({ ...base, safetySettings: vertexOnly })
-    ).toThrow("Invalid safety setting threshold: OFF");
+      resolveConfig({
+        ...base,
+        safetySettings: [
+          { category: "HARM_CATEGORY_HATE_SPEECH" },
+        ] as unknown as SafetySetting[],
+      })
+    ).toThrow("Invalid safety setting");
+  });
+
+  test("rejects an unknown provider with the extension's wording", () => {
+    expect(() =>
+      resolveConfig({
+        ...base,
+        provider: "vertexai" as unknown as GenerativeAIProvider,
+      })
+    ).toThrow("Invalid Provider: vertexai");
   });
 });
 

--- a/kits/firestore-genai-chatbot/tests/generate-chat-response.test.ts
+++ b/kits/firestore-genai-chatbot/tests/generate-chat-response.test.ts
@@ -56,7 +56,9 @@ describe("createGenerateChatResponse", () => {
       topK: 9,
       candidateCount: 2,
       maxOutputTokens: 50,
-      safetySettings: [{ category: "category", threshold: "threshold" }],
+      safetySettings: [
+        { category: "HARM_CATEGORY_HATE_SPEECH", threshold: "BLOCK_ONLY_HIGH" },
+      ],
     });
     const generate = createGenerateChatResponse(config);
 
@@ -70,7 +72,9 @@ describe("createGenerateChatResponse", () => {
       topK: 9,
       candidateCount: 2,
       maxOutputTokens: 50,
-      safetySettings: [{ category: "category", threshold: "threshold" }],
+      safetySettings: [
+        { category: "HARM_CATEGORY_HATE_SPEECH", threshold: "BLOCK_ONLY_HIGH" },
+      ],
     });
     expect(result).toEqual({
       response: "first",


### PR DESCRIPTION
The kit typed safety settings as a local `{ category: string; threshold: string }`, dropping the enum-level typing the extension got from the SDK `SafetySetting` types. `SafetySetting` is now typed with template-literal unions over both pinned SDKs' enums (`@google/generative-ai` and `@google/genai` `HarmCategory` / `HarmBlockThreshold`), so misspelled values fail to compile while plain string literals and enum members both stay valid for lib consumers. An earlier revision also rejected non-enum values at runtime; that was dropped after review, because the extension never validated safety values at runtime (it casts raw env strings) and the pinned `@google/generative-ai` enums lag the live API (no `OFF`, no `HARM_CATEGORY_CIVIC_INTEGRITY`), so the rejection broke previously-working configs. `resolveConfig` now only checks safety settings structurally, and rejects an unknown provider with the extension's `Invalid Provider: X` wording. `getProjectId` now throws the extension's `Missing required environment variables: PROJECT_ID` wording instead of `FIREBASE_CONFIG is not set`, including when `FIREBASE_CONFIG` is present without a projectId. Covered by new resolveConfig, provider and getProjectId tests; full suite (29 tests), tsc and prettier are clean, and the test files were typechecked explicitly since tsconfig excludes them. Not verified against a live deploy. Part of #3036.