### PR TITLE
test(firestore-genai-chatbot): port missing coverage from the legacy extension

### DIFF
--- a/kits/firestore-genai-chatbot/package.json
+++ b/kits/firestore-genai-chatbot/package.json
@@ -27,6 +27,7 @@
     "build": "tsc -b",
     "clean": "tsc -b --clean",
     "test": "vitest run",
+    "test:emulator": "firebase emulators:exec --only firestore --project demo-test --config tests/integration/firebase.json \"vitest run tests/integration\"",
     "deploy": "pnpm build && firebase deploy --only functions",
     "serve": "firebase emulators:start --only functions"
   },

--- a/kits/firestore-genai-chatbot/tests/handlers.test.ts
+++ b/kits/firestore-genai-chatbot/tests/handlers.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchHistory: vi.fn(),
+  fetchDiscussionOptions: vi.fn(),
+  getGenerativeClient: vi.fn(),
+  send: vi.fn(),
+}));
+
+vi.mock("../src/firestore", () => ({
+  fetchHistory: mocks.fetchHistory,
+  fetchDiscussionOptions: mocks.fetchDiscussionOptions,
+}));
+
+vi.mock("../src/generative-client", () => ({
+  getGenerativeClient: mocks.getGenerativeClient,
+}));
+
+import { resolveConfig } from "../src/export-config";
+import { State } from "../src/firestore-onwrite-processor/common";
+import type { DocumentWriteEvent, HandlerContext } from "../src/handlers";
+import { createProcessor, handleDocumentWrite } from "../src/handlers";
+
+function config(overrides: Record<string, unknown> = {}) {
+  return resolveConfig({
+    projectId: "project",
+    model: "gemini-2.5-flash",
+    apiKey: "test-key",
+    ...overrides,
+  });
+}
+
+/** A fake message document snapshot, in the onwrite-processor test's style. */
+function makeSnap(data: Record<string, unknown> | undefined, update = vi.fn()) {
+  return {
+    exists: data !== undefined,
+    createTime: "create-time",
+    ref: { update },
+    get: (field: string) => data?.[field],
+  };
+}
+
+/** A create event for a message doc, as delivered to the trigger. */
+function createEvent(
+  data: Record<string, unknown>,
+  update = vi.fn()
+): DocumentWriteEvent {
+  return {
+    data: { before: makeSnap(undefined), after: makeSnap(data, update) },
+  } as unknown as DocumentWriteEvent;
+}
+
+describe("handleDocumentWrite", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.fetchHistory.mockResolvedValue([]);
+    mocks.fetchDiscussionOptions.mockResolvedValue({});
+    mocks.getGenerativeClient.mockReturnValue({ send: mocks.send });
+    mocks.send.mockResolvedValue({ response: "generated" });
+  });
+
+  test("ignores an event with no change data", async () => {
+    const run = vi.fn();
+    const ctx = { processor: { run } } as unknown as HandlerContext;
+
+    await handleDocumentWrite({ data: undefined } as DocumentWriteEvent, ctx);
+
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  test("forwards the change to the context processor", async () => {
+    const run = vi.fn();
+    const ctx = { processor: { run } } as unknown as HandlerContext;
+    const event = createEvent({ prompt: "hello" });
+
+    await handleDocumentWrite(event, ctx);
+
+    expect(run).toHaveBeenCalledWith(event.data);
+  });
+
+  test("generates a response and writes it back to the message doc", async () => {
+    const update = vi.fn();
+    const event = createEvent({ prompt: "hello" }, update);
+
+    await handleDocumentWrite(event, { processor: createProcessor(config()) });
+
+    expect(mocks.send).toHaveBeenCalledWith(
+      "hello",
+      expect.objectContaining({ history: [] })
+    );
+    expect(update).toHaveBeenCalledTimes(2);
+    expect(update.mock.calls[0][0].status.state).toBe(State.PROCESSING);
+    expect(update.mock.calls[1][0]).toMatchObject({
+      response: "generated",
+      "status.state": State.COMPLETED,
+    });
+  });
+
+  test("reads the prompt from, and writes the response to, the configured fields", async () => {
+    const update = vi.fn();
+    const event = createEvent({ question: "hello" }, update);
+    const processor = createProcessor(
+      config({ promptField: "question", responseField: "answer" })
+    );
+
+    await handleDocumentWrite(event, { processor });
+
+    expect(mocks.send).toHaveBeenCalledWith("hello", expect.anything());
+    expect(update.mock.calls[1][0]).toMatchObject({ answer: "generated" });
+  });
+
+  test("maps a generation failure through the error message builder", async () => {
+    const update = vi.fn();
+    mocks.send.mockRejectedValue(
+      Object.assign(new Error("denied"), {
+        reason: "ACCESS_TOKEN_SCOPE_INSUFFICIENT",
+      })
+    );
+
+    await handleDocumentWrite(createEvent({ prompt: "hello" }, update), {
+      processor: createProcessor(config()),
+    });
+
+    expect(update.mock.calls[1][0].status).toMatchObject({
+      state: State.ERROR,
+      error:
+        "The project or service account likely does not have access to the Gemini API.",
+    });
+  });
+
+  test("skips a document that is already completed", async () => {
+    const update = vi.fn();
+    const event = createEvent(
+      { prompt: "hello", status: { state: State.COMPLETED } },
+      update
+    );
+
+    await handleDocumentWrite(event, { processor: createProcessor(config()) });
+
+    expect(mocks.send).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/kits/firestore-genai-chatbot/tests/integration/chat-flow.emulator.test.ts
+++ b/kits/firestore-genai-chatbot/tests/integration/chat-flow.emulator.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * End-to-end message flow against a real Firestore emulator, with only the
+ * generative client mocked. Skipped unless FIRESTORE_EMULATOR_HOST is set.
+ *
+ * Run locally:
+ *   npm run test:emulator
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getGenerativeClient: vi.fn(),
+  send: vi.fn(),
+}));
+
+vi.mock("../../src/generative-client", () => ({
+  getGenerativeClient: mocks.getGenerativeClient,
+}));
+
+import { type App, deleteApp, initializeApp } from "firebase-admin/app";
+import type { DocumentReference, Firestore } from "firebase-admin/firestore";
+import { getFirestore } from "firebase-admin/firestore";
+import { resolveConfig } from "../../src/export-config";
+import { State } from "../../src/firestore-onwrite-processor/common";
+import type { DocumentWriteEvent } from "../../src/handlers";
+import { createProcessor, handleDocumentWrite } from "../../src/handlers";
+
+const describeEmulator = process.env.FIRESTORE_EMULATOR_HOST
+  ? describe
+  : describe.skip;
+
+const config = resolveConfig({
+  projectId: "demo-test",
+  model: "gemini-2.5-flash",
+  apiKey: "test-key",
+});
+
+/** Runs the trigger handler over a write that created `ref`. */
+async function processCreate(
+  ref: DocumentReference,
+  before: Awaited<ReturnType<DocumentReference["get"]>>
+): Promise<void> {
+  const after = await ref.get();
+  const event = {
+    data: { before, after },
+  } as unknown as DocumentWriteEvent;
+
+  await handleDocumentWrite(event, { processor: createProcessor(config) });
+}
+
+describeEmulator("message flow against the Firestore emulator", () => {
+  let app: App;
+  let db: Firestore;
+  let discussion: DocumentReference;
+
+  beforeAll(() => {
+    app = initializeApp({ projectId: "demo-test" }, "genai-chatbot-emulator");
+    db = getFirestore(app);
+  });
+
+  afterAll(async () => {
+    await deleteApp(app);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getGenerativeClient.mockReturnValue({ send: mocks.send });
+    mocks.send.mockResolvedValue({ response: "generated response" });
+    discussion = db.collection("discussions").doc();
+  });
+
+  test("takes a new message from PROCESSING to COMPLETED", async () => {
+    const observedStates: unknown[] = [];
+    const ref = discussion.collection("messages").doc();
+
+    // The client runs after the start event is written, so reading the document
+    // here observes the in-flight state without racing a snapshot listener.
+    mocks.send.mockImplementation(async () => {
+      observedStates.push((await ref.get()).get("status")?.state);
+      return { response: "generated response" };
+    });
+
+    const before = await ref.get();
+    await ref.set({ prompt: "hello" });
+
+    await processCreate(ref, before);
+
+    expect(observedStates).toEqual([State.PROCESSING]);
+
+    const completed = await ref.get();
+    expect(completed.get("response")).toBe("generated response");
+    expect(completed.get("status")).toMatchObject({ state: State.COMPLETED });
+    // The processor backfills the order field so history stays sortable.
+    expect(completed.get("createTime")).toBeDefined();
+  });
+
+  test("passes earlier messages in the discussion as history", async () => {
+    const first = discussion.collection("messages").doc();
+    const firstBefore = await first.get();
+    await first.set({ prompt: "first prompt" });
+    await processCreate(first, firstBefore);
+
+    const second = discussion.collection("messages").doc();
+    const secondBefore = await second.get();
+    await second.set({ prompt: "second prompt" });
+    await processCreate(second, secondBefore);
+
+    expect(mocks.send).toHaveBeenLastCalledWith(
+      "second prompt",
+      expect.objectContaining({
+        history: [
+          {
+            path: first.path,
+            prompt: "first prompt",
+            response: "generated response",
+          },
+        ],
+      })
+    );
+  });
+
+  test("records a generation failure as ERROR on the document", async () => {
+    mocks.send.mockRejectedValue(new Error("model unavailable"));
+    const ref = discussion.collection("messages").doc();
+
+    const before = await ref.get();
+    await ref.set({ prompt: "hello" });
+    await processCreate(ref, before);
+
+    expect((await ref.get()).get("status")).toMatchObject({
+      state: State.ERROR,
+      error:
+        "An error occurred while processing the provided message, model unavailable",
+    });
+  });
+});

--- a/kits/firestore-genai-chatbot/tests/integration/firebase.json
+++ b/kits/firestore-genai-chatbot/tests/integration/firebase.json
@@ -1,0 +1,14 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  },
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    },
+    "singleProjectMode": true,
+    "ui": {
+      "enabled": false
+    }
+  }
+}

