### PR TITLE
fix(firestore-translate-text): construct the translation client once per process

### DIFF
--- a/kits/firestore-translate-text/CHANGELOG.md
+++ b/kits/firestore-translate-text/CHANGELOG.md
@@ -1,3 +1,3 @@
-- Construct the translation client once per process instead of on every invocation, matching the legacy extension
+- Construct the translation client once per process instead of on every invocation, matching the legacy extension. This changes the exported `HandlerContext` type from `{ firestore, config, googleAiApiKey? }` to `{ config, service }`: `handleDocumentWrite` no longer builds the `TranslationService` itself and instead expects it on the context (build one with `createTranslationService`)
 - Initial release of kit, see README for differences between the legacy extension and this kit
 - The Google AI API key (and any other secret-shaped config value) is now masked as `<omitted>` in the config logged at startup and on each invocation; the legacy extension logs it in cleartext

--- a/kits/firestore-translate-text/CHANGELOG.md
+++ b/kits/firestore-translate-text/CHANGELOG.md
@@ -1,2 +1,3 @@
+- Construct the translation client once per process instead of on every invocation, matching the legacy extension
 - Initial release of kit, see README for differences between the legacy extension and this kit
 - The Google AI API key (and any other secret-shaped config value) is now masked as `<omitted>` in the config logged at startup and on each invocation; the legacy extension logs it in cleartext

--- a/kits/firestore-translate-text/src/handlers.ts
+++ b/kits/firestore-translate-text/src/handlers.ts
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 
-import {
-  type DocumentSnapshot,
-  FieldValue,
-  type Firestore,
-} from "firebase-admin/firestore";
+import { type DocumentSnapshot, FieldValue } from "firebase-admin/firestore";
 import type { Change, FirestoreEvent } from "firebase-functions/v2/firestore";
 import * as events from "./events";
 import type { ResolvedTranslateConfig } from "./export-config";
 import * as logs from "./logs";
