### PR TITLE
fix(speech-to-text): stop stripping tmp/ from the .txt transcription path

### DIFF
--- a/kits/speech-to-text/CHANGELOG.md
+++ b/kits/speech-to-text/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Initial release of kit, see README for differences between the legacy extension and this kit
+- The `.txt` transcription output no longer has `tmp/` stripped from its path, a remnant of the legacy extension's temp-file handling; it lands at `<transcoded object>_transcription.txt` exactly ([#3026](https://github.com/firebase/extensions/issues/3026))

--- a/kits/speech-to-text/README.md
+++ b/kits/speech-to-text/README.md
@@ -150,8 +150,11 @@ The transcript itself is written to the same place as before
 (`<original path>.wav_transcription.txt`, under `OUTPUT_STORAGE_PATH` when set),
 so only the intermediate audio moves. If you have lifecycle rules, cleanup jobs
 or client code that expect the WAV under a `tmp/` prefix, point them at the new
-path. Both files still carry the `isTranscodeOutput` metadata flag that stops the
-function from processing its own output.
+path. The transcoded `.wav` still carries the `isTranscodeOutput` metadata flag
+that stops the function from processing its own output. The transcript `.txt` is
+written directly by the Speech-to-Text API and carries no metadata, so its
+finalize event runs the function again; that run creates a transcript document
+for the `.txt` object and marks it `FAILED` with "Invalid content type.".
 
 ### The function may now run for nine minutes
 

--- a/kits/speech-to-text/src/transcribe.ts
+++ b/kits/speech-to-text/src/transcribe.ts
@@ -65,10 +65,7 @@ export async function transcribeAndUpload({
   options: SpeechOptions;
 }): Promise<TranscribeAudioResult> {
   const inputUri = `gs://${bucket.name}/${name}`;
-  const outputUri = `gs://${bucket.name}/${name.replace(
-    "tmp/",
-    ""
-  )}_transcription.txt`;
+  const outputUri = `gs://${bucket.name}/${name}_transcription.txt`;
   const warnings: WarningType[] = [];
   const request: google.cloud.speech.v1.ILongRunningRecognizeRequest = {
     config: {

--- a/kits/speech-to-text/tests/transcribe.test.ts
+++ b/kits/speech-to-text/tests/transcribe.test.ts
@@ -47,8 +47,10 @@ vi.mock("fluent-ffmpeg", () => {
   return { default: ffmpeg };
 });
 
-import { transcodeToLinear16 } from "../src/transcribe";
+import { transcodeToLinear16, transcribeAndUpload } from "../src/transcribe";
 import { Status } from "../src/types";
+import type { SpeechClient } from "@google-cloud/speech";
+import type { Bucket } from "@google-cloud/storage";
 
 describe("transcodeToLinear16", () => {
   beforeEach(() => {
@@ -68,5 +70,51 @@ describe("transcodeToLinear16", () => {
       expect(result.sampleRateHertz).toBe(44100);
       expect(typeof result.sampleRateHertz).toBe("number");
     }
+  });
+});
+
+describe("transcribeAndUpload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("writes the .txt next to the uploaded object, even when its path contains tmp/", async () => {
+    const longRunningRecognize = vi.fn().mockResolvedValue([
+      {
+        promise: vi.fn().mockResolvedValue([
+          {
+            results: [
+              { channelTag: 1, alternatives: [{ transcript: "hello" }] },
+            ],
+          },
+        ]),
+      },
+    ]);
+    const client = { longRunningRecognize } as unknown as SpeechClient;
+
+    const result = await transcribeAndUpload({
+      client,
+      file: {
+        bucket: { name: "my-bucket" } as Bucket,
+        name: "audio/tmp/clip.mp3.wav",
+      },
+      sampleRateHertz: 44100,
+      audioChannelCount: 1,
+      options: {
+        languageCode: "en-US",
+        model: "default",
+        enableAutomaticPunctuation: true,
+      },
+    });
+
+    expect(result.status).toBe(Status.SUCCESS);
+    expect(longRunningRecognize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        audio: { uri: "gs://my-bucket/audio/tmp/clip.mp3.wav" },
+        outputConfig: {
+          gcsUri: "gs://my-bucket/audio/tmp/clip.mp3.wav_transcription.txt",
+        },
+      })
+    );
   });
 });


### PR DESCRIPTION
The `.txt` transcription output URI retained `replace("tmp/", "")` from the legacy extension, where the transcoded `.wav` was uploaded under an object name derived from its local `/tmp` path. The kit uploads the `.wav` bucket-relative, so the remnant only mangled object paths that legitimately contain `tmp/` (e.g. `audio/tmp/clip.mp3` produced a transcript at `audio/clip.mp3.wav_transcription.txt`). The transform is removed; the `.txt` now lands at `<transcoded object>_transcription.txt` exactly, as the README states.

Added a unit test on `transcribeAndUpload` pinning the `gcsUri` for a `tmp/`-containing path; it was red against the remnant and is green after. Full vitest suite, `tsc -b` and prettier pass. Live transcription was not run.

The open decision on where the transcoded `.wav` lands (#2974 Migration section) is out of scope and unchanged.

Fixes #3026