### PR TITLE
fix(delete-user-data): restore the INSTANCE_ID param name

### DIFF
--- a/kits/delete-user-data/src/config.ts
+++ b/kits/delete-user-data/src/config.ts
@@ -26,7 +26,7 @@ import {
 } from "firebase-functions/params";
 import type { DeleteUserDataConfig } from "./export-config";
 
-const instanceId = defineString("FIREBASE_KIT_INSTANCE_ID");
+const instanceId = defineString("INSTANCE_ID");
 
 const params = {
   instanceId,


### PR DESCRIPTION
The two failing tests in kits/delete-user-data/tests/config.test.ts pin the correct behavior: every other kit declares this param as INSTANCE_ID, the kit's README documents INSTANCE_ID, and firebase-tools reserves the FIREBASE_ env prefix (RESERVED_PREFIXES in lib/functions/env.js), so a param named FIREBASE_KIT_INSTANCE_ID cannot be set through .env files at all. The rename landed as a lone drive-by commit (03dd40b4) on the unrelated #3004 branch without updating tests, README, or the other kits, so this reverts the code side rather than the tests. Full suite is green: 95 tests passing, tsc -b clean. Fixes #3048