--- a/kits/firestore-genai-chatbot/tests/integration/firestore.rules
+++ b/kits/firestore-genai-chatbot/tests/integration/firestore.rules
@@ -1,0 +1,11 @@
+rules_version = '2';
+
+// The emulator flow test drives Firestore through the Admin SDK, which bypasses
+// rules; this file exists only because the emulator requires a rules source.
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}

--- a/kits/firestore-genai-chatbot/tests/logger.test.ts
+++ b/kits/firestore-genai-chatbot/tests/logger.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("firebase-functions", () => ({ logger: mocks }));
+
+import { Logger, LogLevel, logger } from "../src/logger";
+
+const PREFIX = "[firestore-genai-chatbot]";
+
+describe("Logger", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logger.setLogLevel(LogLevel.INFO);
+  });
+
+  test("getInstance returns the same instance as the exported logger", () => {
+    expect(Logger.getInstance()).toBe(Logger.getInstance());
+    expect(logger).toBe(Logger.getInstance());
+  });
+
+  test("a freshly loaded logger defaults to INFO", async () => {
+    vi.resetModules();
+    const { logger: fresh } = await vi.importActual<
+      typeof import("../src/logger")
+    >("../src/logger");
+
+    fresh.debug("debug message");
+    fresh.info("info message");
+
+    expect(mocks.debug).not.toHaveBeenCalled();
+    expect(mocks.info).toHaveBeenCalledWith(`${PREFIX} info message`);
+  });
+
+  describe("level filtering", () => {
+    test("debug is emitted at DEBUG and suppressed at INFO", () => {
+      logger.setLogLevel(LogLevel.DEBUG);
+      logger.debug("message");
+      expect(mocks.debug).toHaveBeenCalledWith(`${PREFIX} message`);
+
+      mocks.debug.mockClear();
+      logger.setLogLevel(LogLevel.INFO);
+      logger.debug("message");
+      expect(mocks.debug).not.toHaveBeenCalled();
+    });
+
+    test("info is emitted at INFO and suppressed at WARN", () => {
+      logger.info("message");
+      expect(mocks.info).toHaveBeenCalledWith(`${PREFIX} message`);
+
+      mocks.info.mockClear();
+      logger.setLogLevel(LogLevel.WARN);
+      logger.info("message");
+      expect(mocks.info).not.toHaveBeenCalled();
+    });
+
+    test("warn is emitted at WARN and suppressed at ERROR", () => {
+      logger.setLogLevel(LogLevel.WARN);
+      logger.warn("message");
+      expect(mocks.warn).toHaveBeenCalledWith(`${PREFIX} message`);
+
+      mocks.warn.mockClear();
+      logger.setLogLevel(LogLevel.ERROR);
+      logger.warn("message");
+      expect(mocks.warn).not.toHaveBeenCalled();
+    });
+
+    test("error is emitted at every level", () => {
+      for (const level of Object.values(LogLevel)) {
+        mocks.error.mockClear();
+        logger.setLogLevel(level);
+        logger.error("message");
+        expect(mocks.error).toHaveBeenCalledWith(`${PREFIX} message`);
+      }
+    });
+
+    test("only warn and above are emitted at WARN", () => {
+      logger.setLogLevel(LogLevel.WARN);
+
+      logger.debug("debug message");
+      logger.info("info message");
+      logger.warn("warn message");
+      logger.error("error message");
+
+      expect(mocks.debug).not.toHaveBeenCalled();
+      expect(mocks.info).not.toHaveBeenCalled();
+      expect(mocks.warn).toHaveBeenCalledOnce();
+      expect(mocks.error).toHaveBeenCalledOnce();
+    });
+
+    test("every level is emitted at DEBUG", () => {
+      logger.setLogLevel(LogLevel.DEBUG);
+
+      logger.debug("debug message");
+      logger.info("info message");
+      logger.warn("warn message");
+      logger.error("error message");
+
+      expect(mocks.debug).toHaveBeenCalledOnce();
+      expect(mocks.info).toHaveBeenCalledOnce();
+      expect(mocks.warn).toHaveBeenCalledOnce();
+      expect(mocks.error).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("message formatting", () => {
+    test("prefixes the message and forwards extra arguments", () => {
+      const detail = { key: "value" };
+      const items = ["array"];
+
+      logger.info("test message", detail, items);
+
+      expect(mocks.info).toHaveBeenCalledWith(
+        `${PREFIX} test message`,
+        detail,
+        items
+      );
+    });
+
+    test("forwards error objects unchanged", () => {
+      const error = new Error("test error");
+
+      logger.error("test message", error);
+
+      expect(mocks.error).toHaveBeenCalledWith(`${PREFIX} test message`, error);
+    });
+  });
+});

--- a/kits/firestore-genai-chatbot/tests/overrides.test.ts
+++ b/kits/firestore-genai-chatbot/tests/overrides.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DocumentSnapshot } from "firebase-admin/firestore";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  error: vi.fn(),
+}));
+
+vi.mock("../src/logger", () => ({ logger: { error: mocks.error } }));
+
+import { extractOverrides } from "../src/overrides";
+
+/** A fake discussion document snapshot carrying `data`. */
+function snap(data: Record<string, unknown>): DocumentSnapshot {
+  return { data: () => data } as unknown as DocumentSnapshot;
+}
+
+describe("extractOverrides", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("extracts string fields", () => {
+    const overrides = extractOverrides(
+      snap({ context: "testContext", model: "testModel" })
+    );
+
+    expect(overrides).toEqual({ context: "testContext", model: "testModel" });
+  });
+
+  test("coerces integer fields from strings and keeps numbers", () => {
+    const overrides = extractOverrides(
+      snap({
+        topK: "10",
+        candidateCount: 5,
+        maxOutputTokens: "1024",
+      })
+    );
+
+    expect(overrides).toEqual({
+      topK: 10,
+      candidateCount: 5,
+      maxOutputTokens: 1024,
+    });
+  });
+
+  test("coerces float fields from strings and keeps numbers", () => {
+    const overrides = extractOverrides(snap({ topP: "0.9", temperature: 0.7 }));
+
+    expect(overrides).toEqual({ topP: 0.9, temperature: 0.7 });
+  });
+
+  test("drops fields that are not overrides", () => {
+    const overrides = extractOverrides(
+      snap({ model: "testModel", examples: [{ prompt: "p", response: "r" }] })
+    );
+
+    expect(overrides).toEqual({ model: "testModel" });
+  });
+
+  test("returns an empty object when the discussion doc has no overrides", () => {
+    expect(extractOverrides(snap({}))).toEqual({});
+  });
+
+  test("throws and logs when a field has the wrong type", () => {
+    expect(() => extractOverrides(snap({ context: 123 }))).toThrow(
+      "Error parsing overrides from parent doc."
+    );
+    expect(mocks.error).toHaveBeenCalledOnce();
+  });
+
+  test("drops an integer field whose string value is not numeric", () => {
+    const overrides = extractOverrides(snap({ topK: "not-a-number" }));
+
+    expect(overrides.topK).toBeUndefined();
+  });
+});

