### PR TITLE
test(firestore-send-email): port the legacy unit suites into the kit

### DIFF
--- a/kits/firestore-send-email/tests/config.test.ts
+++ b/kits/firestore-send-email/tests/config.test.ts
@@ -16,10 +16,22 @@
 
 import { describe, expect, test, vi } from "vitest";
 
+interface StringParamOpts {
+  default?: string;
+  input?: { text?: { validationRegex?: RegExp } };
+}
+
+const { stringParamOpts } = vi.hoisted(() => ({
+  stringParamOpts: new Map<string, StringParamOpts | undefined>(),
+}));
+
 vi.mock("firebase-functions/params", () => ({
-  defineString: (_name: string, opts?: { default?: string }) => ({
-    value: () => opts?.default ?? "",
-  }),
+  defineString: (name: string, opts?: StringParamOpts) => {
+    stringParamOpts.set(name, opts);
+    return {
+      value: () => opts?.default ?? "",
+    };
+  },
   defineInt: (_name: string, opts?: { default?: number }) => ({
     value: () => opts?.default ?? 0,
   }),
@@ -87,6 +99,43 @@ describe("secretParamsForAuthType", () => {
     expect(() => secretParamsForAuthType("Unknown")).toThrow(
       "Unsupported AUTH_TYPE for firestore-send-email: Unknown"
     );
+  });
+});
+
+describe("SMTP_CONNECTION_URI validationRegex", () => {
+  function connectionUriRegex(): RegExp {
+    const regex = stringParamOpts.get("SMTP_CONNECTION_URI")?.input?.text
+      ?.validationRegex;
+    if (!regex) {
+      throw new Error("SMTP_CONNECTION_URI declares no validationRegex");
+    }
+    return regex;
+  }
+
+  test("accepts the documented URI forms and a blank value", () => {
+    for (const uri of [
+      "smtps://username@smtp.hostname.com:465",
+      "smtps://smtp.gmail.com:465",
+      "smtps://username@gmail.com:password@smtp.gmail.com:465",
+      "smtp://smtp.gmail.com:587?pool=true",
+      "",
+    ]) {
+      expect(connectionUriRegex().test(uri)).toBe(true);
+    }
+  });
+
+  test("rejects a URI without a scheme or without a port", () => {
+    expect(connectionUriRegex().test("smtp.gmail.com:465")).toBe(false);
+    expect(connectionUriRegex().test("smtp://smtp.gmail.com")).toBe(false);
+  });
+
+  test("accepts trailing garbage after a valid prefix because the first alternative is unanchored", () => {
+    for (const uri of [
+      "smtp://fakeemail@gmail.com:4,h?dhuNTbv9zMrP4&7&7%*3:smtp.gmail.com:465?pool=true&service=gmail",
+      "smtps://smtp.gmail.com:465 and then total garbage",
+    ]) {
+      expect(connectionUriRegex().test(uri)).toBe(true);
+    }
   });
 });
 

--- a/kits/firestore-send-email/tests/config.test.ts
+++ b/kits/firestore-send-email/tests/config.test.ts
@@ -129,6 +129,7 @@ describe("SMTP_CONNECTION_URI validationRegex", () => {
     expect(connectionUriRegex().test("smtp://smtp.gmail.com")).toBe(false);
   });
 
+  // Inherited from the legacy extension.yaml regex; anchoring is tracked in #3067.
   test("accepts trailing garbage after a valid prefix because the first alternative is unanchored", () => {
     for (const uri of [
       "smtp://fakeemail@gmail.com:4,h?dhuNTbv9zMrP4&7&7%*3:smtp.gmail.com:465?pool=true&service=gmail",

--- a/kits/firestore-send-email/tests/helpers.test.ts
+++ b/kits/firestore-send-email/tests/helpers.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { logger } from "firebase-functions";
+import Mail from "nodemailer/lib/mailer";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { ResolvedSendEmailConfig } from "../src/export-config";
+import { isSendGrid, setSmtpCredentials } from "../src/helpers";
+import { AuthenticatonType } from "../src/types";
+
+const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
+
+function makeConfig(
+  overrides: Partial<ResolvedSendEmailConfig>
+): ResolvedSendEmailConfig {
+  return {
+    databaseId: "(default)",
+    databaseRegion: "us-central1",
+    mailCollection: "mail",
+    defaultFrom: "",
+    testing: false,
+    ttlExpireType: "never",
+    ttlExpireValue: 1,
+    tlsOptions: "{}",
+    oauthSecure: true,
+    authType: AuthenticatonType.UsernamePassword,
+    ...overrides,
+  };
+}
+
+describe("setSmtpCredentials", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("prefers the smtpPassword secret over the password in the URI", () => {
+    const config = makeConfig({
+      smtpConnectionUri:
+        "smtps://fakeemail@gmail.com:secret-password@smtp.gmail.com:465",
+      smtpPassword: "fakepassword",
+    });
+
+    const credentials = setSmtpCredentials(config);
+
+    expect(credentials).toBeInstanceOf(Mail);
+    expect(credentials.options.port).toBe(465);
+    expect(credentials.options.host).toBe("smtp.gmail.com");
+    expect(credentials.options.auth.pass).toBe("fakepassword");
+    expect(credentials.options.secure).toBe(true);
+  });
+
+  test("falls back to the password embedded in the URI", () => {
+    const config = makeConfig({
+      smtpConnectionUri:
+        "smtps://fakeemail@gmail.com:secret-password@smtp.gmail.com:465",
+    });
+
+    const credentials = setSmtpCredentials(config);
+
+    expect(credentials).toBeInstanceOf(Mail);
+    expect(credentials.options.port).toBe(465);
+    expect(credentials.options.host).toBe("smtp.gmail.com");
+    expect(credentials.options.auth.user).toBe("fakeemail@gmail.com");
+    expect(credentials.options.auth.pass).toBe("secret-password");
+    expect(credentials.options.secure).toBe(true);
+  });
+
+  test("accepts a URI with a username but no password", () => {
+    const config = makeConfig({
+      smtpConnectionUri: "smtps://fakeemail@gmail.com@smtp.gmail.com:465",
+    });
+
+    const credentials = setSmtpCredentials(config);
+
+    expect(credentials).toBeInstanceOf(Mail);
+    expect(credentials.options.port).toBe(465);
+    expect(credentials.options.host).toBe("smtp.gmail.com");
+    expect(credentials.options.auth.user).toBe("fakeemail@gmail.com");
+    expect(credentials.options.auth.pass).toBe("");
+    expect(credentials.options.secure).toBe(true);
+  });
+
+  test("accepts a URI with neither username nor password", () => {
+    const config = makeConfig({
+      smtpConnectionUri: "smtp://smtp.gmail.com:465",
+    });
+
+    const credentials = setSmtpCredentials(config);
+
+    expect(credentials).toBeInstanceOf(Mail);
+    expect(credentials.options.port).toBe(465);
+    expect(credentials.options.host).toBe("smtp.gmail.com");
+    expect(credentials.options.auth).toBe(undefined);
+    expect(credentials.options.secure).toBe(false);
+  });
+
+  test("forwards query params from the URI to the transport options", () => {
+    const config = makeConfig({
+      smtpConnectionUri:
+        "smtp://fakeemail@gmail.com:secret-password@smtp.gmail.com:465?pool=true&service=gmail",
+    });
+
+    const credentials = setSmtpCredentials(config);
+
+    expect(credentials).toBeInstanceOf(Mail);
+    expect(credentials.options.port).toBe(465);
+    expect(credentials.options.host).toBe("smtp.gmail.com");
+    expect(credentials.options.auth.user).toBe("fakeemail@gmail.com");
+    expect(credentials.options.auth.pass).toBe("secret-password");
+    expect(credentials.options.secure).toBe(false);
+    expect(credentials.options.pool).toBe(true);
+    expect(credentials.options.service).toBe("gmail");
+  });
+
+  test("percent-encodes special characters in the smtpPassword secret", () => {
+    const config = makeConfig({
+      smtpConnectionUri:
+        "smtp://fakeemail@gmail.com@smtp.gmail.com:465?pool=true&service=gmail",
+      smtpPassword: "4,h?dhuNTbv9zMrP4&7&7%*3",
+    });
+
+    const credentials = setSmtpCredentials(config);
+
+    expect(credentials).toBeInstanceOf(Mail);
+    expect(credentials.options.port).toBe(465);
+    expect(credentials.options.host).toBe("smtp.gmail.com");
+    expect(credentials.options.auth.user).toBe("fakeemail@gmail.com");
+    expect(credentials.options.auth.pass).toBe("4,h?dhuNTbv9zMrP4&7&7%*3");
+    expect(credentials.options.secure).toBe(false);
+    expect(credentials.options.pool).toBe(true);
+    expect(credentials.options.service).toBe("gmail");
+  });
+
+  test("percent-encodes special characters in the URI password", () => {
+    const config = makeConfig({
+      smtpConnectionUri:
+        "smtp://fakeemail@gmail.com:4,hdhuNTbv9zMrP4&7&7%*3@smtp.gmail.com:465?pool=true&service=gmail",
+    });
+
+    const credentials = setSmtpCredentials(config);
+
+    expect(credentials).toBeInstanceOf(Mail);
+    expect(credentials.options.port).toBe(465);
+    expect(credentials.options.host).toBe("smtp.gmail.com");
+    expect(credentials.options.auth.user).toBe("fakeemail@gmail.com");
+    expect(credentials.options.auth.pass).toBe("4,hdhuNTbv9zMrP4&7&7%*3");
+    expect(credentials.options.secure).toBe(false);
+    expect(credentials.options.pool).toBe(true);
+    expect(credentials.options.service).toBe("gmail");
+  });
+
+  test("throws and warns when the URI cannot be parsed", () => {
+    const config = makeConfig({
+      smtpConnectionUri:
+        "smtp://fakeemail@gmail.com:4,h?dhuNTbv9zMrP4&7&7%*3@smtp.gmail.com:465?pool=true&service=gmail",
+    });
+
+    expect(() => setSmtpCredentials(config)).toThrow(Error);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Invalid URI: please reconfigure with a valid SMTP connection URI"
+    );
+  });
+
+  test("builds an OAuth2 transport when the auth type is OAuth2", () => {
+    const config = makeConfig({
+      smtpConnectionUri:
+        "smtps://fakeemail@gmail.com:secret-password@smtp.gmail.com:465",
+      host: "smtp.gmail.com",
+      clientId: "fakeClientId",
+      clientSecret: "fakeClientSecret",
+      refreshToken: "test_refresh_token",
+      oauthSecure: true,
+      authType: AuthenticatonType.OAuth2,
+      user: "test@test.com",
+    });
+
+    const credentials = setSmtpCredentials(config);
+
+    expect(credentials).toBeInstanceOf(Mail);
+    expect(credentials.options.secure).toBe(true);
+    expect(credentials.options.host).toBe("smtp.gmail.com");
+    expect(credentials.options.auth.type).toBe("OAuth2");
+    expect(credentials.options.auth.clientId).toBe("fakeClientId");
+    expect(credentials.options.auth.clientSecret).toBe("fakeClientSecret");
+    expect(credentials.options.auth.user).toBe("test@test.com");
+    expect(credentials.options.auth.refreshToken).toBe("test_refresh_token");
+  });
+});
+
+describe("isSendGrid", () => {
+  test("returns true for a SendGrid SMTP URI", () => {
+    expect(
+      isSendGrid(
+        makeConfig({
+          smtpConnectionUri: "smtps://apikey@smtp.sendgrid.net:465",
+          authType: AuthenticatonType.ApiKey,
+        })
+      )
+    ).toBe(true);
+  });
+
+  test("returns false for a non-SendGrid SMTP URI", () => {
+    expect(
+      isSendGrid(
+        makeConfig({
+          smtpConnectionUri:
+            "smtps://fakeemail@gmail.com:secret-password@smtp.gmail.com:465",
+        })
+      )
+    ).toBe(false);
+  });
+
+  test("returns false for a hostname that merely contains sendgrid", () => {
+    expect(
+      isSendGrid(
+        makeConfig({
+          smtpConnectionUri: "smtps://apikey@fake-sendgrid.net:465",
+        })
+      )
+    ).toBe(false);
+  });
+
+  test("returns false when no URI is configured", () => {
+    expect(isSendGrid(makeConfig({}))).toBe(false);
+  });
+});

--- a/kits/firestore-send-email/tests/helpers.test.ts
+++ b/kits/firestore-send-email/tests/helpers.test.ts
@@ -125,7 +125,7 @@ describe("setSmtpCredentials", () => {
     expect(credentials.options.service).toBe("gmail");
   });
 
-  test("percent-encodes special characters in the smtpPassword secret", () => {
+  test("round-trips special characters in the smtpPassword secret", () => {
     const config = makeConfig({
       smtpConnectionUri:
         "smtp://fakeemail@gmail.com@smtp.gmail.com:465?pool=true&service=gmail",
@@ -144,7 +144,7 @@ describe("setSmtpCredentials", () => {
     expect(credentials.options.service).toBe("gmail");
   });
 
-  test("percent-encodes special characters in the URI password", () => {
+  test("round-trips special characters in the URI password", () => {
     const config = makeConfig({
       smtpConnectionUri:
         "smtp://fakeemail@gmail.com:4,hdhuNTbv9zMrP4&7&7%*3@smtp.gmail.com:465?pool=true&service=gmail",
@@ -160,6 +160,22 @@ describe("setSmtpCredentials", () => {
     expect(credentials.options.secure).toBe(false);
     expect(credentials.options.pool).toBe(true);
     expect(credentials.options.service).toBe("gmail");
+  });
+
+  test("builds a hotmail service transport for Microsoft SMTP hosts", () => {
+    const config = makeConfig({
+      smtpConnectionUri:
+        "smtp://fakeemail@outlook.com@smtp-mail.outlook.com:587",
+      smtpPassword: "secret/password",
+    });
+
+    const credentials = setSmtpCredentials(config);
+
+    expect(credentials).toBeInstanceOf(Mail);
+    expect(credentials.options.service).toBe("hotmail");
+    expect(credentials.options.auth.user).toBe("fakeemail@outlook.com");
+    expect(credentials.options.auth.pass).toBe("secret/password");
+    expect(credentials.options.tls).toBeUndefined();
   });
 
   test("throws and warns when the URI cannot be parsed", () => {

--- a/kits/firestore-send-email/tests/nodemailer-sendgrid.test.ts
+++ b/kits/firestore-send-email/tests/nodemailer-sendgrid.test.ts
@@ -52,7 +52,7 @@ function flush(): Promise<void> {
 }
 
 function sentMessage(): any {
-  return send.mock.calls[0][0] as any;
+  return send.mock.calls[0]?.[0];
 }
 
 const successInfo = {

--- a/kits/firestore-send-email/tests/nodemailer-sendgrid.test.ts
+++ b/kits/firestore-send-email/tests/nodemailer-sendgrid.test.ts
@@ -1,0 +1,437 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@sendgrid/mail", () => ({
+  setApiKey: vi.fn(),
+  send: vi.fn().mockResolvedValue([
+    {
+      headers: { "x-message-id": "test-message-id" },
+      statusCode: 202,
+    },
+    {},
+  ]),
+}));
+
+import * as sgMail from "@sendgrid/mail";
+import { SendGridTransport } from "../src/nodemailer-sendgrid";
+import type {
+  Address,
+  AttachmentEntry,
+  IcalEvent,
+  MailSource,
+} from "../src/nodemailer-sendgrid/types";
+
+const setApiKey = vi.mocked(sgMail.setApiKey);
+const send = vi.mocked(sgMail.send);
+
+/** Wraps a normalized mail source in the minimal MailSource shape the transport consumes. */
+function mailFrom(source: Partial<MailSource>): MailSource {
+  return {
+    normalize: (cb) => cb(null, source as MailSource),
+  } as MailSource;
+}
+
+/** Yields to the microtask queue so the transport's normalize/send chain settles. */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function sentMessage(): any {
+  return send.mock.calls[0][0] as any;
+}
+
+const successInfo = {
+  messageId: null,
+  queueId: "test-message-id",
+  accepted: [] as string[],
+  rejected: [],
+  pending: [],
+  response: "status=202",
+};
+
+describe("SendGridTransport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("sets the API key when one is provided", () => {
+    new SendGridTransport({ apiKey: "API-KEY-123" });
+    expect(setApiKey).toHaveBeenCalledWith("API-KEY-123");
+  });
+
+  test("does not set an API key when the option is absent", () => {
+    new SendGridTransport({});
+    expect(setApiKey).not.toHaveBeenCalled();
+  });
+
+  test("calls back with the normalize error and never sends", async () => {
+    const transport = new SendGridTransport({ apiKey: "X" });
+    const normalizeError = new Error("normalize failed");
+    const cb = vi.fn();
+
+    transport.send(
+      { normalize: (callback) => callback(normalizeError, {} as MailSource) },
+      cb
+    );
+    await flush();
+
+    expect(cb).toHaveBeenCalledWith(normalizeError);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  test("maps subject, text and html straight through", async () => {
+    const transport = new SendGridTransport();
+    const cb = vi.fn();
+
+    transport.send(mailFrom({ subject: "S", text: "T", html: "<p>H</p>" }), cb);
+    await flush();
+
+    expect(send).toHaveBeenCalledWith({
+      subject: "S",
+      text: "T",
+      html: "<p>H</p>",
+    });
+    expect(cb).toHaveBeenCalledWith(null, successInfo);
+  });
+
+  test("maps from and replyTo to single addresses", async () => {
+    const transport = new SendGridTransport();
+    const address: Address = { name: "Alice", address: "a@x.com" };
+    const cb = vi.fn();
+
+    transport.send(mailFrom({ from: address, replyTo: [address] }), cb);
+    await flush();
+
+    expect(sentMessage().from).toEqual({ name: "Alice", email: "a@x.com" });
+    expect(sentMessage().replyTo).toEqual({ name: "Alice", email: "a@x.com" });
+    expect(cb).toHaveBeenCalledWith(null, successInfo);
+  });
+
+  test("maps to, cc and bcc into address arrays", async () => {
+    const transport = new SendGridTransport();
+    const first: Address = { name: "B", address: "b@x" };
+    const second: Address = { name: "C", address: "c@x" };
+    const cb = vi.fn();
+
+    transport.send(
+      mailFrom({ to: [first], cc: second, bcc: [first, second] }),
+      cb
+    );
+    await flush();
+
+    expect(sentMessage().to).toEqual([{ name: "B", email: "b@x" }]);
+    expect(sentMessage().cc).toEqual([{ name: "C", email: "c@x" }]);
+    expect(sentMessage().bcc).toEqual([
+      { name: "B", email: "b@x" },
+      { name: "C", email: "c@x" },
+    ]);
+    expect(cb).toHaveBeenCalledWith(null, {
+      ...successInfo,
+      accepted: ["b@x", "c@x"],
+    });
+  });
+
+  test("maps attachments with inline and attachment dispositions", async () => {
+    const transport = new SendGridTransport();
+    const attachments: AttachmentEntry[] = [
+      { content: "foo", filename: "f.txt", contentType: "text/plain" },
+      {
+        content: "img",
+        filename: "i.png",
+        contentType: "image/png",
+        cid: "cid123",
+      },
+    ];
+    const cb = vi.fn();
+
+    transport.send(mailFrom({ attachments }), cb);
+    await flush();
+
+    const sent = sentMessage().attachments;
+    expect(sent).toHaveLength(2);
+    expect(sent[0]).toMatchObject({
+      content: "foo",
+      filename: "f.txt",
+      type: "text/plain",
+      disposition: "attachment",
+    });
+    expect(sent[1]).toMatchObject({
+      content: "img",
+      filename: "i.png",
+      type: "image/png",
+      disposition: "inline",
+      content_id: "cid123",
+    });
+    expect(cb).toHaveBeenCalledWith(null, successInfo);
+  });
+
+  test("maps alternatives into the content array", async () => {
+    const transport = new SendGridTransport();
+    const cb = vi.fn();
+
+    transport.send(
+      mailFrom({ alternatives: [{ content: "alt", contentType: "text/alt" }] }),
+      cb
+    );
+    await flush();
+
+    expect(sentMessage().content).toEqual([{ type: "text/alt", value: "alt" }]);
+    expect(cb).toHaveBeenCalledWith(null, successInfo);
+  });
+
+  test("maps icalEvent to an attachment", async () => {
+    const transport = new SendGridTransport();
+    const event: IcalEvent = { content: "ics", filename: "evt.ics" };
+    const cb = vi.fn();
+
+    transport.send(mailFrom({ icalEvent: event }), cb);
+    await flush();
+
+    expect(sentMessage().attachments[0]).toMatchObject({
+      content: "ics",
+      filename: "evt.ics",
+      type: "application/ics",
+      disposition: "attachment",
+    });
+    expect(cb).toHaveBeenCalledWith(null, successInfo);
+  });
+
+  test("maps watchHtml into the content array", async () => {
+    const transport = new SendGridTransport();
+    const cb = vi.fn();
+
+    transport.send(mailFrom({ watchHtml: "<watch>" }), cb);
+    await flush();
+
+    expect(sentMessage().content).toEqual([
+      { type: "text/watch-html", value: "<watch>" },
+    ]);
+    expect(cb).toHaveBeenCalledWith(null, successInfo);
+  });
+
+  test("merges normalizedHeaders and messageId into headers", async () => {
+    const transport = new SendGridTransport();
+    const cb = vi.fn();
+
+    transport.send(
+      mailFrom({
+        normalizedHeaders: { "X-Custom": "val" },
+        messageId: "msg-123",
+      }),
+      cb
+    );
+    await flush();
+
+    expect(sentMessage().headers).toMatchObject({
+      "X-Custom": "val",
+      "message-id": "msg-123",
+    });
+    expect(cb).toHaveBeenCalledWith(null, {
+      ...successInfo,
+      messageId: "msg-123",
+    });
+  });
+
+  test("folds text and html into the content array when alternatives exist", async () => {
+    const transport = new SendGridTransport();
+    const cb = vi.fn();
+
+    transport.send(
+      mailFrom({
+        text: "TXT",
+        html: "<H>",
+        alternatives: [{ content: "alt1", contentType: "type1" }],
+      }),
+      cb
+    );
+    await flush();
+
+    expect(sentMessage().content).toEqual([
+      { type: "text/html", value: "<H>" },
+      { type: "text/plain", value: "TXT" },
+      { type: "type1", value: "alt1" },
+    ]);
+    expect(cb).toHaveBeenCalledWith(null, successInfo);
+  });
+
+  test("calls back with the error when the SendGrid send rejects", async () => {
+    const transport = new SendGridTransport();
+    const sendError = new Error("send failed");
+    send.mockRejectedValueOnce(sendError);
+    const cb = vi.fn();
+
+    transport.send(mailFrom({ subject: "Hi" }), cb);
+    await flush();
+
+    expect(cb).toHaveBeenCalledWith(sendError);
+  });
+
+  test("forwards the categories array", async () => {
+    const transport = new SendGridTransport({ apiKey: "KEY" });
+    const cb = vi.fn();
+
+    transport.send(
+      mailFrom({
+        from: { address: "a@x.com" },
+        to: [{ address: "b@x.com" }],
+        subject: "Category test",
+        categories: ["alpha", "beta", "gamma"],
+      }),
+      cb
+    );
+    await flush();
+
+    expect(sentMessage().categories).toEqual(["alpha", "beta", "gamma"]);
+    expect(cb).toHaveBeenCalledWith(null, {
+      ...successInfo,
+      accepted: ["b@x.com"],
+    });
+  });
+
+  test("forwards templateId and dynamicTemplateData", async () => {
+    const transport = new SendGridTransport({ apiKey: "KEY" });
+    const cb = vi.fn();
+
+    transport.send(
+      mailFrom({
+        from: { address: "from@ex.com" },
+        to: [{ address: "to@ex.com" }],
+        subject: "Template test",
+        templateId: "d-1234567890abcdef",
+        dynamicTemplateData: { name: "Jacob", count: 42 },
+      }),
+      cb
+    );
+    await flush();
+
+    expect(sentMessage().templateId).toBe("d-1234567890abcdef");
+    expect(sentMessage().dynamicTemplateData).toMatchObject({
+      name: "Jacob",
+      count: 42,
+    });
+    expect(cb).toHaveBeenCalledWith(null, {
+      ...successInfo,
+      accepted: ["to@ex.com"],
+    });
+  });
+
+  test("forwards the mailSettings object", async () => {
+    const transport = new SendGridTransport({ apiKey: "KEY" });
+    const cb = vi.fn();
+
+    transport.send(
+      mailFrom({
+        from: { address: "a@x.com" },
+        to: [{ address: "b@x.com" }],
+        subject: "MailSettings test",
+        mailSettings: {
+          sandboxMode: { enable: true },
+          personalization: { enable: false },
+        },
+      }),
+      cb
+    );
+    await flush();
+
+    expect(sentMessage().mailSettings).toMatchObject({
+      sandboxMode: { enable: true },
+      personalization: { enable: false },
+    });
+    expect(cb).toHaveBeenCalledWith(null, {
+      ...successInfo,
+      accepted: ["b@x.com"],
+    });
+  });
+
+  test("forwards the customArgs object", async () => {
+    const transport = new SendGridTransport({ apiKey: "KEY" });
+    const cb = vi.fn();
+
+    transport.send(
+      mailFrom({
+        from: { address: "a@x.com" },
+        to: [{ address: "b@x.com" }],
+        subject: "Custom args test",
+        customArgs: { campaign: "welcome", source: "signup" },
+      }),
+      cb
+    );
+    await flush();
+
+    expect(sentMessage().customArgs).toEqual({
+      campaign: "welcome",
+      source: "signup",
+    });
+    expect(cb).toHaveBeenCalledWith(null, {
+      ...successInfo,
+      accepted: ["b@x.com"],
+    });
+  });
+
+  test("forwards the ipPoolName string", async () => {
+    const transport = new SendGridTransport({ apiKey: "KEY" });
+    const cb = vi.fn();
+
+    transport.send(
+      mailFrom({
+        from: { address: "a@x.com" },
+        to: [{ address: "b@x.com" }],
+        subject: "IP pool test",
+        ipPoolName: "transactional",
+      }),
+      cb
+    );
+    await flush();
+
+    expect(sentMessage().ipPoolName).toBe("transactional");
+    expect(cb).toHaveBeenCalledWith(null, {
+      ...successInfo,
+      accepted: ["b@x.com"],
+    });
+  });
+
+  test("lowercases and deduplicates accepted recipients across to, cc and bcc", async () => {
+    const transport = new SendGridTransport();
+    const cb = vi.fn();
+
+    transport.send(
+      mailFrom({
+        to: [{ address: "User@example.com" }, { address: "user@example.com" }],
+        cc: [{ address: "user@example.com" }, { address: "other@example.com" }],
+        bcc: [
+          { address: "user@example.com" },
+          { address: "ANOTHER@example.com" },
+        ],
+      }),
+      cb
+    );
+    await flush();
+
+    expect(sentMessage().to).toHaveLength(2);
+    expect(sentMessage().cc).toHaveLength(2);
+    expect(sentMessage().bcc).toHaveLength(2);
+    expect(cb).toHaveBeenCalledWith(null, {
+      ...successInfo,
+      accepted: [
+        "user@example.com",
+        "other@example.com",
+        "another@example.com",
+      ],
+    });
+  });
+});

--- a/kits/firestore-send-email/tests/nodemailer-sendgrid.test.ts
+++ b/kits/firestore-send-email/tests/nodemailer-sendgrid.test.ts
@@ -46,7 +46,7 @@ function mailFrom(source: Partial<MailSource>): MailSource {
   } as MailSource;
 }
 
-/** Yields to the microtask queue so the transport's normalize/send chain settles. */
+/** Defers to the check phase, after the transport's normalize/send promise chain settles. */
 function flush(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
 }
@@ -224,6 +224,17 @@ describe("SendGridTransport", () => {
     expect(cb).toHaveBeenCalledWith(null, successInfo);
   });
 
+  test("skips an empty watchHtml instead of emitting a content entry", async () => {
+    const transport = new SendGridTransport();
+    const cb = vi.fn();
+
+    transport.send(mailFrom({ watchHtml: "" }), cb);
+    await flush();
+
+    expect(sentMessage().content).toBeUndefined();
+    expect(cb).toHaveBeenCalledWith(null, successInfo);
+  });
+
   test("merges normalizedHeaders and messageId into headers", async () => {
     const transport = new SendGridTransport();
     const cb = vi.fn();
@@ -245,6 +256,20 @@ describe("SendGridTransport", () => {
       ...successInfo,
       messageId: "msg-123",
     });
+  });
+
+  test("skips an empty messageId instead of emitting a message-id header", async () => {
+    const transport = new SendGridTransport();
+    const cb = vi.fn();
+
+    transport.send(
+      mailFrom({ normalizedHeaders: { "X-Custom": "val" }, messageId: "" }),
+      cb
+    );
+    await flush();
+
+    expect(sentMessage().headers).toEqual({ "X-Custom": "val" });
+    expect(cb).toHaveBeenCalledWith(null, successInfo);
   });
 
   test("folds text and html into the content array when alternatives exist", async () => {

--- a/kits/firestore-send-email/tests/prepare-payload.test.ts
+++ b/kits/firestore-send-email/tests/prepare-payload.test.ts
@@ -221,7 +221,7 @@ describe("preparePayload template merging", () => {
     expect(result.message.attachments).toEqual([{ filename: "original.doc" }]);
   });
 
-  test("a template that renders nothing leaves the message intact", async () => {
+  test("a template that renders nothing only adds an empty attachments array", async () => {
     const result = await prepare({
       to: "test@example.com",
       template: { name: "empty-template", data: {} },

--- a/kits/firestore-send-email/tests/prepare-payload.test.ts
+++ b/kits/firestore-send-email/tests/prepare-payload.test.ts
@@ -211,6 +211,16 @@ describe("preparePayload template merging", () => {
     expect(result.message.attachments).toEqual([{ filename: "template.pdf" }]);
   });
 
+  test("message attachments survive a template that renders none", async () => {
+    const result = await prepare({
+      to: "test@example.com",
+      template: { name: "html-only-template", data: {} },
+      message: { attachments: [{ filename: "original.doc" }] },
+    });
+
+    expect(result.message.attachments).toEqual([{ filename: "original.doc" }]);
+  });
+
   test("a template that renders nothing leaves the message intact", async () => {
     const result = await prepare({
       to: "test@example.com",
@@ -231,7 +241,6 @@ describe("preparePayload template merging", () => {
       to: "test@example.com",
       template: { name: "html-only-template", data: {} },
       message: { text: "Original text content", subject: "Original Subject" },
-      attachments: [{ filename: "original.doc" }],
     });
 
     expect(result.message.html).toBe("<h1>Template HTML</h1>");

--- a/kits/firestore-send-email/tests/prepare-payload.test.ts
+++ b/kits/firestore-send-email/tests/prepare-payload.test.ts
@@ -17,6 +17,8 @@
 import { describe, expect, test, vi } from "vitest";
 import type { ResolvedSendEmailConfig } from "../src/export-config";
 import { preparePayload } from "../src/prepare-payload";
+import type { Templates } from "../src/templates";
+import type { QueuePayload } from "../src/types";
 
 const baseConfig: ResolvedSendEmailConfig = {
   databaseId: "(default)",
@@ -94,5 +96,339 @@ describe("preparePayload", () => {
       )
     ).rejects.toThrow("Expected at least one document ref.");
     expect(db.getAll).toHaveBeenCalledOnce();
+  });
+});
+
+const templateRenders: Record<string, Record<string, unknown>> = {
+  "html-only-template": {
+    html: "<h1>Template HTML</h1>",
+    subject: "Template Subject",
+  },
+  "text-only-template": {
+    text: "Template text content",
+    subject: "Template Subject",
+  },
+  "both-html-text-template": {
+    html: "<h1>Template HTML</h1>",
+    text: "Template text content",
+    subject: "Template Subject",
+  },
+  "template-with-attachments": {
+    html: "<h1>Template HTML</h1>",
+    subject: "Template Subject",
+    attachments: [{ filename: "template.pdf" }],
+  },
+  "template-with-null-values": {
+    html: null,
+    text: null,
+    subject: "Template Subject",
+  },
+  "template-with-empty-strings": {
+    html: "",
+    text: "",
+    subject: "Template Subject",
+  },
+  "template-with-undefined-values": {
+    html: undefined,
+    text: undefined,
+    subject: "Template Subject",
+  },
+};
+
+const templates = {
+  render: vi.fn(async (name: string, data: Record<string, unknown>) => {
+    if (name === "template-with-data") {
+      return {
+        html: `<h1>Hello ${data.name}</h1>`,
+        subject: `Subject for ${data.name}`,
+      };
+    }
+    return templateRenders[name] ?? {};
+  }),
+} as unknown as Templates;
+
+/** Runs preparePayload against a stub Firestore and the template renders above. */
+function prepare(payload: unknown) {
+  const db = { getAll: vi.fn() } as any;
+  return preparePayload(payload as QueuePayload, {
+    db,
+    config: baseConfig,
+    templates,
+  });
+}
+
+describe("preparePayload template merging", () => {
+  test("rejects a payload with neither message nor template", async () => {
+    await expect(prepare({ to: "test@example.com" })).rejects.toThrow(
+      "Invalid email configuration: Email configuration must include either a 'message', 'template', or 'sendGrid' object"
+    );
+  });
+
+  test("takes text and subject from a text-only template", async () => {
+    const result = await prepare({
+      to: "test@example.com",
+      template: { name: "text-only-template", data: {} },
+    });
+
+    expect(result.message.text).toBe("Template text content");
+    expect(result.message.html).toBeUndefined();
+    expect(result.message.subject).toBe("Template Subject");
+  });
+
+  test("preserves message html when the template only provides text", async () => {
+    const result = await prepare({
+      to: "test@example.com",
+      template: { name: "text-only-template", data: {} },
+      message: {
+        html: "<p>Original HTML content</p>",
+        subject: "Original Subject",
+      },
+    });
+
+    expect(result.message.html).toBe("<p>Original HTML content</p>");
+    expect(result.message.text).toBe("Template text content");
+    expect(result.message.subject).toBe("Template Subject");
+  });
+
+  test("template html and text both win over message text", async () => {
+    const result = await prepare({
+      to: "test@example.com",
+      template: { name: "both-html-text-template", data: {} },
+      message: { text: "Original text content" },
+    });
+
+    expect(result.message.html).toBe("<h1>Template HTML</h1>");
+    expect(result.message.text).toBe("Template text content");
+  });
+
+  test("template attachments replace message attachments", async () => {
+    const result = await prepare({
+      to: "test@example.com",
+      template: { name: "template-with-attachments", data: {} },
+      message: { attachments: [{ filename: "original.doc" }] },
+    });
+
+    expect(result.message.attachments).toEqual([{ filename: "template.pdf" }]);
+  });
+
+  test("a template that renders nothing leaves the message intact", async () => {
+    const result = await prepare({
+      to: "test@example.com",
+      template: { name: "empty-template", data: {} },
+      message: {
+        html: "<p>Original HTML content</p>",
+        subject: "Original Subject",
+      },
+    });
+
+    expect(result.message.html).toBe("<p>Original HTML content</p>");
+    expect(result.message.subject).toBe("Original Subject");
+    expect(result.message.attachments).toEqual([]);
+  });
+
+  test("merges template html over message text and subject", async () => {
+    const result = await prepare({
+      to: "test@example.com",
+      template: { name: "html-only-template", data: {} },
+      message: { text: "Original text content", subject: "Original Subject" },
+      attachments: [{ filename: "original.doc" }],
+    });
+
+    expect(result.message.html).toBe("<h1>Template HTML</h1>");
+    expect(result.message.text).toBe("Original text content");
+    expect(result.message.subject).toBe("Template Subject");
+  });
+
+  test("passes template data through to the render", async () => {
+    const result = await prepare({
+      to: "test@example.com",
+      template: { name: "template-with-data", data: { name: "John" } },
+    });
+
+    expect(result.message.html).toBe("<h1>Hello John</h1>");
+    expect(result.message.subject).toBe("Subject for John");
+  });
+
+  test("wraps string recipient addresses in arrays", async () => {
+    const result = await prepare({
+      to: "test@example.com",
+      cc: "cc@example.com",
+      bcc: "bcc@example.com",
+      message: { subject: "Test Subject", html: "<p>Test HTML content</p>" },
+    });
+
+    expect(result.to).toEqual(["test@example.com"]);
+    expect(result.cc).toEqual(["cc@example.com"]);
+    expect(result.bcc).toEqual(["bcc@example.com"]);
+  });
+
+  test("keeps array recipient addresses as-is", async () => {
+    const result = await prepare({
+      to: ["test1@example.com", "test2@example.com"],
+      cc: ["cc1@example.com", "cc2@example.com"],
+      bcc: ["bcc1@example.com", "bcc2@example.com"],
+      message: { subject: "Test Subject", html: "<p>Test HTML content</p>" },
+    });
+
+    expect(result.to).toEqual(["test1@example.com", "test2@example.com"]);
+    expect(result.cc).toEqual(["cc1@example.com", "cc2@example.com"]);
+    expect(result.bcc).toEqual(["bcc1@example.com", "bcc2@example.com"]);
+  });
+
+  test("leaves a message without a template untouched", async () => {
+    const result = await prepare({
+      to: "test@example.com",
+      message: {
+        html: "<p>Direct HTML content</p>",
+        subject: "Direct Subject",
+      },
+    });
+
+    expect(result.message.html).toBe("<p>Direct HTML content</p>");
+    expect(result.message.subject).toBe("Direct Subject");
+  });
+
+  test("accepts an empty message object", async () => {
+    const result = await prepare({ to: "test@example.com", message: {} });
+
+    expect(result.message).toEqual({});
+  });
+
+  test("omits null template values entirely", async () => {
+    const result = await prepare({
+      to: "test@example.com",
+      template: { name: "template-with-null-values", data: {} },
+    });
+
+    expect(result.message.subject).toBe("Template Subject");
+    expect("html" in result.message).toBe(false);
+    expect("text" in result.message).toBe(false);
+  });
+
+  test("null template values do not overwrite message content", async () => {
+    const result = await prepare({
+      to: "test@example.com",
+      template: { name: "template-with-null-values", data: {} },
+      message: {
+        html: "<p>Original HTML</p>",
+        text: "Original text",
+        subject: "Original Subject",
+      },
+    });
+
+    expect(result.message.html).toBe("<p>Original HTML</p>");
+    expect(result.message.text).toBe("Original text");
+    expect(result.message.subject).toBe("Template Subject");
+  });
+
+  test("empty string template values overwrite message content", async () => {
+    const result = await prepare({
+      to: "test@example.com",
+      template: { name: "template-with-empty-strings", data: {} },
+      message: {
+        html: "<p>Original HTML</p>",
+        text: "Original text",
+        subject: "Original Subject",
+      },
+    });
+
+    expect(result.message.html).toBe("");
+    expect(result.message.text).toBe("");
+    expect(result.message.subject).toBe("Template Subject");
+  });
+
+  test("undefined template values do not overwrite message content", async () => {
+    const result = await prepare({
+      to: "test@example.com",
+      template: { name: "template-with-undefined-values", data: {} },
+      message: {
+        html: "<p>Original HTML</p>",
+        text: "Original text",
+        subject: "Original Subject",
+      },
+    });
+
+    expect(result.message.html).toBe("<p>Original HTML</p>");
+    expect(result.message.text).toBe("Original text");
+    expect(result.message.subject).toBe("Template Subject");
+  });
+
+  test("strips attachment entries that carry no recognised keys", async () => {
+    const result = await prepare({
+      to: "tester@gmx.at",
+      template: {
+        name: "med_order_reply_greimel",
+        data: {
+          address: "Halbenrain 140 Graz",
+          doctorName: "Dr. Andreas",
+          openingHours: "Mo., Mi., Fr. 8:00-12:00Di., Do. 10:30-15:30",
+          orderText: "Some stuff i need",
+          userName: "Pfeiler ",
+          name: "med_order_reply_greimel",
+        },
+      },
+      message: {
+        attachments: [{ html: null, text: null }],
+        subject: "Bestellbestätigung",
+      },
+    });
+
+    expect(result.message.attachments).toEqual([]);
+    expect(result.message.subject).toBe("Bestellbestätigung");
+    expect(result.to).toEqual(["tester@gmx.at"]);
+  });
+
+  describe("attachment validation", () => {
+    test("rejects non-array attachments", async () => {
+      await expect(
+        prepare({
+          to: "test@example.com",
+          message: {
+            subject: "Test Subject",
+            text: "Test text",
+            attachments: "not-an-array",
+          },
+        })
+      ).rejects.toThrow();
+    });
+
+    test("rejects null attachments", async () => {
+      await expect(
+        prepare({
+          to: "test@example.com",
+          message: {
+            subject: "Test Subject",
+            text: "Test text",
+            attachments: null,
+          },
+        })
+      ).rejects.toThrow();
+    });
+
+    test("accepts undefined attachments", async () => {
+      const result = await prepare({
+        to: "test@example.com",
+        message: {
+          subject: "Test Subject",
+          text: "Test text",
+          attachments: undefined,
+        },
+      });
+
+      expect(result.message.attachments).toBeUndefined();
+    });
+
+    test("accepts an empty attachments array", async () => {
+      const result = await prepare({
+        to: "test@example.com",
+        message: {
+          subject: "Test Subject",
+          text: "Test text",
+          attachments: [],
+        },
+      });
+
+      expect(result.message.attachments).toEqual([]);
+    });
   });
 });

--- a/kits/firestore-send-email/tests/validation.test.ts
+++ b/kits/firestore-send-email/tests/validation.test.ts
@@ -16,7 +16,592 @@
 
 import { describe, expect, test } from "vitest";
 import { z } from "zod";
-import { formatZodError } from "../src/validation";
+import {
+  ValidationError,
+  formatZodError,
+  validatePayload,
+} from "../src/validation";
+
+describe("validatePayload", () => {
+  describe("valid payloads", () => {
+    test("accepts a standard message payload", () => {
+      expect(() =>
+        validatePayload({
+          to: "test@example.com",
+          message: { subject: "Test Subject", text: "Test message" },
+        })
+      ).not.toThrow();
+    });
+
+    test("accepts a message with HTML content", () => {
+      expect(() =>
+        validatePayload({
+          to: "test@example.com",
+          message: { subject: "Test Subject", html: "<p>Test message</p>" },
+        })
+      ).not.toThrow();
+    });
+
+    test("accepts a SendGrid template payload", () => {
+      expect(() =>
+        validatePayload({
+          to: "test@example.com",
+          sendGrid: {
+            templateId: "d-template-id",
+            dynamicTemplateData: { name: "Test User" },
+          },
+        })
+      ).not.toThrow();
+    });
+
+    test("accepts a custom template payload", () => {
+      expect(() =>
+        validatePayload({
+          to: "test@example.com",
+          template: { name: "welcome-email", data: { name: "Test User" } },
+        })
+      ).not.toThrow();
+    });
+
+    test("accepts multiple recipients", () => {
+      expect(() =>
+        validatePayload({
+          to: ["test1@example.com", "test2@example.com"],
+          cc: ["cc1@example.com"],
+          bcc: ["bcc1@example.com"],
+          message: { subject: "Test Subject", text: "Test message" },
+        })
+      ).not.toThrow();
+    });
+
+    test("accepts UID-based recipients", () => {
+      expect(() =>
+        validatePayload({
+          toUids: ["user1", "user2"],
+          ccUids: ["user3"],
+          bccUids: ["user4"],
+          message: { subject: "Test Subject", text: "Test message" },
+        })
+      ).not.toThrow();
+    });
+
+    test("accepts a payload with optional fields", () => {
+      expect(() =>
+        validatePayload({
+          to: "test@example.com",
+          from: "sender@example.com",
+          replyTo: "reply@example.com",
+          categories: ["category1", "category2"],
+          message: {
+            subject: "Test Subject",
+            text: "Test message",
+            attachments: [],
+          },
+        })
+      ).not.toThrow();
+    });
+
+    test("accepts a friendly name in the from field", () => {
+      expect(() =>
+        validatePayload({
+          to: "test@example.com",
+          from: "Friendly Firebaser test@example.com",
+          message: { subject: "Test Subject", text: "Test message" },
+        })
+      ).not.toThrow();
+    });
+
+    test("accepts a template payload without html or text", () => {
+      expect(() =>
+        validatePayload({
+          to: "test@example.com",
+          template: { name: "welcome-email", data: { name: "Test User" } },
+        })
+      ).not.toThrow();
+    });
+
+    test("accepts a template payload with a message override", () => {
+      expect(() =>
+        validatePayload({
+          to: "test@example.com",
+          template: { name: "welcome-email", data: { name: "Test User" } },
+          message: { subject: "Custom Subject", attachments: [] },
+        })
+      ).not.toThrow();
+    });
+
+    test("accepts a template payload with empty data", () => {
+      expect(() =>
+        validatePayload({
+          to: "test@example.com",
+          template: { name: "welcome-email" },
+        })
+      ).not.toThrow();
+    });
+
+    test("accepts a template with a message containing only a subject", () => {
+      expect(() =>
+        validatePayload({
+          to: "test@example.com",
+          template: { name: "welcome-email" },
+          message: { subject: "Test Subject" },
+        })
+      ).not.toThrow();
+    });
+
+    test("accepts a template with a message containing optional fields", () => {
+      expect(() =>
+        validatePayload({
+          to: "test@example.com",
+          template: { name: "welcome-email", data: { name: "User" } },
+          message: {
+            subject: "Test Subject",
+            attachments: [],
+            categories: ["category1"],
+          },
+        })
+      ).not.toThrow();
+    });
+
+    test("accepts a template payload when the message has no html or text", () => {
+      expect(() =>
+        validatePayload({
+          to: "test@example.com",
+          template: { name: "welcome-email", data: { userName: "John Doe" } },
+          message: { subject: "Welcome!" },
+        })
+      ).not.toThrow();
+    });
+
+    test("accepts a template with a completely empty message object", () => {
+      expect(() =>
+        validatePayload({
+          to: "test@example.com",
+          template: { name: "welcome-email", data: { userName: "John Doe" } },
+          message: {},
+        })
+      ).not.toThrow();
+    });
+
+    test("accepts a template without a message object", () => {
+      expect(() =>
+        validatePayload({
+          to: "test@example.com",
+          template: {
+            name: "EGFMB64MzmVz0Or75ctL",
+            data: { userName: "cabljac", name: "jacob" },
+          },
+        })
+      ).not.toThrow();
+    });
+
+    test("accepts a SendGrid payload with customArgs", () => {
+      expect(() =>
+        validatePayload({
+          to: "test@example.com",
+          sendGrid: {
+            templateId: "d-template-id",
+            customArgs: { campaign: "welcome", source: "signup" },
+          },
+        })
+      ).not.toThrow();
+    });
+
+    test("accepts a SendGrid payload with ipPoolName", () => {
+      expect(() =>
+        validatePayload({
+          to: "test@example.com",
+          sendGrid: {
+            templateId: "d-template-id",
+            ipPoolName: "transactional",
+          },
+        })
+      ).not.toThrow();
+    });
+
+    test("accepts a SendGrid payload with only mailSettings", () => {
+      expect(() =>
+        validatePayload({
+          to: "test@example.com",
+          sendGrid: { mailSettings: { sandboxMode: { enable: true } } },
+        })
+      ).not.toThrow();
+    });
+  });
+
+  describe("invalid payloads", () => {
+    test("rejects a message without text or html", () => {
+      const payload = {
+        to: "test@example.com",
+        message: { subject: "Test Subject" },
+      };
+      expect(() => validatePayload(payload)).toThrow(ValidationError);
+      expect(() => validatePayload(payload)).toThrow(
+        "Invalid message configuration: At least one of 'text' or 'html' must be provided in message"
+      );
+    });
+
+    test("rejects SendGrid dynamicTemplateData without a templateId", () => {
+      const payload = {
+        to: "test@example.com",
+        sendGrid: { dynamicTemplateData: { name: "Test User" } },
+      };
+      expect(() => validatePayload(payload)).toThrow(ValidationError);
+      expect(() => validatePayload(payload)).toThrow(
+        "Invalid sendGrid configuration: Field 'templateId' is required when 'dynamicTemplateData' is provided"
+      );
+    });
+
+    test("rejects SendGrid customArgs with non-string values", () => {
+      expect(() =>
+        validatePayload({
+          to: "test@example.com",
+          sendGrid: { customArgs: { campaign: 123 } },
+        })
+      ).toThrow(ValidationError);
+    });
+
+    test("rejects a SendGrid ipPoolName that is not a string", () => {
+      expect(() =>
+        validatePayload({
+          to: "test@example.com",
+          sendGrid: { ipPoolName: 123 },
+        })
+      ).toThrow(ValidationError);
+    });
+
+    test("rejects a custom template without a name", () => {
+      const payload = {
+        to: "test@example.com",
+        template: { data: { name: "Test User" } },
+      };
+      expect(() => validatePayload(payload)).toThrow(ValidationError);
+      expect(() => validatePayload(payload)).toThrow(
+        "Invalid template configuration: Field 'template.name' must be a string"
+      );
+    });
+
+    test("rejects a payload with no recipients", () => {
+      const payload = {
+        message: { subject: "Test Subject", text: "Test message" },
+      };
+      expect(() => validatePayload(payload)).toThrow(ValidationError);
+      expect(() => validatePayload(payload)).toThrow(
+        "Invalid email configuration: Email must have at least one recipient"
+      );
+    });
+
+    test("rejects a recipient field with an invalid type", () => {
+      const payload = {
+        to: 123,
+        message: { subject: "Test Subject", text: "Test message" },
+      };
+      expect(() => validatePayload(payload)).toThrow(ValidationError);
+      expect(() => validatePayload(payload)).toThrow(
+        "Invalid email configuration: Field 'to' must be either a string or an array of strings"
+      );
+    });
+
+    test("rejects a payload with no message, template or sendGrid", () => {
+      const payload = { to: "test@example.com" };
+      expect(() => validatePayload(payload)).toThrow(ValidationError);
+      expect(() => validatePayload(payload)).toThrow(
+        "Invalid email configuration: Email configuration must include either a 'message', 'template', or 'sendGrid' object"
+      );
+    });
+
+    test("rejects a message without a subject", () => {
+      const payload = {
+        to: "test@example.com",
+        message: { text: "Test message" },
+      };
+      expect(() => validatePayload(payload)).toThrow(ValidationError);
+      expect(() => validatePayload(payload)).toThrow(
+        "Invalid message configuration: Field 'message.subject' must be a string"
+      );
+    });
+
+    test("rejects a template with an invalid name type", () => {
+      const payload = { to: "test@example.com", template: { name: 123 } };
+      expect(() => validatePayload(payload)).toThrow(ValidationError);
+      expect(() => validatePayload(payload)).toThrow(
+        "Invalid template configuration: Field 'template.name' must be a string"
+      );
+    });
+
+    test("rejects a template that is not a map", () => {
+      const payload = { to: "test@example.com", template: 123 };
+      expect(() => validatePayload(payload)).toThrow(ValidationError);
+      expect(() => validatePayload(payload)).toThrow(
+        "Invalid template configuration: Field 'template' must be a map"
+      );
+    });
+
+    test("rejects a template with an invalid data type", () => {
+      const payload = {
+        to: "test@example.com",
+        template: { name: "welcome-email", data: "invalid-data" },
+      };
+      expect(() => validatePayload(payload)).toThrow(ValidationError);
+      expect(() => validatePayload(payload)).toThrow(
+        "Invalid template configuration: Field 'template.data' must be a map"
+      );
+    });
+  });
+
+  describe("attachment validation", () => {
+    describe("valid attachments", () => {
+      test("accepts a plain text attachment", () => {
+        expect(() =>
+          validatePayload({
+            to: "test@example.com",
+            message: {
+              subject: "Test Subject",
+              text: "Test message",
+              attachments: [{ filename: "hello.txt", content: "Hello world!" }],
+            },
+          })
+        ).not.toThrow();
+      });
+
+      test("accepts a binary buffer attachment", () => {
+        expect(() =>
+          validatePayload({
+            to: "test@example.com",
+            message: {
+              subject: "Test Subject",
+              text: "Test message",
+              attachments: [
+                {
+                  filename: "buffer.txt",
+                  content: Buffer.from("Hello world!", "utf8"),
+                },
+              ],
+            },
+          })
+        ).not.toThrow();
+      });
+
+      test("accepts a local file attachment", () => {
+        expect(() =>
+          validatePayload({
+            to: "test@example.com",
+            message: {
+              subject: "Test Subject",
+              text: "Test message",
+              attachments: [
+                {
+                  filename: "report.pdf",
+                  path: "/absolute/path/to/report.pdf",
+                },
+              ],
+            },
+          })
+        ).not.toThrow();
+      });
+
+      test("accepts an attachment with an implicit filename", () => {
+        expect(() =>
+          validatePayload({
+            to: "test@example.com",
+            message: {
+              subject: "Test Subject",
+              text: "Test message",
+              attachments: [{ path: "/absolute/path/to/image.png" }],
+            },
+          })
+        ).not.toThrow();
+      });
+
+      test("accepts an attachment with a custom content type", () => {
+        expect(() =>
+          validatePayload({
+            to: "test@example.com",
+            message: {
+              subject: "Test Subject",
+              text: "Test message",
+              attachments: [
+                {
+                  filename: "data.bin",
+                  content: Buffer.from("deadbeef", "hex"),
+                  contentType: "application/octet-stream",
+                },
+              ],
+            },
+          })
+        ).not.toThrow();
+      });
+
+      test("accepts a remote file attachment", () => {
+        expect(() =>
+          validatePayload({
+            to: "test@example.com",
+            message: {
+              subject: "Test Subject",
+              text: "Test message",
+              attachments: [
+                {
+                  filename: "license.txt",
+                  href: "https://raw.githubusercontent.com/nodemailer/nodemailer/master/LICENSE",
+                },
+              ],
+            },
+          })
+        ).not.toThrow();
+      });
+
+      test("accepts a base64 encoded attachment", () => {
+        expect(() =>
+          validatePayload({
+            to: "test@example.com",
+            message: {
+              subject: "Test Subject",
+              text: "Test message",
+              attachments: [
+                {
+                  filename: "photo.jpg",
+                  content: "/9j/4AAQSkZJRgABAQAAAQABAAD…",
+                  encoding: "base64",
+                },
+              ],
+            },
+          })
+        ).not.toThrow();
+      });
+
+      test("accepts a data URI attachment", () => {
+        expect(() =>
+          validatePayload({
+            to: "test@example.com",
+            message: {
+              subject: "Test Subject",
+              text: "Test message",
+              attachments: [
+                { path: "data:text/plain;base64,SGVsbG8gd29ybGQ=" },
+              ],
+            },
+          })
+        ).not.toThrow();
+      });
+
+      test("accepts a pre-built MIME node attachment", () => {
+        expect(() =>
+          validatePayload({
+            to: "test@example.com",
+            message: {
+              subject: "Test Subject",
+              text: "Test message",
+              attachments: [
+                {
+                  raw: [
+                    "Content-Type: text/plain; charset=utf-8",
+                    'Content-Disposition: attachment; filename="greeting.txt"',
+                    "",
+                    "Hello world!",
+                  ].join("\r\n"),
+                },
+              ],
+            },
+          })
+        ).not.toThrow();
+      });
+
+      test("accepts an embedded image attachment", () => {
+        expect(() =>
+          validatePayload({
+            to: "test@example.com",
+            message: {
+              subject: "Test Subject",
+              html: '<p><img src="cid:logo@nodemailer" alt="Nodemailer logo"></p>',
+              attachments: [
+                {
+                  filename: "logo.png",
+                  path: "./assets/logo.png",
+                  cid: "logo@nodemailer",
+                },
+              ],
+            },
+          })
+        ).not.toThrow();
+      });
+
+      test("accepts multiple attachments", () => {
+        expect(() =>
+          validatePayload({
+            to: "test@example.com",
+            message: {
+              subject: "Test Subject",
+              text: "Test message",
+              attachments: [
+                { filename: "file1.txt", content: "Content 1" },
+                { filename: "file2.txt", content: "Content 2" },
+              ],
+            },
+          })
+        ).not.toThrow();
+      });
+    });
+
+    describe("invalid attachments", () => {
+      test("rejects an attachment with an invalid httpHeaders type", () => {
+        const payload = {
+          to: "test@example.com",
+          message: {
+            subject: "Test Subject",
+            text: "Test message",
+            attachments: [
+              {
+                filename: "test.txt",
+                href: "https://example.com",
+                httpHeaders: "not-an-object",
+              },
+            ],
+          },
+        };
+        expect(() => validatePayload(payload)).toThrow(ValidationError);
+        expect(() => validatePayload(payload)).toThrow(
+          "Invalid message configuration: Field 'message.attachments.0.httpHeaders' must be a map"
+        );
+      });
+
+      test("rejects an attachment with an invalid headers type", () => {
+        const payload = {
+          to: "test@example.com",
+          message: {
+            subject: "Test Subject",
+            text: "Test message",
+            attachments: [
+              {
+                filename: "test.txt",
+                content: "test",
+                headers: "not-an-object",
+              },
+            ],
+          },
+        };
+        expect(() => validatePayload(payload)).toThrow(ValidationError);
+        expect(() => validatePayload(payload)).toThrow(
+          "Invalid message configuration: Field 'message.attachments.0.headers' must be a map"
+        );
+      });
+
+      test("rejects attachments that are not an array", () => {
+        const payload = {
+          to: "test@example.com",
+          message: {
+            subject: "Test Subject",
+            text: "Test message",
+            attachments: { filename: "test.txt", content: "test" },
+          },
+        };
+        expect(() => validatePayload(payload)).toThrow(ValidationError);
+        expect(() => validatePayload(payload)).toThrow(
+          "Invalid message configuration: Field 'message.attachments' must be an array"
+        );
+      });
+    });
+  });
+});
 
 function zodErrorFrom(schema: z.ZodSchema, value: unknown): z.ZodError {
   const result = schema.safeParse(value);


### PR DESCRIPTION
The `firestore-send-email` kit shipped with 14 tests against roughly 1,900 lines of source, while the legacy extension it was ported from carries around 2,000 lines of unit tests. This PR ports the four pure unit suites that transfer without an emulator: `validatePayload` (new `tests/validation.test.ts`), `setSmtpCredentials` / `isSendGrid` (new `tests/helpers.test.ts`), `SendGridTransport` (new `tests/nodemailer-sendgrid.test.ts`), and template merging appended to the existing `tests/prepare-payload.test.ts`. Jest goes to vitest, `it` to `test`, and the legacy `setDependencies` mocking is replaced by the kit's `PreparePayloadDependencies` seam. The kit test count goes from 14 to 115, all green, `tsc -b` clean, prettier clean. Only test files change; no source or manifest is touched.

Three tests are new rather than ported, each mutation-verified by breaking the branch it covers and confirming it was the only failure. Two pin guards the kit's transport refactor added and the legacy transport lacked: an empty `watchHtml` emits no content entry, an empty `messageId` emits no header. The third covers the template merge falling back to the message's own attachments when the render supplies none.

Deliberately not ported: everything gated on the `TESTING` env flag (the kit has no `process.env.TESTING`), the `describe.skip`'d SMTP e2e, and the `E2E_SENDGRID` live suite. Also dropped are the legacy helper tests' `regex.test(...)` assertions, which only exercised a regex literal declared inside the test file rather than the kit's own `SMTP_CONNECTION_URI` `validationRegex`.

Two notes. #3040 also adds `tests/validation.test.ts` with `formatZodError` tests; the two files do not overlap in coverage but will need a trivial merge, whichever lands second. Its `invalid_string` branch is also the one real difference between the kit's `validation.ts` and the legacy file, which are otherwise logic-identical on every reachable path. And no test here touches the SendGrid OAuth2 secret gating in #3009, so nothing pins that bug.

Part of #2974.
