### PR TITLE
fix(firestore-vector-search): validate prefilters on the query onWrite path

### DIFF
--- a/kits/firestore-vector-search/src/handlers.ts
+++ b/kits/firestore-vector-search/src/handlers.ts
@@ -26,8 +26,8 @@ import type { ResolvedVectorSearchConfig } from "./export-config";
 import * as logs from "./logs";
 import {
   FirestoreVectorStoreClient,
-  type Prefilter,
   parseLimit,
+  parsePrefilters,
   parseQuerySchema,
   performTextQuery,
 } from "./queries";
@@ -129,7 +129,7 @@ export async function handleQueryOnWrite(
   const result = await performTextQuery({
     query,
     limit: data.limit ? parseLimit(data.limit) : ctx.config.defaultQueryLimit,
-    prefilters: (data.prefilters as Prefilter[] | undefined) ?? [],
+    prefilters: parsePrefilters(data.prefilters),
     embedClient: embedClient(ctx),
     vectorStore: vectorStore(ctx),
     config: ctx.config,

--- a/kits/firestore-vector-search/src/queries/index.ts
+++ b/kits/firestore-vector-search/src/queries/index.ts
@@ -26,10 +26,16 @@ const prefiltersSchema = z.array(prefilterSchema);
 
 /** Validates raw prefilters from a watched query document. */
 export function parsePrefilters(data: unknown): Prefilter[] {
-  if (data === undefined) return [];
+  if (data == null) return [];
   const parsed = prefiltersSchema.safeParse(data);
   if (!parsed.success) {
-    const issues = parsed.error.issues.map((issue) => issue.message).join("; ");
+    const issues = parsed.error.issues
+      .map((issue) =>
+        issue.path.length
+          ? `${issue.path.join(".")}: ${issue.message}`
+          : issue.message
+      )
+      .join("; ");
     throw new Error(`Invalid prefilters: ${issues}`);
   }
   return parsed.data;

--- a/kits/firestore-vector-search/src/queries/index.ts
+++ b/kits/firestore-vector-search/src/queries/index.ts
@@ -22,6 +22,19 @@ import type { FirestoreVectorStoreClient } from "../vector-store";
 export const prefilterSchema = z.record(z.any());
 export type Prefilter = z.infer<typeof prefilterSchema>;
 
+const prefiltersSchema = z.array(prefilterSchema);
+
+/** Validates raw prefilters from a watched query document. */
+export function parsePrefilters(data: unknown): Prefilter[] {
+  if (data === undefined) return [];
+  const parsed = prefiltersSchema.safeParse(data);
+  if (!parsed.success) {
+    const issues = parsed.error.issues.map((issue) => issue.message).join("; ");
+    throw new Error(`Invalid prefilters: ${issues}`);
+  }
+  return parsed.data;
+}
+
 export interface ParsedQueryRequest {
   query: string;
   limit?: string | number;

--- a/kits/firestore-vector-search/tests/handlers.test.ts
+++ b/kits/firestore-vector-search/tests/handlers.test.ts
@@ -284,4 +284,29 @@ describe("handleQueryOnWrite prefilters validation", () => {
     expect(chain.where).not.toHaveBeenCalled();
     expect(set).toHaveBeenCalledWith({ result: { ids: IDS } }, { merge: true });
   });
+
+  test("treats an explicit null prefilters as no prefilters", async () => {
+    const { ctx, chain } = makeCtx();
+    const { event, set } = queryDocEvent({
+      query: "test query",
+      prefilters: null,
+    });
+
+    await handleQueryOnWrite(event, ctx);
+
+    expect(chain.where).not.toHaveBeenCalled();
+    expect(set).toHaveBeenCalledWith({ result: { ids: IDS } }, { merge: true });
+  });
+
+  test("names the offending entry's index in the error", async () => {
+    const { ctx } = makeCtx();
+    const { event } = queryDocEvent({
+      query: "test query",
+      prefilters: [{ field: "category", operator: "==", value: "test" }, 42],
+    });
+
+    await expect(handleQueryOnWrite(event, ctx)).rejects.toThrow(
+      "Invalid prefilters: 1: Expected object, received number"
+    );
+  });
 });

--- a/kits/firestore-vector-search/tests/handlers.test.ts
+++ b/kits/firestore-vector-search/tests/handlers.test.ts
@@ -36,7 +36,12 @@ vi.mock("../src/embeddings", () => ({
 // handler never needs it.
 vi.mock("../src/queries/setup", () => ({ createIndex: vi.fn() }));
 
-import { type HandlerContext, handleQueryCall } from "../src/handlers";
+import {
+  type HandlerContext,
+  type VectorWriteEvent,
+  handleQueryCall,
+  handleQueryOnWrite,
+} from "../src/handlers";
 import { resolveVectorSearchConfig } from "../src/export-config";
 
 const config = resolveVectorSearchConfig({
@@ -203,5 +208,80 @@ describe("handleQueryCall", () => {
 
     expect((err as { code: string }).code).toBe("unknown");
     expect((err as Error).message).toBe("Query failed");
+  });
+});
+
+describe("handleQueryOnWrite prefilters validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSingleEmbedding.mockResolvedValue(EMBEDDING);
+  });
+
+  /** A create event for a watched query document with a spy on ref.set. */
+  function queryDocEvent(data: Record<string, unknown>) {
+    const set = vi.fn();
+    const event = {
+      data: {
+        before: { exists: false, data: () => undefined },
+        after: {
+          exists: true,
+          data: () => data,
+          ref: { set, path: "test-collection/doc-1" },
+        },
+      },
+      params: {},
+    } as unknown as VectorWriteEvent;
+    return { event, set };
+  }
+
+  test("runs the query and applies valid prefilters", async () => {
+    const { ctx, chain } = makeCtx();
+    const { event, set } = queryDocEvent({
+      query: "test query",
+      prefilters: [{ field: "category", operator: "==", value: "test" }],
+    });
+
+    await handleQueryOnWrite(event, ctx);
+
+    expect(chain.where).toHaveBeenCalledWith("category", "==", "test");
+    expect(set).toHaveBeenCalledWith({ result: { ids: IDS } }, { merge: true });
+  });
+
+  test("rejects a non-array prefilters value before embedding", async () => {
+    const { ctx } = makeCtx();
+    const { event, set } = queryDocEvent({
+      query: "test query",
+      prefilters: "not an array",
+    });
+
+    await expect(handleQueryOnWrite(event, ctx)).rejects.toThrow(
+      /Invalid prefilters/
+    );
+    expect(getSingleEmbedding).not.toHaveBeenCalled();
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  test("rejects a prefilter entry that is not an object", async () => {
+    const { ctx } = makeCtx();
+    const { event, set } = queryDocEvent({
+      query: "test query",
+      prefilters: ["category == test"],
+    });
+
+    await expect(handleQueryOnWrite(event, ctx)).rejects.toThrow(
+      /Invalid prefilters/
+    );
+    expect(getSingleEmbedding).not.toHaveBeenCalled();
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  test("treats missing prefilters as no prefilters", async () => {
+    const { ctx, chain } = makeCtx();
+    const { event, set } = queryDocEvent({ query: "test query" });
+
+    await handleQueryOnWrite(event, ctx);
+
+    expect(chain.where).not.toHaveBeenCalled();
+    expect(set).toHaveBeenCalledWith({ result: { ids: IDS } }, { merge: true });
   });
 });


### PR DESCRIPTION
On the queryOnWrite path, `handleQueryOnWrite` cast `data.prefilters as Prefilter[]` without validation, so malformed prefilters on a watched query document (a non-array, or non-object entries) either failed downstream inside the Firestore query or silently misbehaved. The legacy extension (firestore-vector-search v0.1.3) zod-parses prefilters with `z.array(prefilterSchema)` on this path (parity ledger #2974, item 7b).

This reuses the kit's existing `prefilterSchema` via a new `parsePrefilters` helper and replaces the cast at the point of use, throwing `Invalid prefilters: ...` before any embedding work. The legacy processor additionally caught the error and wrote an ERROR status to the document; the kit throws out of this handler today, and status parity is deferred to ledger item 7c.

Tests: a new `handleQueryOnWrite prefilters validation` describe block, confirmed red before the fix; full suite, `tsc -b`, and prettier pass. Note #3038 touches the head of the same function and appends its own onWrite tests; whichever lands second rebases trivially.

Fixes #3013

Following review (050ce5d5): an explicit `prefilters: null` is treated as no prefilters, preserving the `?? []` behavior the parse replaced, and validation errors include each issue's path so a mixed array names the index of the bad entry. Note the parse checks the top-level shape only (an array of objects), matching legacy's `z.record(z.any())` prefilterSchema; a typo'd key inside a prefilter is not caught here and still surfaces from the Firestore query downstream.