--- a/kits/firestore-genai-chatbot/tests/overrides.test.ts
+++ b/kits/firestore-genai-chatbot/tests/overrides.test.ts
@@ -89,4 +89,16 @@ describe("extractOverrides", () => {
 
     expect(overrides.topK).toBeUndefined();
   });
+
+  test("drops an integer field whose string value is zero", () => {
+    const overrides = extractOverrides(snap({ topK: "0" }));
+
+    expect(overrides.topK).toBeUndefined();
+  });
+
+  test("lets NaN through for a float field whose string value is not numeric", () => {
+    const overrides = extractOverrides(snap({ temperature: "not-a-number" }));
+
+    expect(Number.isNaN(overrides.temperature)).toBe(true);
+  });
 });


### PR DESCRIPTION
The kit migration dropped the legacy extension's logger and overrides suites, and `handlers.ts` arrived with no coverage at all. This restores them, test-only, with no source changes.

`logger.test.ts` and `overrides.test.ts` are ports. The logger suite asserts behaviour instead of reaching into the private level field. The overrides suite pins what the kit's schema actually does with numeric strings: `parseInt(arg, 10) || undefined` drops a non-numeric value and also drops a legitimate `"0"`, and a non-numeric float string yields `NaN`, which passes `z.number()` and reaches the generation options unchecked. The `NaN` pass-through is inherited from the legacy extension and deserves a small src follow-up on the #2974 ledger; these tests only pin it, they do not fix it.

`handlers.test.ts` drives `handleDocumentWrite` with the fake-snapshot style the onwrite-processor tests already use, mocking only the generative client and Firestore reads, so it covers config through `createProcessor` to the status writes and the error mapper.

`tests/integration/chat-flow.emulator.test.ts` runs the same flow against a real Firestore emulator, covering the dotted-path status update, the order-field backfill, and the history query. It is gated on `FIRESTORE_EMULATOR_HOST`, so `npm test` skips it; `npm run test:emulator` runs it. It passed three consecutive runs locally, but no CI job runs kit emulator tests today.

Legacy `config.test.ts` was deliberately not ported: its `EXT_INSTANCE_ID`/env shapes are extension-runtime specific and the export-config and deploy-options suites already cover the kit-native equivalents.

25 new tests (47 passing, 3 emulator-gated). `tsc -b` clean, test files typecheck, prettier clean.

Part of #2974.