### PR TITLE
ci(kits): run emulator-gated kit suites on pull requests

### DIFF
--- a/.github/workflows/test-kits.yml
+++ b/.github/workflows/test-kits.yml
@@ -69,3 +69,10 @@ jobs:
       - name: Test
         working-directory: ${{ matrix.kit }}
         run: npm test
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools@15
+
+      - name: Emulator tests
+        working-directory: ${{ matrix.kit }}
+        run: npm run test:emulator --if-present


### PR DESCRIPTION
Adds two steps to the kit test job: install the Firebase CLI (pinned to major 15) and run `npm run test:emulator --if-present` in each changed kit. Kits without a `test:emulator` script are unaffected; `--if-present` makes the step a no-op for them, so kits can opt in by adding the script. Plain `npm test` skips the emulator-gated integration suites when `FIRESTORE_EMULATOR_HOST` is unset, so CI never ran them before.

Assumption: the Firestore emulator needs a JRE, and ubuntu-latest ships Temurin preinstalled, so no setup-java step is added. Validated locally: YAML parses, the matrix-detection logic is untouched, and firestore-counter's `test:emulator` passes from a clean `npm ci`. Caveat: this PR touches no `kits/**` paths, so the workflow only proves itself on the next kit PR after merge.
