### PR TITLE
test(bigquery-firestore-export): port legacy unit coverage into the kit

### DIFF
--- a/kits/bigquery-firestore-export/tests/dts-transfer-config.test.ts
+++ b/kits/bigquery-firestore-export/tests/dts-transfer-config.test.ts
@@ -74,6 +74,18 @@ function unchangedTransferConfig(): TransferConfig {
   } as TransferConfig;
 }
 
+/**
+ * The stored config with only `delta` applied, so a change case can assert the
+ * whole updated config and catch edits the update mask does not mention.
+ */
+function transferConfigWithDelta(
+  delta: (transferConfig: TransferConfig) => void
+): TransferConfig {
+  const expected = unchangedTransferConfig();
+  delta(expected);
+  return expected;
+}
+
 function clientReturning(transferConfig: TransferConfig | null) {
   return {
     getTransferConfig: vi.fn().mockResolvedValue([transferConfig]),
@@ -128,10 +140,11 @@ describe("constructUpdateTransferConfigRequest change detection", () => {
     );
 
     expect(request.updateMask?.paths).toEqual(["schedule"]);
-    expect(request.transferConfig?.schedule).toBe("every 15 minutes");
-    expect(
-      request.transferConfig?.params?.fields?.partitioning_field?.stringValue
-    ).toBe("");
+    expect(request.transferConfig).toEqual(
+      transferConfigWithDelta((expected) => {
+        expected.schedule = "every 15 minutes";
+      })
+    );
   });
 
   test("masks params when the destination table name changed", async () => {
@@ -142,10 +155,12 @@ describe("constructUpdateTransferConfigRequest change detection", () => {
     );
 
     expect(request.updateMask?.paths).toEqual(["params"]);
-    expect(
-      request.transferConfig?.params?.fields?.destination_table_name_template
-        ?.stringValue
-    ).toBe('different_table_{run_time|"%H%M%S"}');
+    expect(request.transferConfig).toEqual(
+      transferConfigWithDelta((expected) => {
+        expected.params.fields.destination_table_name_template.stringValue =
+          'different_table_{run_time|"%H%M%S"}';
+      })
+    );
   });
 
   test("masks params when the query changed", async () => {
@@ -156,8 +171,11 @@ describe("constructUpdateTransferConfigRequest change detection", () => {
     );
 
     expect(request.updateMask?.paths).toEqual(["params"]);
-    expect(request.transferConfig?.params?.fields?.query?.stringValue).toBe(
-      "SELECT * FROM source.accounts"
+    expect(request.transferConfig).toEqual(
+      transferConfigWithDelta((expected) => {
+        expected.params.fields.query.stringValue =
+          "SELECT * FROM source.accounts";
+      })
     );
   });
 
@@ -165,12 +183,20 @@ describe("constructUpdateTransferConfigRequest change detection", () => {
     const request = await constructUpdateTransferConfigRequest(
       clientReturning(unchangedTransferConfig()),
       TRANSFER_CONFIG_NAME,
-      { ...config, queryString: "SELECT * FROM source.accounts" }
+      {
+        ...config,
+        partitioningField: undefined,
+        queryString: "SELECT * FROM source.accounts",
+      }
     );
 
-    expect(
-      request.transferConfig?.params?.fields?.partitioning_field?.stringValue
-    ).toBe("");
+    expect(request.updateMask?.paths).toEqual(["params"]);
+    expect(request.transferConfig).toEqual(
+      transferConfigWithDelta((expected) => {
+        expected.params.fields.query.stringValue =
+          "SELECT * FROM source.accounts";
+      })
+    );
   });
 
   test("masks the notification topic when the stored one drifted", async () => {
@@ -183,10 +209,14 @@ describe("constructUpdateTransferConfigRequest change detection", () => {
       { ...config, schedule: "every 15 minutes" }
     );
 
-    expect(request.updateMask?.paths).toContain("notification_pubsub_topic");
-    expect(request.updateMask?.paths).toContain("schedule");
-    expect(request.transferConfig?.notificationPubsubTopic).toBe(
-      EXPECTED_TOPIC
+    expect(request.updateMask?.paths).toEqual([
+      "schedule",
+      "notification_pubsub_topic",
+    ]);
+    expect(request.transferConfig).toEqual(
+      transferConfigWithDelta((expected) => {
+        expected.schedule = "every 15 minutes";
+      })
     );
   });
 
@@ -197,8 +227,12 @@ describe("constructUpdateTransferConfigRequest change detection", () => {
       { ...config, datasetId: "new_dataset_id" }
     );
 
-    expect(request.updateMask?.paths).toContain("destination_dataset_id");
-    expect(request.transferConfig?.destinationDatasetId).toBe("new_dataset_id");
+    expect(request.updateMask?.paths).toEqual(["destination_dataset_id"]);
+    expect(request.transferConfig).toEqual(
+      transferConfigWithDelta((expected) => {
+        expected.destinationDatasetId = "new_dataset_id";
+      })
+    );
   });
 
   test("adds a partitioning field that was not previously set", async () => {
@@ -209,9 +243,11 @@ describe("constructUpdateTransferConfigRequest change detection", () => {
     );
 
     expect(request.updateMask?.paths).toEqual(["params"]);
-    expect(
-      request.transferConfig?.params?.fields?.partitioning_field?.stringValue
-    ).toBe("created_at");
+    expect(request.transferConfig).toEqual(
+      transferConfigWithDelta((expected) => {
+        expected.params.fields.partitioning_field.stringValue = "created_at";
+      })
+    );
   });
 
   test("rejects a stored config without params.fields", async () => {

--- a/kits/bigquery-firestore-export/tests/dts-transfer-config.test.ts
+++ b/kits/bigquery-firestore-export/tests/dts-transfer-config.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as bigqueryDataTransfer from "@google-cloud/bigquery-data-transfer";
 import { describe, expect, test, vi } from "vitest";
 import {
   constructUpdateTransferConfigRequest,
@@ -34,6 +35,9 @@ vi.mock("../src/logs", () => ({
   transferConfigUpdated: vi.fn(),
   updateTransferConfig: vi.fn(),
 }));
+
+const { UpdateTransferConfigRequest } =
+  bigqueryDataTransfer.protos.google.cloud.bigquery.datatransfer.v1;
 
 const TRANSFER_CONFIG_NAME =
   "projects/test-project/locations/us/transferConfigs/642f3a36-0000-2fbb-ad1d-001a114e2fa6";
@@ -334,7 +338,26 @@ describe("updateTransferConfig", () => {
     });
 
     expect(result).toEqual(updated);
-    expect(client.updateTransferConfig).toHaveBeenCalledOnce();
+    expect(client.updateTransferConfig).toHaveBeenCalledWith(
+      UpdateTransferConfigRequest.fromObject({
+        transferConfig: transferConfigWithDelta((expected) => {
+          expected.schedule = "every 15 minutes";
+        }),
+        updateMask: { paths: ["schedule"] },
+      })
+    );
+  });
+
+  test("still sends the update, with an empty mask, when nothing changed", async () => {
+    const client = clientReturning(unchangedTransferConfig());
+    client.updateTransferConfig.mockResolvedValue([unchangedTransferConfig()]);
+
+    await updateTransferConfig(client, TRANSFER_CONFIG_NAME, config);
+
+    const sent = client.updateTransferConfig.mock.calls[0][0];
+    expect(sent.updateMask?.paths).toEqual([]);
+    // On the wire the empty path list serializes as an empty FieldMask.
+    expect(sent.toJSON().updateMask).toEqual({});
   });
 
   test("rejects when the transfer config no longer exists", async () => {

--- a/kits/bigquery-firestore-export/tests/dts-transfer-config.test.ts
+++ b/kits/bigquery-firestore-export/tests/dts-transfer-config.test.ts
@@ -1,0 +1,323 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+import {
+  constructUpdateTransferConfigRequest,
+  createTransferConfig,
+  type DataTransferClient,
+  getTransferConfig,
+  type TransferConfig,
+  updateTransferConfig,
+} from "../src/dts";
+import { resolveConfig } from "../src/export-config";
+
+vi.mock("../src/logs", () => ({
+  createTransferConfig: vi.fn(),
+  getTransferConfigFailed: vi.fn(),
+  partitioningFieldRemovalAttempted: vi.fn(),
+  transferConfigCreated: vi.fn(),
+  transferConfigNotFound: vi.fn(),
+  transferConfigUpdated: vi.fn(),
+  updateTransferConfig: vi.fn(),
+}));
+
+const TRANSFER_CONFIG_NAME =
+  "projects/test-project/locations/us/transferConfigs/642f3a36-0000-2fbb-ad1d-001a114e2fa6";
+const EXPECTED_TOPIC =
+  "projects/test-project/topics/kit-users-export-processMessages";
+const GRPC_NOT_FOUND = 5;
+
+const config = resolveConfig({
+  bigqueryDatasetLocation: "US",
+  projectId: "test-project",
+  instanceId: "users-export",
+  datasetId: "analytics",
+  tableName: "users",
+  queryString: "SELECT * FROM source.users",
+  displayName: "Users export",
+  schedule: "every 24 hours",
+});
+
+/** A stored config that already matches `config` in every comparable field. */
+function unchangedTransferConfig(): TransferConfig {
+  return {
+    name: TRANSFER_CONFIG_NAME,
+    dataSourceId: "scheduled_query",
+    destinationDatasetId: "analytics",
+    displayName: "Users export",
+    notificationPubsubTopic: EXPECTED_TOPIC,
+    schedule: "every 24 hours",
+    params: {
+      fields: {
+        query: { stringValue: "SELECT * FROM source.users" },
+        destination_table_name_template: {
+          stringValue: 'users_{run_time|"%H%M%S"}',
+        },
+        write_disposition: { stringValue: "WRITE_TRUNCATE" },
+        partitioning_field: { stringValue: "" },
+      },
+    },
+  } as TransferConfig;
+}
+
+function clientReturning(transferConfig: TransferConfig | null) {
+  return {
+    getTransferConfig: vi.fn().mockResolvedValue([transferConfig]),
+    createTransferConfig: vi.fn(),
+    updateTransferConfig: vi.fn(),
+  } as unknown as DataTransferClient & {
+    getTransferConfig: ReturnType<typeof vi.fn>;
+    createTransferConfig: ReturnType<typeof vi.fn>;
+    updateTransferConfig: ReturnType<typeof vi.fn>;
+  };
+}
+
+function clientRejecting(err: unknown) {
+  return {
+    getTransferConfig: vi.fn().mockRejectedValue(err),
+  } as unknown as DataTransferClient;
+}
+
+function grpcNotFound(): Error {
+  return Object.assign(new Error("Transfer config not found"), {
+    code: GRPC_NOT_FOUND,
+  });
+}
+
+describe("constructUpdateTransferConfigRequest change detection", () => {
+  test("rejects when the stored config cannot be read", async () => {
+    await expect(
+      constructUpdateTransferConfigRequest(
+        clientReturning(null),
+        TRANSFER_CONFIG_NAME,
+        config
+      )
+    ).rejects.toThrow("Transfer config not found");
+  });
+
+  test("produces an empty update mask when nothing changed", async () => {
+    const request = await constructUpdateTransferConfigRequest(
+      clientReturning(unchangedTransferConfig()),
+      TRANSFER_CONFIG_NAME,
+      config
+    );
+
+    expect(request.updateMask?.paths).toEqual([]);
+    expect(request.transferConfig).toEqual(unchangedTransferConfig());
+  });
+
+  test("masks the schedule alone when only the schedule changed", async () => {
+    const request = await constructUpdateTransferConfigRequest(
+      clientReturning(unchangedTransferConfig()),
+      TRANSFER_CONFIG_NAME,
+      { ...config, schedule: "every 15 minutes" }
+    );
+
+    expect(request.updateMask?.paths).toEqual(["schedule"]);
+    expect(request.transferConfig?.schedule).toBe("every 15 minutes");
+    expect(
+      request.transferConfig?.params?.fields?.partitioning_field?.stringValue
+    ).toBe("");
+  });
+
+  test("masks params when the destination table name changed", async () => {
+    const request = await constructUpdateTransferConfigRequest(
+      clientReturning(unchangedTransferConfig()),
+      TRANSFER_CONFIG_NAME,
+      { ...config, tableName: "different_table" }
+    );
+
+    expect(request.updateMask?.paths).toEqual(["params"]);
+    expect(
+      request.transferConfig?.params?.fields?.destination_table_name_template
+        ?.stringValue
+    ).toBe('different_table_{run_time|"%H%M%S"}');
+  });
+
+  test("masks params when the query changed", async () => {
+    const request = await constructUpdateTransferConfigRequest(
+      clientReturning(unchangedTransferConfig()),
+      TRANSFER_CONFIG_NAME,
+      { ...config, queryString: "SELECT * FROM source.accounts" }
+    );
+
+    expect(request.updateMask?.paths).toEqual(["params"]);
+    expect(request.transferConfig?.params?.fields?.query?.stringValue).toBe(
+      "SELECT * FROM source.accounts"
+    );
+  });
+
+  test("leaves an unset partitioning field untouched when other params change", async () => {
+    const request = await constructUpdateTransferConfigRequest(
+      clientReturning(unchangedTransferConfig()),
+      TRANSFER_CONFIG_NAME,
+      { ...config, queryString: "SELECT * FROM source.accounts" }
+    );
+
+    expect(
+      request.transferConfig?.params?.fields?.partitioning_field?.stringValue
+    ).toBe("");
+  });
+
+  test("masks the notification topic when the stored one drifted", async () => {
+    const stored = unchangedTransferConfig();
+    stored.notificationPubsubTopic = "projects/test-project/topics/wrong-topic";
+
+    const request = await constructUpdateTransferConfigRequest(
+      clientReturning(stored),
+      TRANSFER_CONFIG_NAME,
+      { ...config, schedule: "every 15 minutes" }
+    );
+
+    expect(request.updateMask?.paths).toContain("notification_pubsub_topic");
+    expect(request.updateMask?.paths).toContain("schedule");
+    expect(request.transferConfig?.notificationPubsubTopic).toBe(
+      EXPECTED_TOPIC
+    );
+  });
+
+  test("masks the destination dataset when it changed", async () => {
+    const request = await constructUpdateTransferConfigRequest(
+      clientReturning(unchangedTransferConfig()),
+      TRANSFER_CONFIG_NAME,
+      { ...config, datasetId: "new_dataset_id" }
+    );
+
+    expect(request.updateMask?.paths).toContain("destination_dataset_id");
+    expect(request.transferConfig?.destinationDatasetId).toBe("new_dataset_id");
+  });
+
+  test("adds a partitioning field that was not previously set", async () => {
+    const request = await constructUpdateTransferConfigRequest(
+      clientReturning(unchangedTransferConfig()),
+      TRANSFER_CONFIG_NAME,
+      { ...config, partitioningField: "created_at" }
+    );
+
+    expect(request.updateMask?.paths).toEqual(["params"]);
+    expect(
+      request.transferConfig?.params?.fields?.partitioning_field?.stringValue
+    ).toBe("created_at");
+  });
+
+  test("rejects a stored config without params.fields", async () => {
+    const stored = unchangedTransferConfig();
+    delete stored.params;
+
+    await expect(
+      constructUpdateTransferConfigRequest(
+        clientReturning(stored),
+        TRANSFER_CONFIG_NAME,
+        config
+      )
+    ).rejects.toThrow("missing params.fields");
+  });
+});
+
+describe("getTransferConfig", () => {
+  test("returns the transfer config when found", async () => {
+    const client = clientReturning(unchangedTransferConfig());
+
+    const result = await getTransferConfig(client, TRANSFER_CONFIG_NAME);
+
+    expect(result).toEqual(unchangedTransferConfig());
+    expect(client.getTransferConfig).toHaveBeenCalledWith({
+      name: TRANSFER_CONFIG_NAME,
+    });
+  });
+
+  test("returns null on a gRPC NOT_FOUND", async () => {
+    const result = await getTransferConfig(
+      clientRejecting(grpcNotFound()),
+      TRANSFER_CONFIG_NAME
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("rethrows any other API failure", async () => {
+    await expect(
+      getTransferConfig(
+        clientRejecting(new Error("API Error")),
+        TRANSFER_CONFIG_NAME
+      )
+    ).rejects.toThrow("API Error");
+  });
+});
+
+describe("createTransferConfig", () => {
+  test("returns the created transfer config", async () => {
+    const created = { name: TRANSFER_CONFIG_NAME };
+    const client = clientReturning(null);
+    client.createTransferConfig.mockResolvedValue([created]);
+
+    const result = await createTransferConfig(client, config);
+
+    expect(result).toEqual(created);
+    expect(client.createTransferConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ parent: "projects/test-project" })
+    );
+  });
+
+  test("rejects when the API returns a config without a name", async () => {
+    const client = clientReturning(null);
+    client.createTransferConfig.mockResolvedValue([{}]);
+
+    await expect(createTransferConfig(client, config)).rejects.toThrow(
+      "BigQuery API returned a transfer config without a name"
+    );
+  });
+});
+
+describe("updateTransferConfig", () => {
+  test("returns the updated transfer config", async () => {
+    const updated = {
+      name: TRANSFER_CONFIG_NAME,
+      schedule: "every 15 minutes",
+    };
+    const client = clientReturning(unchangedTransferConfig());
+    client.updateTransferConfig.mockResolvedValue([updated]);
+
+    const result = await updateTransferConfig(client, TRANSFER_CONFIG_NAME, {
+      ...config,
+      schedule: "every 15 minutes",
+    });
+
+    expect(result).toEqual(updated);
+    expect(client.updateTransferConfig).toHaveBeenCalledOnce();
+  });
+
+  test("rejects when the transfer config no longer exists", async () => {
+    const client = clientReturning(null);
+
+    await expect(
+      updateTransferConfig(client, TRANSFER_CONFIG_NAME, config)
+    ).rejects.toThrow("Transfer config not found");
+    expect(client.updateTransferConfig).not.toHaveBeenCalled();
+  });
+
+  test("rethrows a failure from the update call", async () => {
+    const client = clientReturning(unchangedTransferConfig());
+    client.updateTransferConfig.mockRejectedValue(
+      new Error("Update API Error")
+    );
+
+    await expect(
+      updateTransferConfig(client, TRANSFER_CONFIG_NAME, config)
+    ).rejects.toThrow("Update API Error");
+  });
+});

--- a/kits/bigquery-firestore-export/tests/helper-values.test.ts
+++ b/kits/bigquery-firestore-export/tests/helper-values.test.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  BigQueryDate,
+  BigQueryDatetime,
+  BigQueryTime,
+  BigQueryTimestamp,
+} from "@google-cloud/bigquery";
+import { Timestamp } from "firebase-admin/firestore";
+import { describe, expect, test } from "vitest";
+import {
+  convertUnsupportedDataTypes,
+  parseTransferConfigName,
+  parseTransferRunName,
+} from "../src/helper";
+import type { FirestoreRow } from "../src/types";
+
+describe("parseTransferRunName", () => {
+  test("parses ids containing hyphens", () => {
+    expect(
+      parseTransferRunName(
+        "projects/project-123/locations/us-central1/transferConfigs/642f3a36-0000-2fbb-ad1d-001a114e2fa6/runs/648762e0-0000-28ef-9109-001a11446b2a"
+      )
+    ).toEqual({
+      projectId: "project-123",
+      location: "us-central1",
+      transferConfigId: "642f3a36-0000-2fbb-ad1d-001a114e2fa6",
+      runId: "648762e0-0000-28ef-9109-001a11446b2a",
+    });
+  });
+
+  test("rejects a name without a runs segment", () => {
+    expect(() =>
+      parseTransferRunName("projects/p/locations/l/transferConfigs/c")
+    ).toThrow("Invalid transfer run name format");
+  });
+
+  test("rejects an empty name", () => {
+    expect(() => parseTransferRunName("")).toThrow(
+      "Invalid transfer run name format"
+    );
+  });
+});
+
+describe("parseTransferConfigName", () => {
+  test("parses ids containing hyphens", () => {
+    expect(
+      parseTransferConfigName(
+        "projects/project-123/locations/us-central1/transferConfigs/642f3a36-0000-2fbb-ad1d-001a114e2fa6"
+      )
+    ).toEqual({
+      projectId: "project-123",
+      location: "us-central1",
+      transferConfigId: "642f3a36-0000-2fbb-ad1d-001a114e2fa6",
+    });
+  });
+
+  test("rejects a transfer run name", () => {
+    expect(() =>
+      parseTransferConfigName("projects/p/locations/l/transferConfigs/c/runs/r")
+    ).toThrow("Invalid transfer config name format");
+  });
+
+  test("rejects an empty name", () => {
+    expect(() => parseTransferConfigName("")).toThrow(
+      "Invalid transfer config name format"
+    );
+  });
+});
+
+describe("convertUnsupportedDataTypes", () => {
+  test("returns null and primitives unchanged", () => {
+    expect(convertUnsupportedDataTypes(null)).toBeNull();
+    expect(convertUnsupportedDataTypes("string")).toBe("string");
+    expect(convertUnsupportedDataTypes(123)).toBe(123);
+    expect(convertUnsupportedDataTypes(true)).toBe(true);
+  });
+
+  test("converts every BigQuery temporal type to a Firestore Timestamp", () => {
+    const converted = convertUnsupportedDataTypes({
+      timestamp: new BigQueryTimestamp("2023-01-15T10:30:00Z"),
+      date: new BigQueryDate("2023-01-15"),
+      datetime: new BigQueryDatetime("2023-01-15T10:30:00"),
+      time: new BigQueryTime("1970-01-01T10:30:00Z"),
+    });
+
+    expect(converted.timestamp).toBeInstanceOf(Timestamp);
+    expect(converted.date).toBeInstanceOf(Timestamp);
+    expect(converted.datetime).toBeInstanceOf(Timestamp);
+    expect(converted.time).toBeInstanceOf(Timestamp);
+    expect((converted.timestamp as Timestamp).toDate().toISOString()).toBe(
+      "2023-01-15T10:30:00.000Z"
+    );
+  });
+
+  test("converts a plain Date to a Firestore Timestamp", () => {
+    const converted = convertUnsupportedDataTypes({
+      date: new Date("2023-01-15T10:30:00Z"),
+    });
+
+    expect((converted.date as Timestamp).toDate().toISOString()).toBe(
+      "2023-01-15T10:30:00.000Z"
+    );
+  });
+
+  test("converts a Buffer to a Uint8Array of the same bytes", () => {
+    const converted = convertUnsupportedDataTypes({
+      data: Buffer.from([1, 2, 3, 4]),
+    });
+
+    expect(converted.data).toBeInstanceOf(Uint8Array);
+    expect(Array.from(converted.data as Uint8Array)).toEqual([1, 2, 3, 4]);
+  });
+
+  test("descends into nested objects and arrays", () => {
+    const converted = convertUnsupportedDataTypes({
+      outer: {
+        inner: { timestamp: new BigQueryTimestamp("2023-01-15T10:30:00Z") },
+      },
+      items: [
+        { timestamp: new BigQueryTimestamp("2023-01-15T10:30:00Z") },
+        { value: "plain" },
+      ],
+    });
+
+    const inner = (converted.outer as FirestoreRow).inner as FirestoreRow;
+    const items = converted.items as FirestoreRow[];
+    expect(inner.timestamp).toBeInstanceOf(Timestamp);
+    expect(items[0].timestamp).toBeInstanceOf(Timestamp);
+    expect(items[1].value).toBe("plain");
+  });
+
+  test("preserves null values at every depth", () => {
+    const converted = convertUnsupportedDataTypes({
+      name: "test",
+      nullField: null,
+      nested: { alsoNull: null },
+    });
+
+    expect(converted.nullField).toBeNull();
+    expect((converted.nested as FirestoreRow).alsoNull).toBeNull();
+  });
+});

--- a/kits/bigquery-firestore-export/tests/helper-values.test.ts
+++ b/kits/bigquery-firestore-export/tests/helper-values.test.ts
@@ -123,6 +123,8 @@ describe("convertUnsupportedDataTypes", () => {
     });
 
     expect(converted.data).toBeInstanceOf(Uint8Array);
+    // Buffer extends Uint8Array, so only this pins the conversion.
+    expect(converted.data).not.toBeInstanceOf(Buffer);
     expect(Array.from(converted.data as Uint8Array)).toEqual([1, 2, 3, 4]);
   });
 

--- a/kits/bigquery-firestore-export/tests/helper-values.test.ts
+++ b/kits/bigquery-firestore-export/tests/helper-values.test.ts
@@ -90,21 +90,30 @@ describe("convertUnsupportedDataTypes", () => {
     expect(convertUnsupportedDataTypes(true)).toBe(true);
   });
 
-  test("converts every BigQuery temporal type to a Firestore Timestamp", () => {
+  test("converts timestamp, date, and datetime values to Firestore Timestamps", () => {
     const converted = convertUnsupportedDataTypes({
       timestamp: new BigQueryTimestamp("2023-01-15T10:30:00Z"),
       date: new BigQueryDate("2023-01-15"),
       datetime: new BigQueryDatetime("2023-01-15T10:30:00"),
-      time: new BigQueryTime("1970-01-01T10:30:00Z"),
     });
 
-    expect(converted.timestamp).toBeInstanceOf(Timestamp);
-    expect(converted.date).toBeInstanceOf(Timestamp);
-    expect(converted.datetime).toBeInstanceOf(Timestamp);
-    expect(converted.time).toBeInstanceOf(Timestamp);
     expect((converted.timestamp as Timestamp).toDate().toISOString()).toBe(
       "2023-01-15T10:30:00.000Z"
     );
+    expect((converted.date as Timestamp).toDate().toISOString()).toBe(
+      "2023-01-15T00:00:00.000Z"
+    );
+    // A DATETIME carries no offset, so the conversion reads it in the
+    // machine's zone rather than UTC.
+    expect(converted.datetime).toEqual(
+      Timestamp.fromDate(new Date("2023-01-15T10:30:00"))
+    );
+  });
+
+  test("throws on a TIME value, which no Date can represent", () => {
+    expect(() =>
+      convertUnsupportedDataTypes({ time: new BigQueryTime("10:30:00") })
+    ).toThrow('Value for argument "seconds" is not a valid integer.');
   });
 
   test("converts a plain Date to a Firestore Timestamp", () => {

--- a/kits/bigquery-firestore-export/tests/notification-topic.test.ts
+++ b/kits/bigquery-firestore-export/tests/notification-topic.test.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { resolveConfig } from "../src/export-config";
+import type { HandlerContext } from "../src/handlers";
+
+const mocks = vi.hoisted(() => ({
+  createTransferConfig: vi.fn(),
+  getTransferConfig: vi.fn(),
+  updateTransferConfig: vi.fn(),
+  topicCreated: vi.fn(),
+}));
+
+vi.mock("../src/dts", () => ({
+  createTransferConfig: mocks.createTransferConfig,
+  getTransferConfig: mocks.getTransferConfig,
+  updateTransferConfig: mocks.updateTransferConfig,
+}));
+
+vi.mock("../src/logs", () => ({
+  complete: vi.fn(),
+  error: vi.fn(),
+  start: vi.fn(),
+  topicCreated: mocks.topicCreated,
+}));
+
+import { handleUpsertTransferConfig } from "../src/handlers";
+
+const config = resolveConfig({
+  bigqueryDatasetLocation: "US",
+  projectId: "test-project",
+  instanceId: "users-export",
+  datasetId: "analytics",
+  tableName: "users",
+  queryString: "SELECT * FROM source.users",
+  displayName: "Users export",
+  schedule: "every 24 hours",
+});
+
+function makeContext(options: { topicExists: boolean }) {
+  const set = vi.fn();
+  const exists = vi.fn().mockResolvedValue([options.topicExists]);
+  const topic = vi.fn(() => ({ exists }));
+  const createTopic = vi.fn().mockResolvedValue(undefined);
+  const collection = vi.fn(() => ({
+    doc: vi.fn(() => ({ set })),
+    where: vi.fn(() => ({
+      limit: vi.fn(() => ({
+        get: vi.fn().mockResolvedValue({ empty: true, docs: [] }),
+      })),
+    })),
+  }));
+
+  return {
+    ctx: {
+      db: { collection },
+      bigquery: {},
+      dataTransfer: {},
+      pubsub: { topic, createTopic },
+      config,
+    } as unknown as HandlerContext,
+    topic,
+    createTopic,
+  };
+}
+
+/** gRPC status codes surfaced by the Pub/Sub admin client. */
+const ALREADY_EXISTS = 6;
+const PERMISSION_DENIED = 7;
+
+function grpcError(code: number, message: string): Error {
+  return Object.assign(new Error(message), { code });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.createTransferConfig.mockResolvedValue({
+    name: "projects/p/locations/us/transferConfigs/config-1",
+  });
+});
+
+describe("ensureNotificationTopic", () => {
+  test("does not create the topic when it already exists", async () => {
+    const { ctx, topic, createTopic } = makeContext({ topicExists: true });
+
+    await handleUpsertTransferConfig(ctx);
+
+    expect(topic).toHaveBeenCalledWith(config.pubSubTopic);
+    expect(createTopic).not.toHaveBeenCalled();
+    expect(mocks.topicCreated).not.toHaveBeenCalled();
+  });
+
+  test("creates the topic when it does not exist", async () => {
+    const { ctx, createTopic } = makeContext({ topicExists: false });
+
+    await handleUpsertTransferConfig(ctx);
+
+    expect(createTopic).toHaveBeenCalledWith(config.pubSubTopic);
+    expect(mocks.topicCreated).toHaveBeenCalledWith(config.pubSubTopic);
+  });
+
+  test("swallows ALREADY_EXISTS from a concurrent create", async () => {
+    const { ctx, createTopic } = makeContext({ topicExists: false });
+    createTopic.mockRejectedValue(
+      grpcError(ALREADY_EXISTS, "Topic already exists")
+    );
+
+    await expect(handleUpsertTransferConfig(ctx)).resolves.toBeUndefined();
+
+    expect(mocks.topicCreated).not.toHaveBeenCalled();
+    expect(mocks.createTransferConfig).toHaveBeenCalledOnce();
+  });
+
+  test("rethrows other gRPC failures and skips the transfer config", async () => {
+    const { ctx, createTopic } = makeContext({ topicExists: false });
+    createTopic.mockRejectedValue(
+      grpcError(PERMISSION_DENIED, "User not authorized")
+    );
+
+    await expect(handleUpsertTransferConfig(ctx)).rejects.toThrow(
+      "User not authorized"
+    );
+
+    expect(mocks.createTransferConfig).not.toHaveBeenCalled();
+  });
+
+  test("rethrows errors that carry no gRPC status code", async () => {
+    const { ctx, createTopic } = makeContext({ topicExists: false });
+    createTopic.mockRejectedValue(new Error("network unreachable"));
+
+    await expect(handleUpsertTransferConfig(ctx)).rejects.toThrow(
+      "network unreachable"
+    );
+
+    expect(mocks.createTransferConfig).not.toHaveBeenCalled();
+  });
+});

--- a/kits/bigquery-firestore-export/tests/run-results.test.ts
+++ b/kits/bigquery-firestore-export/tests/run-results.test.ts
@@ -15,7 +15,6 @@
  */
 
 import type { BigQuery } from "@google-cloud/bigquery";
-import type { Firestore } from "firebase-admin/firestore";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { resolveConfig } from "../src/export-config";
 import type { BigQueryRow, TransferRunMessage } from "../src/types";

--- a/kits/bigquery-firestore-export/tests/run-results.test.ts
+++ b/kits/bigquery-firestore-export/tests/run-results.test.ts
@@ -1,0 +1,373 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { BigQuery } from "@google-cloud/bigquery";
+import type { Firestore } from "firebase-admin/firestore";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { resolveConfig } from "../src/export-config";
+import type { BigQueryRow, TransferRunMessage } from "../src/types";
+
+const mocks = vi.hoisted(() => ({
+  errorWritingToFirestore: vi.fn(),
+  latestDocUpdateSkipped: vi.fn(),
+  handlingNonSuccessRun: vi.fn(),
+}));
+
+vi.mock("../src/logs", () => ({
+  bigqueryJobStarted: vi.fn(),
+  bigqueryQueryFailed: vi.fn(),
+  bigqueryResultsRowCount: vi.fn(),
+  errorWritingToFirestore: mocks.errorWritingToFirestore,
+  handlingNonSuccessRun: mocks.handlingNonSuccessRun,
+  latestDocUpdateSkipped: mocks.latestDocUpdateSkipped,
+  runResultsWrittenToFirestore: vi.fn(),
+}));
+
+import {
+  handleTransferRunMessage,
+  type ResultHandlerContext,
+  writeRunResultsToFirestore,
+} from "../src/helper";
+
+type Data = Record<string, unknown>;
+
+const config = resolveConfig({
+  bigqueryDatasetLocation: "US",
+  projectId: "test-project",
+  instanceId: "users-export",
+  datasetId: "analytics",
+  tableName: "users",
+  queryString: "SELECT * FROM source.users",
+  displayName: "Users export",
+  schedule: "every 24 hours",
+});
+
+const TRANSFER_CONFIG_ID = "642f3a36-0000-2fbb-ad1d-001a114e2fa6";
+const RUN_ID = "648762e0-0000-28ef-9109-001a11446b2a";
+
+function runName(runId = RUN_ID): string {
+  return `projects/test-project/locations/us/transferConfigs/${TRANSFER_CONFIG_ID}/runs/${runId}`;
+}
+
+function message(
+  overrides: Partial<TransferRunMessage["json"]> = {}
+): TransferRunMessage {
+  return {
+    json: {
+      name: runName(),
+      runTime: "2023-03-23T21:03:00Z",
+      state: "SUCCEEDED",
+      destinationDatasetId: "test",
+      dataSourceId: "scheduled_query",
+      schedule: "every 15 minutes",
+      scheduleTime: "2023-03-23T21:03:00Z",
+      startTime: "2023-03-23T21:03:01.133872Z",
+      endTime: "2023-03-23T21:04:16.167236Z",
+      updateTime: "2023-03-23T21:04:16.167248Z",
+      userId: "-1291228896441774269",
+      notificationPubsubTopic: "projects/test-project/topics/transfer_runs",
+      params: {
+        destination_table_name_template: 'users_{run_time|"%H%M%S"}',
+        partitioning_field: "",
+        query: "SELECT * FROM source.users",
+        write_disposition: "WRITE_TRUNCATE",
+      },
+      emailPreferences: {},
+      errorStatus: {},
+      ...overrides,
+    },
+  };
+}
+
+/**
+ * Minimal in-memory stand-in for the Firestore surface the helpers touch:
+ * path-addressed documents, auto-id adds, a single equality query and a
+ * transaction that runs its body against the same store.
+ */
+class FakeFirestore {
+  readonly docs = new Map<string, Data>();
+  private nextAutoId = 0;
+  /** Fails an `add` whose row index matches, to exercise partial write failures. */
+  rejectAddAt: number | null = null;
+  private addCount = 0;
+
+  collection(path: string) {
+    return {
+      doc: (id: string) => this.docRef(`${path}/${id}`),
+      add: async (data: Data) => {
+        const index = this.addCount++;
+        if (index === this.rejectAddAt) {
+          throw new Error(`write failed for row ${index}`);
+        }
+        const ref = this.docRef(`${path}/auto-${this.nextAutoId++}`);
+        this.docs.set(ref.path, data);
+        return ref;
+      },
+      where: (field: string, _op: string, value: unknown) => {
+        const query = {
+          limit: () => query,
+          get: async () => {
+            const docs = [...this.docs.entries()]
+              .filter(([docPath]) => parentPath(docPath) === path)
+              .filter(([, data]) => data[field] === value)
+              .map(([docPath, data]) => ({
+                id: docPath.split("/").at(-1),
+                data: () => data,
+              }));
+            return { empty: docs.length === 0, docs };
+          },
+        };
+        return query;
+      },
+    };
+  }
+
+  async runTransaction<T>(
+    body: (transaction: {
+      get: (ref: { path: string }) => Promise<{ data: () => Data | undefined }>;
+      set: (ref: { path: string }, data: Data) => void;
+    }) => Promise<T>
+  ): Promise<T> {
+    return body({
+      get: async (ref) => ({ data: () => this.docs.get(ref.path) }),
+      set: (ref, data) => {
+        this.docs.set(ref.path, data);
+      },
+    });
+  }
+
+  private docRef(path: string) {
+    return {
+      path,
+      id: path.split("/").at(-1),
+      set: async (data: Data) => {
+        this.docs.set(path, data);
+      },
+    };
+  }
+}
+
+function parentPath(path: string): string {
+  return path.slice(0, path.lastIndexOf("/"));
+}
+
+function fakeBigquery(rows: BigQueryRow[]) {
+  const createQueryJob = vi.fn().mockResolvedValue([
+    {
+      id: "job-1",
+      getQueryResults: vi.fn().mockResolvedValue([rows]),
+    },
+  ]);
+  return { createQueryJob } as unknown as BigQuery & {
+    createQueryJob: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeContext(rows: BigQueryRow[] = [{ query: "result" }]) {
+  const db = new FakeFirestore();
+  const bigquery = fakeBigquery(rows);
+  return {
+    db,
+    bigquery,
+    ctx: { db, bigquery, config } as unknown as ResultHandlerContext,
+  };
+}
+
+function associate(db: FakeFirestore): void {
+  db.docs.set(`${config.firestoreCollection}/${TRANSFER_CONFIG_ID}`, {
+    extInstanceId: config.instanceId,
+  });
+}
+
+function runsPath(): string {
+  return `${config.firestoreCollection}/${TRANSFER_CONFIG_ID}/runs`;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("writeRunResultsToFirestore", () => {
+  test("queries the run's destination table and writes every row", async () => {
+    const rows = [{ query: "result" }, { query: "second" }];
+    const { db, bigquery, ctx } = makeContext(rows);
+
+    await writeRunResultsToFirestore(ctx, message());
+
+    expect(bigquery.createQueryJob).toHaveBeenCalledWith({
+      query: "SELECT * FROM `test-project.test.users_210300`",
+      location: "US",
+    });
+    const outputPath = `${runsPath()}/${RUN_ID}/output`;
+    const written = [...db.docs.entries()]
+      .filter(([path]) => parentPath(path) === outputPath)
+      .map(([, data]) => data);
+    expect(written).toEqual(rows);
+  });
+
+  test("records the run and latest documents with row counts", async () => {
+    const { db, ctx } = makeContext();
+    const msg = message();
+
+    await writeRunResultsToFirestore(ctx, msg);
+
+    expect(db.docs.get(`${runsPath()}/${RUN_ID}`)).toEqual({
+      runMetadata: msg.json,
+      failedRowCount: 0,
+      totalRowCount: 1,
+    });
+    expect(db.docs.get(`${runsPath()}/latest`)).toEqual({
+      runMetadata: msg.json,
+      latestRunId: RUN_ID,
+      failedRowCount: 0,
+      totalRowCount: 1,
+    });
+  });
+
+  test("counts and logs rows that fail to write", async () => {
+    const { db, ctx } = makeContext([
+      { query: "first" },
+      { query: "second" },
+      { query: "third" },
+    ]);
+    db.rejectAddAt = 1;
+
+    await writeRunResultsToFirestore(ctx, message());
+
+    expect(mocks.errorWritingToFirestore).toHaveBeenCalledOnce();
+    expect(db.docs.get(`${runsPath()}/${RUN_ID}`)).toMatchObject({
+      failedRowCount: 1,
+      totalRowCount: 3,
+    });
+    expect(db.docs.get(`${runsPath()}/latest`)).toMatchObject({
+      failedRowCount: 1,
+      totalRowCount: 3,
+    });
+  });
+});
+
+describe("handleTransferRunMessage", () => {
+  test("rejects a run belonging to another extension instance", async () => {
+    const { ctx } = makeContext();
+
+    await expect(handleTransferRunMessage(ctx, message())).rejects.toThrow(
+      `Skipping handling pubsub message because transferConfig '${TRANSFER_CONFIG_ID}' is not associated with extension instance '${config.instanceId}'.`
+    );
+  });
+
+  test("records a non-successful run with explicit zero counts", async () => {
+    const { db, ctx } = makeContext();
+    associate(db);
+    const failed = message({
+      state: "FAILED",
+      errorStatus: { message: "Query failed" },
+    });
+
+    await handleTransferRunMessage(ctx, failed);
+
+    expect(mocks.handlingNonSuccessRun).toHaveBeenCalledWith(
+      TRANSFER_CONFIG_ID,
+      RUN_ID,
+      "FAILED"
+    );
+    expect(db.docs.get(`${runsPath()}/${RUN_ID}`)).toEqual({
+      runMetadata: failed.json,
+      failedRowCount: 0,
+      totalRowCount: 0,
+    });
+    expect(db.docs.get(`${runsPath()}/latest`)).toEqual({
+      runMetadata: failed.json,
+      latestRunId: RUN_ID,
+      failedRowCount: 0,
+      totalRowCount: 0,
+    });
+  });
+
+  test("a newer failed run replaces a latest document from a successful run", async () => {
+    const { db, ctx } = makeContext();
+    associate(db);
+    const earlierRunId = "earlier-run";
+
+    await handleTransferRunMessage(
+      ctx,
+      message({ name: runName(earlierRunId), runTime: "2023-03-23T21:00:00Z" })
+    );
+    await handleTransferRunMessage(
+      ctx,
+      message({ state: "FAILED", runTime: "2023-03-23T22:00:00Z" })
+    );
+
+    const latest = db.docs.get(`${runsPath()}/latest`) as Data;
+    expect(latest.latestRunId).toBe(RUN_ID);
+    expect((latest.runMetadata as Data).state).toBe("FAILED");
+  });
+
+  test("an older run leaves the latest document alone", async () => {
+    const { db, ctx } = makeContext();
+    associate(db);
+
+    await handleTransferRunMessage(
+      ctx,
+      message({ runTime: "2023-03-23T22:00:00Z" })
+    );
+    await handleTransferRunMessage(
+      ctx,
+      message({
+        name: runName("older-run"),
+        state: "FAILED",
+        runTime: "2023-03-23T21:00:00Z",
+      })
+    );
+
+    const latest = db.docs.get(`${runsPath()}/latest`) as Data;
+    expect(latest.latestRunId).toBe(RUN_ID);
+    expect((latest.runMetadata as Data).state).toBe("SUCCEEDED");
+    expect(mocks.latestDocUpdateSkipped).toHaveBeenCalledOnce();
+  });
+
+  test("a redelivered message for the same run updates latest despite an equal runTime", async () => {
+    const { db, ctx } = makeContext();
+    associate(db);
+
+    await handleTransferRunMessage(
+      ctx,
+      message({ state: "FAILED", errorStatus: { message: "Query failed" } })
+    );
+    expect(
+      ((db.docs.get(`${runsPath()}/latest`) as Data).runMetadata as Data).state
+    ).toBe("FAILED");
+
+    await handleTransferRunMessage(ctx, message());
+
+    const latest = db.docs.get(`${runsPath()}/latest`) as Data;
+    expect((latest.runMetadata as Data).state).toBe("SUCCEEDED");
+    expect(latest.latestRunId).toBe(RUN_ID);
+    expect(mocks.latestDocUpdateSkipped).not.toHaveBeenCalled();
+  });
+
+  test("overwrites a latest document that is missing its run metadata", async () => {
+    const { db, ctx } = makeContext();
+    associate(db);
+    db.docs.set(`${runsPath()}/latest`, { someOtherField: "corrupted" });
+
+    await handleTransferRunMessage(ctx, message());
+
+    const latest = db.docs.get(`${runsPath()}/latest`) as Data;
+    expect(latest.latestRunId).toBe(RUN_ID);
+    expect(latest.runMetadata).toBeDefined();
+    expect(latest.someOtherField).toBeUndefined();
+  });
+});


### PR DESCRIPTION
The kit carried 19 unit tests against roughly 1,330 lines of unit coverage in the legacy `bigquery-firestore-export` extension, and `ensureNotificationTopic` - code with no legacy counterpart - had none at all. This ports the missing coverage: 63 tests now, all in four new files so nothing existing is edited and no src changes are made.

`notification-topic.test.ts` drives `ensureNotificationTopic` through `handleUpsertTransferConfig` and pins the concurrent-create race (gRPC ALREADY_EXISTS swallowed, every other error rethrown before the transfer config is touched). `dts-transfer-config.test.ts` backfills the legacy update-mask change-detection cases and the get/create/update wrappers. `run-results.test.ts` replaces the legacy emulator setup with an in-memory Firestore fake against the injected `HandlerContext`, pinning row counts, partial write failures, non-success runs, latest-document ordering and Pub/Sub redelivery. `helper-values.test.ts` ports the granular value-conversion and name-parsing cases.

Deliberately skipped: the live reconfiguration e2e suite and the `xdescribe`'d `e2e/functions.test.ts`, neither of which runs without live GCP resources. Assertions follow the kit's current behavior, not the legacy soft-failure paths.

Part of #2974.