### PR TITLE
fix(delete-user-data): read the kit instance id from FIREBASE_KIT_INSTANCE_ID

### DIFF
--- a/kits/delete-user-data/CHANGELOG.md
+++ b/kits/delete-user-data/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Initial release of kit, see README for differences between the legacy extension and this kit
+- The instance id now comes from `FIREBASE_KIT_INSTANCE_ID`, which the Firebase CLI (15.27.0 or later) provides to each kit instance; `INSTANCE_ID` is no longer a configuration parameter

--- a/kits/delete-user-data/README.md
+++ b/kits/delete-user-data/README.md
@@ -51,8 +51,9 @@ only deploys what your entry file exports.
 
 ## Deploy
 
-The package's `firebase.json` declares a `kit` stanza (Firebase CLI 15.25.1 or
-later, behind the `kits` experiment):
+The package's `firebase.json` declares a `kit` stanza (Firebase CLI 15.27.0 or
+later, behind the `kits` experiment — earlier CLIs do not provide the
+`FIREBASE_KIT_INSTANCE_ID` variable this kit reads its instance id from):
 
 ```json
 {
@@ -86,9 +87,13 @@ Deploy a single instance with `firebase deploy --only functions:<instance id>`.
 Set these values in a `.env` (or `.env.<projectId>`) file. The Firebase CLI
 loads them at deploy time and prompts for any required values that are missing.
 
+The instance id is not a setting: the CLI provides it to each instance as
+`FIREBASE_KIT_INSTANCE_ID`, set to that instance's key in the `instances` map.
+`FIREBASE_` is a reserved prefix in `.env` files, so it cannot be set or
+overridden there.
+
 | Field | Env var | Required | Default | Description |
 |---|---|---|---|---|
-| `instanceId` | `INSTANCE_ID` | yes | — | Must match this instance's key in the `instances` map |
 | `firestorePaths` | `FIRESTORE_PATHS` | no | (empty) | Comma-separated Firestore paths with `{UID}` |
 | `firestoreDatabaseId` | `FIRESTORE_DATABASE_ID` | no | `(default)` | Firestore database id |
 | `firestoreDeleteMode` | `FIRESTORE_DELETE_MODE` | no | `shallow` | `shallow` or `recursive` |
@@ -101,8 +106,8 @@ loads them at deploy time and prompts for any required values that are missing.
 | `searchDepth` | `AUTO_DISCOVERY_SEARCH_DEPTH` | no | `3` | Discovery depth |
 | `searchFields` | `AUTO_DISCOVERY_SEARCH_FIELDS` | no | `id,uid,userId` | Fields treated as user ids |
 | `searchFunction` | `SEARCH_FUNCTION` | no | (empty) | Optional custom search function |
-| `discoveryTopicName` | `DISCOVERY_TOPIC_NAME` | no | `kit-<INSTANCE_ID>-discovery` | Pub/Sub discovery topic |
-| `deletionTopicName` | `DELETION_TOPIC_NAME` | no | `kit-<INSTANCE_ID>-deletion` | Pub/Sub deletion topic |
+| `discoveryTopicName` | `DISCOVERY_TOPIC_NAME` | no | `kit-<instance id>-discovery` | Pub/Sub discovery topic |
+| `deletionTopicName` | `DELETION_TOPIC_NAME` | no | `kit-<instance id>-deletion` | Pub/Sub deletion topic |
 
 ## Multiple instances
 
@@ -126,8 +131,9 @@ map, each pointing at its own config directory with its own `.env`:
 
 Instance ids must be unique across all kit stanzas in the project, and every
 instance's function names are namespaced by its `kit-<instance id>-` prefix, so
-the instances cannot collide. Set `INSTANCE_ID` in each config directory to the
-same value as that directory's key in the `instances` map.
+the instances cannot collide. Each instance learns its own id from the
+`FIREBASE_KIT_INSTANCE_ID` variable the CLI provides; there is nothing to keep
+in sync by hand.
 
 ## Events
 
@@ -148,17 +154,17 @@ enables it. The extension used `yes` / `no`, so copying an old config across
 leaves auto-discovery silently switched off. Change `yes` to `true` in your
 `.env`.
 
-### You set `INSTANCE_ID` yourself
+### The instance id comes from `firebase.json`
 
 The extension derived an instance id at install time and used it to name the
-Pub/Sub topics. Here it is a setting you provide, and it must match this
-instance's key in the `instances` map in `firebase.json`. If the two disagree,
-auto-discovery publishes to a topic nothing is listening on.
+Pub/Sub topics. Here the CLI derives it from this instance's key in the
+`instances` map in `firebase.json` and provides it to the functions as
+`FIREBASE_KIT_INSTANCE_ID`. There is no `INSTANCE_ID` setting to configure.
 
 ### Pub/Sub topics are named differently
 
-Discovery and deletion topics are now `kit-<INSTANCE_ID>-discovery` and
-`kit-<INSTANCE_ID>-deletion`, where the extension used an `ext-` prefix. The
+Discovery and deletion topics are now `kit-<instance id>-discovery` and
+`kit-<instance id>-deletion`, where the extension used an `ext-` prefix. The
 Firebase CLI creates them for you on deploy, so there is no manual setup step,
 but the old topics from an extension install are not reused and can be deleted
 once you have migrated.

--- a/kits/delete-user-data/src/config.ts
+++ b/kits/delete-user-data/src/config.ts
@@ -18,7 +18,6 @@ import {
   defineBoolean,
   defineInt,
   defineString,
-  expr,
   type IntParam,
   projectID,
   select,
@@ -26,10 +25,13 @@ import {
 } from "firebase-functions/params";
 import type { DeleteUserDataConfig } from "./export-config";
 
-const instanceId = defineString("FIREBASE_KIT_INSTANCE_ID");
+// firebase-tools injects this for kit instances (set to the instance's key in
+// firebase.json) during discovery, in the emulator, and on deployed functions.
+// The FIREBASE_ prefix is reserved in .env files and the params machinery never
+// sees injected values, so it must be a plain env read, not a defineString.
+const instanceId = process.env.FIREBASE_KIT_INSTANCE_ID;
 
 const params = {
-  instanceId,
   firestorePaths: defineString("FIRESTORE_PATHS", {
     label: "Cloud Firestore paths",
     description:
@@ -149,10 +151,10 @@ const params = {
   // Non-empty defaults so Pub/Sub trigger bindings resolve during deploy
   // discovery without freezing an empty topic name into the manifest.
   discoveryTopicName: defineString("DISCOVERY_TOPIC_NAME", {
-    default: expr`kit-${instanceId}-discovery`,
+    default: `kit-${instanceId}-discovery`,
   }),
   deletionTopicName: defineString("DELETION_TOPIC_NAME", {
-    default: expr`kit-${instanceId}-deletion`,
+    default: `kit-${instanceId}-deletion`,
   }),
 };
 
@@ -176,6 +178,14 @@ function optionalInt(param: IntParam): number | undefined {
 }
 
 export function configFromEnv(): DeleteUserDataConfig {
+  const instanceId = process.env.FIREBASE_KIT_INSTANCE_ID;
+  if (!instanceId) {
+    throw new Error(
+      "FIREBASE_KIT_INSTANCE_ID is not set. It is provided automatically to " +
+        "kit instances by firebase-tools >= 15.27.0; deploy or emulate this " +
+        "kit with a supported CLI version."
+    );
+  }
   return {
     firestorePaths: optional(params.firestorePaths.value()),
     firestoreDatabaseId: params.firestoreDatabaseId.value(),
@@ -191,7 +201,7 @@ export function configFromEnv(): DeleteUserDataConfig {
     searchDepth: optionalInt(params.searchDepth),
     searchFields: params.searchFields.value(),
     searchFunction: optional(params.searchFunction.value()),
-    instanceId: params.instanceId.value(),
+    instanceId,
     discoveryTopicName: optional(params.discoveryTopicName.value()),
     deletionTopicName: optional(params.deletionTopicName.value()),
     projectId: projectID.value(),

--- a/kits/delete-user-data/tests/config-runtime.test.ts
+++ b/kits/delete-user-data/tests/config-runtime.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { configFromEnv } from "../src/config";
 import { resolveDeleteUserDataConfig } from "../src/export-config";
 
@@ -33,10 +33,11 @@ describe("searchDepth from the runtime environment", () => {
   const original = process.env.AUTO_DISCOVERY_SEARCH_DEPTH;
 
   beforeEach(() => {
-    process.env.INSTANCE_ID = "test-instance";
+    vi.stubEnv("FIREBASE_KIT_INSTANCE_ID", "test-instance");
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     if (original === undefined) {
       delete process.env.AUTO_DISCOVERY_SEARCH_DEPTH;
     } else {

--- a/kits/delete-user-data/tests/config.test.ts
+++ b/kits/delete-user-data/tests/config.test.ts
@@ -58,17 +58,6 @@ const defineBoolean = vi.fn((_name: string, opts?: { default?: boolean }) => ({
   value: () => opts?.default ?? false,
 }));
 
-const expr = vi.fn(
-  (strings: TemplateStringsArray, ...values: unknown[]) =>
-    new FakeExpression(
-      strings.reduce(
-        (result, part, index) =>
-          result + part + (index < values.length ? cel(values[index]) : ""),
-        ""
-      )
-    )
-);
-
 function cel(value: unknown): string {
   return value instanceof FakeExpression ? value.toCEL() : String(value);
 }
@@ -78,7 +67,6 @@ vi.mock("firebase-functions/params", () => ({
   defineBoolean,
   defineInt,
   defineString,
-  expr,
   projectID: { value: () => "demo-test" },
   select: vi.fn((options: string[]) => ({ options })),
   storageBucket: new FakeStringParam("STORAGE_BUCKET", "demo-test.appspot.com"),
@@ -89,7 +77,7 @@ async function importConfig() {
   defineString.mockClear();
   defineInt.mockClear();
   defineBoolean.mockClear();
-  expr.mockClear();
+  vi.stubEnv("FIREBASE_KIT_INSTANCE_ID", "test-instance");
 
   return import("../src/config");
 }
@@ -130,7 +118,6 @@ describe("configFromEnv", () => {
     const declared = defineString.mock.calls.map(([name]) => name);
     expect(declared).toEqual(
       expect.arrayContaining([
-        "INSTANCE_ID",
         "FIRESTORE_PATHS",
         "FIRESTORE_DATABASE_ID",
         "FIRESTORE_DELETE_MODE",
@@ -155,7 +142,33 @@ describe("configFromEnv", () => {
     ]);
   });
 
-  test("defaults the topic names to kit-{instanceId}-* expressions", async () => {
+  // The CLI injects FIREBASE_KIT_INSTANCE_ID as a reserved env var; declaring
+  // it (or INSTANCE_ID) as a param makes the CLI prompt for a value it cannot
+  // accept and abort loading the kit.
+  test("does not declare an instance-id param", async () => {
+    await importConfig();
+
+    const declared = defineString.mock.calls.map(([name]) => name);
+    expect(declared).not.toContain("INSTANCE_ID");
+    expect(declared).not.toContain("FIREBASE_KIT_INSTANCE_ID");
+  });
+
+  test("reads the instance id from the injected environment", async () => {
+    const { configFromEnv } = await importConfig();
+
+    expect(configFromEnv().instanceId).toBe("test-instance");
+  });
+
+  test("throws when FIREBASE_KIT_INSTANCE_ID is missing", async () => {
+    const { configFromEnv } = await importConfig();
+    vi.stubEnv("FIREBASE_KIT_INSTANCE_ID", undefined);
+
+    expect(() => configFromEnv()).toThrow(
+      /FIREBASE_KIT_INSTANCE_ID is not set/
+    );
+  });
+
+  test("defaults the topic names to kit-{instanceId}-*", async () => {
     const { CONFIG_EXPRESSIONS } = await importConfig();
 
     expect(cel(CONFIG_EXPRESSIONS.discoveryTopicName)).toBe(
@@ -164,13 +177,13 @@ describe("configFromEnv", () => {
     expect(cel(CONFIG_EXPRESSIONS.deletionTopicName)).toBe(
       "{{ params.DELETION_TOPIC_NAME }}"
     );
-    expect(expr.mock.results.map((result) => cel(result.value))).toEqual([
-      "kit-{{ params.INSTANCE_ID }}-discovery",
-      "kit-{{ params.INSTANCE_ID }}-deletion",
-    ]);
     expect(defineString.mock.calls).toContainEqual([
       "DISCOVERY_TOPIC_NAME",
-      { default: expect.anything() },
+      { default: "kit-test-instance-discovery" },
+    ]);
+    expect(defineString.mock.calls).toContainEqual([
+      "DELETION_TOPIC_NAME",
+      { default: "kit-test-instance-deletion" },
     ]);
   });
 

--- a/kits/delete-user-data/tests/context.test.ts
+++ b/kits/delete-user-data/tests/context.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 // Stands in for a project with no Realtime Database URL available, which is what
 // an empty SELECTED_DATABASE_INSTANCE leaves behind.
@@ -58,6 +58,11 @@ function deletionEvent(uid: string) {
 describe("handler context", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubEnv("FIREBASE_KIT_INSTANCE_ID", "test-instance");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   test("builds without resolving the RTDB client", () => {


### PR DESCRIPTION
The rename in 03dd40b4 pointed at the right variable but the wrong mechanism. firebase-tools >= 15.27.0 injects FIREBASE_KIT_INSTANCE_ID for kit instances into discovery, emulator, and deployed runtime envs (loadFirebaseEnvs in lib/functions/env.js:280, called from lib/deploy/functions/prepare.js:194 and :527, and lib/emulator/controller.js:358 in the 15.28.2 tarball). But declared params are satisfied from user .env values only (resolveParams, lib/deploy/functions/params.js:166), and FIREBASE_ is a reserved .env prefix (RESERVED_PREFIXES, lib/functions/env.js:22), so `defineString("FIREBASE_KIT_INSTANCE_ID")` makes the CLI prompt for a value it can never accept, then reject it in writeUserEnvs. Reproduced on 15.28.2: the emulator fails with 'Question "Enter a string value for FIREBASE_KIT_INSTANCE_ID:" does not have a default and cannot be answered in non-interactive mode', and putting the key in .env fails env loading outright.

The fix reads process.env.FIREBASE_KIT_INSTANCE_ID directly, drops the INSTANCE_ID param, derives the topic-name defaults from it at discovery time, and throws a clear error when it is missing. Verified offline in the 15.28.2 emulator with a demo project: no prompt, and the CLI writes kit-<instance>-discovery/-deletion defaults itself. Live deploy not run. README/CHANGELOG document the 15.27.0 CLI minimum. Suite is green (98 tests), tsc -b and prettier clean. The other kits still declare INSTANCE_ID; aligning them is a follow-up, not part of this PR. Replaces #3051, which reverted in the wrong direction and could not be reopened after its branch was pruned. Fixes #3048