-import { createTranslationService, translateDocument } from "./translate";
+import { type TranslationService, translateDocument } from "./translate";
 import * as validators from "./validators";
 
 const CHANGE_TYPE = {
@@ -35,9 +31,8 @@ const CHANGE_TYPE = {
 type ChangeType = (typeof CHANGE_TYPE)[keyof typeof CHANGE_TYPE];
 
 export interface HandlerContext {
-  firestore: Firestore;
   config: ResolvedTranslateConfig;
-  googleAiApiKey?: string;
+  service: TranslationService;
 }
 
 export type TranslateWriteEvent = FirestoreEvent<
@@ -63,11 +58,7 @@ export async function handleDocumentWrite(
     return;
   }
 
-  const config: ResolvedTranslateConfig = {
-    ...ctx.config,
-    googleAiApiKey: ctx.googleAiApiKey ?? ctx.config.googleAiApiKey,
-  };
-  const service = createTranslationService(config, ctx.firestore);
+  const { config, service } = ctx;
 
   logs.start(config);
   await events.recordStartEvent({ data: event.data, params: event.params });
@@ -118,7 +109,7 @@ export async function handleDocumentWrite(
 
 async function handleCreateDocument(
   snapshot: DocumentSnapshot,
-  service: ReturnType<typeof createTranslationService>,
+  service: TranslationService,
   config: ResolvedTranslateConfig
 ): Promise<void> {
   const input = service.extractInput(snapshot);
@@ -137,7 +128,7 @@ function handleDeleteDocument(): void {
 async function handleUpdateDocument(
   before: DocumentSnapshot,
   after: DocumentSnapshot,
-  service: ReturnType<typeof createTranslationService>,
+  service: TranslationService,
   config: ResolvedTranslateConfig
 ): Promise<void> {
   const inputBefore = service.extractInput(before);

--- a/kits/firestore-translate-text/src/index.ts
+++ b/kits/firestore-translate-text/src/index.ts
@@ -27,6 +27,7 @@ import {
 } from "./export-config";
 import { type HandlerContext, handleDocumentWrite } from "./handlers";
 import * as logs from "./logs";
+import { createTranslationService } from "./translate";
 
 export * from "./lib";
 
@@ -82,11 +83,18 @@ function getContext(): HandlerContext {
 
   events.setupEventChannel();
 
-  const config = getConfig();
+  const resolved = getConfig();
+  // The secret is only readable at runtime, so it joins the config here rather
+  // than in resolveTranslateConfig.
+  const config: ResolvedTranslateConfig = {
+    ...resolved,
+    googleAiApiKey: resolved.useGenkit
+      ? googleAiApiKey.value()
+      : resolved.googleAiApiKey,
+  };
   context = {
-    firestore: getFirestore(),
     config,
-    googleAiApiKey: config.useGenkit ? googleAiApiKey.value() : undefined,
+    service: createTranslationService(config, getFirestore()),
   };
 
   return context;

--- a/kits/firestore-translate-text/tests/context.test.ts
+++ b/kits/firestore-translate-text/tests/context.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("firebase-functions", async () => ({
+  ...(await import("./mocks/firebase-functions")),
+  requiresAPI: vi.fn(),
+  requiresRole: vi.fn(),
+}));
+vi.mock("@google-cloud/translate", () => import("./mocks/translate"));
+vi.mock("genkit", () => import("./mocks/genkit"));
+vi.mock("@genkit-ai/google-genai", () => import("./mocks/google-genai"));
+vi.mock("../src/events");
+
+const { configFromEnv, onDocumentWritten } = vi.hoisted(() => ({
+  configFromEnv: vi.fn(),
+  onDocumentWritten: vi.fn(
+    (_options: unknown, handler: (event: unknown) => Promise<void>) => handler
+  ),
+}));
+
+vi.mock("../src/config", () => ({
+  CONFIG_EXPRESSIONS: { document: "translations/{messageId}" },
+  configFromEnv,
+  googleAiApiKey: { name: "GOOGLE_AI_API_KEY", value: vi.fn(() => "api-key") },
+}));
+
+vi.mock("firebase-functions/v2/firestore", () => ({ onDocumentWritten }));
+
+vi.mock("firebase-admin/app", () => ({
+  getApp: vi.fn(() => ({ name: "[DEFAULT]" })),
+  initializeApp: vi.fn(),
+}));
+
+vi.mock("firebase-admin/firestore", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getFirestore: vi.fn(() => ({
+    runTransaction: vi.fn(
+      async (handler: (tx: { update: () => void }) => Promise<void>) =>
+        handler({ update: vi.fn() })
+    ),
+  })),
+}));
+
+import "../src/index";
+import { defaultEnvironment, makeEvent, makeSnapshot } from "./helpers";
+import { translateClass } from "./mocks/translate";
+
+/**
+ * Unlike `index.test.ts`, this suite keeps `../src/handlers` real so the
+ * events flow through the full trigger path against a mocked translation
+ * client.
+ */
+describe("handler context", () => {
+  test("constructs the translation client once across invocations", async () => {
+    configFromEnv.mockReturnValue({
+      collectionPath: defaultEnvironment.COLLECTION_PATH,
+      inputFieldName: defaultEnvironment.INPUT_FIELD_NAME,
+      outputFieldName: defaultEnvironment.OUTPUT_FIELD_NAME,
+      languages: defaultEnvironment.LANGUAGES,
+      languagesFieldName: defaultEnvironment.LANGUAGES_FIELD_NAME,
+      projectId: defaultEnvironment.PROJECT_ID,
+      region: defaultEnvironment.LOCATION,
+    });
+    const [, handler] = onDocumentWritten.mock.calls[0];
+
+    await handler(makeEvent(makeSnapshot(), makeSnapshot({ input: "hello" })));
+    await handler(
+      makeEvent(makeSnapshot(), makeSnapshot({ input: "goodbye" }))
+    );
+
+    expect(translateClass).toHaveBeenCalledTimes(1);
+    expect(translateClass).toHaveBeenCalledWith({
+      projectId: defaultEnvironment.PROJECT_ID,
+    });
+  });
+});

--- a/kits/firestore-translate-text/tests/handlers.test.ts
+++ b/kits/firestore-translate-text/tests/handlers.test.ts
@@ -26,6 +26,7 @@ vi.mock("../src/events");
 import * as events from "../src/events";
 import { handleDocumentWrite } from "../src/handlers";
 import { messages } from "../src/logs/messages";
+import { createTranslationService } from "../src/translate";
 import {
   defaultEnvironment,
   defaultLanguages,
@@ -36,7 +37,7 @@ import {
   testTranslations,
 } from "./helpers";
 import { logger, resetLoggerMocks } from "./mocks/firebase-functions";
-import { googleAI, resetGoogleGenaiMocks } from "./mocks/google-genai";
+import { resetGoogleGenaiMocks } from "./mocks/google-genai";
 import {
   resetTranslateMocks,
   translateClass,
@@ -53,10 +54,13 @@ import {
 describe("handleDocumentWrite", () => {
   let firestore: ReturnType<typeof makeFirestore>;
 
-  const context = (overrides: Parameters<typeof makeConfig>[0] = {}) => ({
-    firestore: firestore.firestore,
-    config: makeConfig(overrides),
-  });
+  const context = (overrides: Parameters<typeof makeConfig>[0] = {}) => {
+    const config = makeConfig(overrides);
+    return {
+      config,
+      service: createTranslationService(config, firestore.firestore),
+    };
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -367,33 +371,11 @@ describe("handleDocumentWrite", () => {
       ctx
     );
 
-    expect(logger.log).toHaveBeenCalledWith(
-      ...messages.start({ ...ctx.config, googleAiApiKey: undefined })
-    );
-  });
-
-  test("prefers the injected Google AI API key over the config value", async () => {
-    await handleDocumentWrite(
-      makeEvent(makeSnapshot(), makeSnapshot({ input: "hello" })),
-      {
-        firestore: firestore.firestore,
-        config: makeConfig({
-          provider: "gemini-googleai",
-          googleAiApiKey: "from-config",
-        }),
-        googleAiApiKey: "from-secret",
-      }
-    );
-
-    expect(googleAI).toHaveBeenCalledWith({ apiKey: "from-secret" });
+    expect(logger.log).toHaveBeenCalledWith(...messages.start(ctx.config));
   });
 
   test("redacts the Google AI API key from the start log", async () => {
-    const ctx = {
-      firestore: firestore.firestore,
-      config: makeConfig(),
-      googleAiApiKey: "super-secret",
-    };
+    const ctx = context({ googleAiApiKey: "super-secret" });
 
     await handleDocumentWrite(
       makeEvent(makeSnapshot(), makeSnapshot({ input: "hello" })),

--- a/kits/firestore-translate-text/tests/index.test.ts
+++ b/kits/firestore-translate-text/tests/index.test.ts
@@ -38,6 +38,9 @@ const { logger, requiresAPI, requiresRole } = vi.hoisted(() => ({
 
 vi.mock("firebase-functions", () => ({ logger, requiresAPI, requiresRole }));
 
+vi.mock("@google-cloud/translate", () => import("./mocks/translate"));
+vi.mock("genkit", () => import("./mocks/genkit"));
+vi.mock("@genkit-ai/google-genai", () => import("./mocks/google-genai"));
 vi.mock("../src/events");
 
 const configFromEnv = vi.fn<() => TranslateConfig>();
@@ -166,10 +169,11 @@ describe("index", () => {
     await handler(event);
 
     expect(handleDocumentWrite).toHaveBeenNthCalledWith(1, event, {
-      firestore,
       config: resolveTranslateConfig(baseConfig),
-      googleAiApiKey: undefined,
+      service: expect.anything(),
     });
+    const contexts = handleDocumentWrite.mock.calls.map(([, ctx]) => ctx);
+    expect(contexts[1]).toBe(contexts[0]);
     expect(configFromEnv).toHaveBeenCalledTimes(1);
     expect(getFirestore).toHaveBeenCalledTimes(1);
     expect(events.setupEventChannel).toHaveBeenCalledTimes(1);
@@ -204,7 +208,27 @@ describe("index", () => {
     expect(googleAiApiKey.value).toHaveBeenCalledTimes(1);
     expect(handleDocumentWrite).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ googleAiApiKey: "api-key" })
+      expect.objectContaining({
+        config: expect.objectContaining({ googleAiApiKey: "api-key" }),
+      })
+    );
+  });
+
+  test("prefers the secret over the configured Google AI API key", async () => {
+    await importIndex({
+      ...baseConfig,
+      provider: "gemini-googleai",
+      googleAiApiKey: "from-config",
+    });
+    const [, handler] = onDocumentWritten.mock.calls[0];
+
+    await handler(makeEvent(makeSnapshot(), makeSnapshot({ input: "hello" })));
+
+    expect(handleDocumentWrite).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        config: expect.objectContaining({ googleAiApiKey: "api-key" }),
+      })
     );
   });
 


### PR DESCRIPTION
The kit's `handleDocumentWrite` called `createTranslationService` on every invocation, so each event built a new `TranslationService` and a fresh translation client. The legacy extension constructs the client once at module scope.

Following the kit family's lazy-context pattern (delete-user-data's `getContext`), the service now lives on the memoized `HandlerContext` built once per process in `getContext()`, which also merges the runtime Google AI API key secret into the config there. The `./lib` entry stays side-effect free.

New `tests/context.test.ts` drives the real trigger path twice with a mocked `v2.Translate` constructor and pins a single construction; it failed with two constructions before the fix. Full suite (90 tests) and `tsc -b` pass.

Fixes #3021