### PR TITLE
fix(firestore-counter): compare worker metadata with strict deep-equal

### DIFF
--- a/kits/firestore-counter/src/worker.ts
+++ b/kits/firestore-counter/src/worker.ts
@@ -115,7 +115,10 @@ export class ShardedCounterWorker {
           await this.db.runTransaction(async (t) => {
             try {
               const snap = await t.get(this.metadoc.ref);
-              if (snap.exists && deepEqual(snap.data(), this.metadata)) {
+              if (
+                snap.exists &&
+                deepEqual(snap.data(), this.metadata, { strict: true })
+              ) {
                 t.update(snap.ref, {
                   timestamp: FieldValue.serverTimestamp(),
                   stats: stats,
@@ -149,7 +152,10 @@ export class ShardedCounterWorker {
 
       unsubscribeMetadataListener = this.metadoc.ref.onSnapshot((snap) => {
         // if something's changed in the worker metadata since we were called, abort.
-        if (!snap.exists || !deepEqual(snap.data(), this.metadata)) {
+        if (
+          !snap.exists ||
+          !deepEqual(snap.data(), this.metadata, { strict: true })
+        ) {
           logger.log("Shutting down because metadoc changed.");
           shutdown().then(resolve).catch(reject);
         }
@@ -243,7 +249,10 @@ export class ShardedCounterWorker {
           }
 
           // Check that we still own the slice.
-          if (!metadoc.exists || !deepEqual(metadoc.data(), this.metadata)) {
+          if (
+            !metadoc.exists ||
+            !deepEqual(metadoc.data(), this.metadata, { strict: true })
+          ) {
             logger.log("Metadata has changed, bailing out...");
             return [];
           }

--- a/kits/firestore-counter/tests/worker.test.ts
+++ b/kits/firestore-counter/tests/worker.test.ts
@@ -15,6 +15,7 @@
  */
 
 import type { DocumentSnapshot } from "firebase-admin/firestore";
+import { logger } from "firebase-functions";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("../src/events");
@@ -277,6 +278,7 @@ describe("run", () => {
       SHARDS_COLLECTION_ID,
       true
     );
+    const logSpy = vi.spyOn(logger, "log");
 
     // `0 == false`, so a non-strict comparison misses this reassignment.
     db.seed("test/worker", {
@@ -286,11 +288,71 @@ describe("run", () => {
 
     await runWorker(worker);
 
+    // The metadoc listener must catch it; the in-transaction ownership check
+    // bailing out later would leave the same state behind.
+    expect(logSpy).toHaveBeenCalledWith(
+      "Shutting down because metadoc changed."
+    );
     expect(db.snapshot("test/counter1").data()).toEqual({ counter: 0 });
     expect(
       db.snapshot(`test/counter1/${SHARDS_COLLECTION_ID}/012345678`).exists
     ).toBe(true);
     expect(db.snapshot("test/worker").data().stats).toBeUndefined();
+  });
+
+  test("bails out of the aggregation transaction on loosely-equal metadata", async () => {
+    db.seed("test/worker", { slice: { start: "", end: "" }, timestamp: 0 });
+    const metadoc = db.snapshot("test/worker");
+    db.seed("test/counter1", { counter: 0 });
+    db.seed(`test/counter1/${SHARDS_COLLECTION_ID}/012345678`, { counter: 1 });
+
+    const worker = new ShardedCounterWorker(
+      metadoc,
+      SHARDS_COLLECTION_ID,
+      true
+    );
+    const logSpy = vi.spyOn(logger, "log");
+
+    const run = worker.run();
+    // Flush the listeners' initial snapshots of the unchanged metadata.
+    await vi.advanceTimersByTimeAsync(0);
+    // seed() bypasses snapshot listeners, so only the in-transaction
+    // ownership read can observe this `0` -> `false` reassignment.
+    db.seed("test/worker", { slice: { start: "", end: "" }, timestamp: false });
+    await vi.advanceTimersByTimeAsync(46_000);
+    await run;
+
+    expect(logSpy).toHaveBeenCalledWith("Metadata has changed, bailing out...");
+    expect(db.snapshot("test/counter1").data()).toEqual({ counter: 0 });
+    expect(
+      db.snapshot(`test/counter1/${SHARDS_COLLECTION_ID}/012345678`).exists
+    ).toBe(true);
+  });
+
+  test("skips the stats write on loosely-equal metadata", async () => {
+    db.seed("test/worker", { slice: { start: "", end: "" }, timestamp: 0 });
+    const metadoc = db.snapshot("test/worker");
+    db.seed("test/counter1", { counter: 0 });
+    db.seed(`test/counter1/${SHARDS_COLLECTION_ID}/012345678`, { counter: 1 });
+
+    const worker = new ShardedCounterWorker(
+      metadoc,
+      SHARDS_COLLECTION_ID,
+      false
+    );
+
+    const run = worker.run();
+    // Let the first aggregation round complete against unchanged metadata.
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(db.snapshot("test/counter1").data()).toEqual({ counter: 1 });
+    // seed() bypasses snapshot listeners and aggregation is already done, so
+    // only the stats-write guard can observe this `0` -> `false` reassignment.
+    db.seed("test/worker", { slice: { start: "", end: "" }, timestamp: false });
+    await vi.advanceTimersByTimeAsync(44_001);
+    await run;
+
+    expect(db.snapshot("test/worker").data().stats).toBeUndefined();
+    expect(db.snapshot("test/worker").data().timestamp).toBe(false);
   });
 
   test("shuts down without aggregating when its metadata changes", async () => {

--- a/kits/firestore-counter/tests/worker.test.ts
+++ b/kits/firestore-counter/tests/worker.test.ts
@@ -266,6 +266,33 @@ describe("run", () => {
     );
   });
 
+  test("treats loosely-equal metadata values as a change", async () => {
+    db.seed("test/worker", { slice: { start: "", end: "" }, timestamp: 0 });
+    const metadoc = db.snapshot("test/worker");
+    db.seed("test/counter1", { counter: 0 });
+    db.seed(`test/counter1/${SHARDS_COLLECTION_ID}/012345678`, { counter: 1 });
+
+    const worker = new ShardedCounterWorker(
+      metadoc,
+      SHARDS_COLLECTION_ID,
+      true
+    );
+
+    // `0 == false`, so a non-strict comparison misses this reassignment.
+    db.seed("test/worker", {
+      slice: { start: "", end: "" },
+      timestamp: false,
+    });
+
+    await runWorker(worker);
+
+    expect(db.snapshot("test/counter1").data()).toEqual({ counter: 0 });
+    expect(
+      db.snapshot(`test/counter1/${SHARDS_COLLECTION_ID}/012345678`).exists
+    ).toBe(true);
+    expect(db.snapshot("test/worker").data().stats).toBeUndefined();
+  });
+
   test("shuts down without aggregating when its metadata changes", async () => {
     const metadoc = seedMetadoc();
     db.seed("test/counter1", { counter: 0 });


### PR DESCRIPTION
The kit's worker calls `deep-equal` on worker metadata without `{ strict: true }`, so loosely-equal values (`0` vs `false`, `""` vs `0`) compare equal. A worker could then keep aggregating a slice the controller had reassigned, or write stats over changed metadata. The legacy extension used `util.isDeepStrictEqual`, which is strict.

This passes `{ strict: true }` at all three call sites in `src/worker.ts` and pins each site with its own FakeFirestore test, arranged so only that site can observe a `0` -> `false` reassignment. Mutation-verified: reverting the strict flag at any single site fails exactly that site's test. The listener test failed before the fix (the shard was aggregated). Unit and emulator suites are green.

Possible follow-up: switch to `util.isDeepStrictEqual` outright and drop the `deep-equal` dependency.

Fixes #3019