### PR TITLE
docs(firestore-bigquery-export): stop claiming the kit publishes onSuccess and onCompletion

### DIFF
--- a/kits/firestore-bigquery-export/README.md
+++ b/kits/firestore-bigquery-export/README.md
@@ -154,9 +154,11 @@ the instances cannot collide.
 
 ## Events
 
-When `EVENTARC_CHANNEL` is configured, the function publishes lifecycle events
-such as `onStart`, `onError`, `onSuccess`, and `onCompletion` under
-`firebase.extensions.firestore-bigquery-export.v1.*`.
+When `EVENTARC_CHANNEL` is configured, the function publishes `onStart` and
+`onError` lifecycle events under
+`firebase.extensions.firestore-bigquery-export.v1.*`. The extension's
+`onSuccess` event is not published; see the events entry under
+"Differences from the Stream Firestore to BigQuery extension" below.
 
 ## Provisioning
 


### PR DESCRIPTION
The kit README's Events section claimed the function publishes `onStart`, `onError`, `onSuccess`, and `onCompletion`. The code publishes `onStart` and `onError` only: `src/handlers.ts` calls `recordStartEvent` and `recordErrorEvent`, and nothing calls `recordSuccessEvent` or `recordCompletionEvent`. The extension emitted `onSuccess` from its `syncBigQuery` task queue handler, which the kit deliberately removed, and the README's differences section already documents that. So the README was the wrong side; this corrects the Events section to list `onStart` and `onError` and point at the differences entry. Re-adding `onSuccess` emission (parity with the extension) is a separate decision, not attempted here.

Doc-only change, so no tests. Note #3066 also edits this README; its hunks (config table, provisioning, region sections) do not overlap this one.

Fixes #3018