### PR TITLE
test(firestore-counter): port the active legacy emulator tests

### DIFF
--- a/kits/firestore-counter/package.json
+++ b/kits/firestore-counter/package.json
@@ -27,6 +27,7 @@
     "build": "tsc -b",
     "clean": "tsc -b --clean",
     "test": "vitest run",
+    "test:emulator": "firebase emulators:exec --only firestore --project demo-test --config tests/integration/firebase.json \"vitest run tests/integration\"",
     "deploy": "pnpm build && firebase deploy --only functions",
     "serve": "firebase emulators:start --only functions"
   },

--- a/kits/firestore-counter/tests/controller.test.ts
+++ b/kits/firestore-counter/tests/controller.test.ts
@@ -54,7 +54,7 @@ describe("Controller", () => {
       },
       {
         slice: {
-          start: "3333333",
+          start: "33333333",
           end: "66666666",
         },
         hasData: true,

--- a/kits/firestore-counter/tests/integration/controller.emulator.test.ts
+++ b/kits/firestore-counter/tests/integration/controller.emulator.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Controller tests against a real Firestore emulator. The rest of the suite
+ * runs on FakeFirestore, so these cover what a fake cannot: real transaction
+ * read/write ordering and server-resolved timestamps.
+ *
+ * They are skipped unless FIRESTORE_EMULATOR_HOST is set.
+ *
+ * Run locally from kits/firestore-counter:
+ *   npx firebase emulators:exec --only firestore -P demo-test \
+ *     --config ../../_emulator/firebase.json "npx vitest run tests/integration"
+ */
+
+import { randomUUID } from "node:crypto";
+
+import { deleteApp, initializeApp, type App } from "firebase-admin/app";
+import {
+  getFirestore,
+  type DocumentReference,
+  type Firestore,
+} from "firebase-admin/firestore";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+import {
+  ControllerStatus,
+  ShardedCounterController,
+} from "../../src/controller";
+
+const runEmulator = !!process.env.FIRESTORE_EMULATOR_HOST;
+const describeEmulator = runEmulator ? describe : describe.skip;
+
+let app: App;
+let db: Firestore;
+
+/** Deletes a document and every document under its subcollections. */
+async function deleteRecursively(ref: DocumentReference): Promise<void> {
+  const subcollections = await ref.listCollections();
+  for (const subcollection of subcollections) {
+    const docs = await subcollection.listDocuments();
+    await Promise.all(docs.map((doc) => deleteRecursively(doc)));
+  }
+  await ref.delete();
+}
+
+describeEmulator("Controller (emulator)", () => {
+  beforeAll(() => {
+    app = initializeApp({ projectId: "demo-test" }, `counter-${randomUUID()}`);
+    db = getFirestore(app);
+  });
+
+  afterAll(async () => {
+    await deleteApp(app);
+  });
+
+  test("can create the internal state document on its first run", async () => {
+    const controllerDocRef = db.collection(randomUUID()).doc("controller");
+    const controller = new ShardedCounterController(
+      controllerDocRef,
+      randomUUID()
+    );
+
+    try {
+      const status = await controller.aggregateOnce(
+        { start: "", end: "" },
+        200
+      );
+      expect(status).toBe(ControllerStatus.SUCCESS);
+
+      const controllerDoc = await controllerDocRef.get();
+      expect(controllerDoc.data()).toEqual({ workers: [], timestamp: 0 });
+    } finally {
+      await deleteRecursively(controllerDocRef);
+    }
+  });
+
+  test("reshards two under-loaded workers into a single slice", async () => {
+    const controllerDocRef = db.collection(randomUUID()).doc("controller");
+    const workersRef = controllerDocRef.collection("workers");
+    const controller = new ShardedCounterController(
+      controllerDocRef,
+      randomUUID()
+    );
+
+    try {
+      await controllerDocRef.set({
+        workers: [
+          { start: "00000000", end: "33333333" },
+          { start: "3333333", end: "66666666" },
+        ],
+        timestamp: Date.now(),
+      });
+      await workersRef.doc("0000").set({
+        slice: { start: "00000000", end: "33333333" },
+        stats: {
+          lastSuccessfulRun: Date.now(),
+          shardsAggregated: 2,
+          splits: ["11111111", "22222222"],
+          rounds: 1,
+          roundsCapped: 0,
+        },
+      });
+      await workersRef.doc("0001").set({
+        slice: { start: "3333333", end: "66666666" },
+        stats: {
+          lastSuccessfulRun: Date.now(),
+          shardsAggregated: 2,
+          splits: ["44444444", "55555555"],
+          rounds: 1,
+          roundsCapped: 0,
+        },
+      });
+
+      await controller.rescheduleWorkers();
+
+      const controllerDoc = await controllerDocRef.get();
+      expect(controllerDoc.get("workers")).toEqual([
+        { start: "00000000", end: "66666666" },
+      ]);
+
+      const workers = await workersRef.orderBy("__name__").get();
+      expect(workers.docs.map((doc) => doc.id)).toEqual(["0000"]);
+      expect(workers.docs[0].get("slice")).toEqual({
+        start: "00000000",
+        end: "66666666",
+      });
+    } finally {
+      await deleteRecursively(controllerDocRef);
+    }
+  });
+});

--- a/kits/firestore-counter/tests/integration/controller.emulator.test.ts
+++ b/kits/firestore-counter/tests/integration/controller.emulator.test.ts
@@ -31,6 +31,7 @@ import { randomUUID } from "node:crypto";
 import { deleteApp, initializeApp, type App } from "firebase-admin/app";
 import {
   getFirestore,
+  Timestamp,
   type DocumentReference,
   type Firestore,
 } from "firebase-admin/firestore";
@@ -100,7 +101,7 @@ describeEmulator("Controller (emulator)", () => {
       await controllerDocRef.set({
         workers: [
           { start: "00000000", end: "33333333" },
-          { start: "3333333", end: "66666666" },
+          { start: "33333333", end: "66666666" },
         ],
         timestamp: Date.now(),
       });
@@ -115,7 +116,7 @@ describeEmulator("Controller (emulator)", () => {
         },
       });
       await workersRef.doc("0001").set({
-        slice: { start: "3333333", end: "66666666" },
+        slice: { start: "33333333", end: "66666666" },
         stats: {
           lastSuccessfulRun: Date.now(),
           shardsAggregated: 2,
@@ -138,6 +139,10 @@ describeEmulator("Controller (emulator)", () => {
         start: "00000000",
         end: "66666666",
       });
+      // The reshard path writes FieldValue.serverTimestamp(); only a real
+      // backend resolves that sentinel into a Timestamp.
+      expect(workers.docs[0].get("timestamp")).toBeInstanceOf(Timestamp);
+      expect(controllerDoc.get("timestamp")).toBeInstanceOf(Timestamp);
     } finally {
       await deleteRecursively(controllerDocRef);
     }

--- a/kits/firestore-counter/tests/integration/controller.emulator.test.ts
+++ b/kits/firestore-counter/tests/integration/controller.emulator.test.ts
@@ -21,9 +21,7 @@
  *
  * They are skipped unless FIRESTORE_EMULATOR_HOST is set.
  *
- * Run locally from kits/firestore-counter:
- *   npx firebase emulators:exec --only firestore -P demo-test \
- *     --config ../../_emulator/firebase.json "npx vitest run tests/integration"
+ * Run from kits/firestore-counter: npm run test:emulator
  */
 
 import { randomUUID } from "node:crypto";

--- a/kits/firestore-counter/tests/integration/firebase.json
+++ b/kits/firestore-counter/tests/integration/firebase.json
@@ -1,0 +1,14 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  },
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    },
+    "singleProjectMode": true,
+    "ui": {
+      "enabled": false
+    }
+  }
+}

--- a/kits/firestore-counter/tests/integration/firestore.rules
+++ b/kits/firestore-counter/tests/integration/firestore.rules
@@ -1,0 +1,12 @@
+rules_version = '2';
+
+// The emulator controller tests drive Firestore through the Admin SDK, which
+// bypasses rules; this file exists only because the emulator requires a rules
+// source.
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}


### PR DESCRIPTION
Issue #2974 flags the kit as having no emulator tests. The kit's FakeFirestore suites already cover more controller and worker logic than the legacy extension ever did, so this is a narrow port rather than a new test layer.

The legacy `controller.emulator.test.ts` had four tests, two of them `test.skip`'d upstream. Both active ones are ported to `tests/integration/controller.emulator.test.ts` and run against a real Firestore emulator: internal-state document creation on first run, and resharding. Resharding goes through `rescheduleWorkers` rather than the static `balanceWorkers` helper - the pure function is already covered by the fake, so the emulator only earns its keep by exercising the surrounding transaction and worker-document writes. `worker.emulator.test.ts` is 100% skipped upstream and is not ported. `e2e.test.ts` needs a deployed functions environment and is out of scope.

The suite skips cleanly when `FIRESTORE_EMULATOR_HOST` is unset. Verified locally against the emulator: 79 passed, 12 files. Both assertions were checked to fail when the expected values are altered. Test-only, no src changes.

Part of #2974.