### PR TITLE
fix(firestore-translate-text): redact the Google AI API key from config logs

### DIFF
--- a/kits/firestore-translate-text/CHANGELOG.md
+++ b/kits/firestore-translate-text/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Initial release of kit, see README for differences between the legacy extension and this kit
+- The Google AI API key (and any other secret-shaped config value) is now masked as `<omitted>` in the config logged at startup and on each invocation; the legacy extension logs it in cleartext

--- a/kits/firestore-translate-text/src/logs/messages.ts
+++ b/kits/firestore-translate-text/src/logs/messages.ts
@@ -14,6 +14,22 @@
  * limitations under the License.
  */
 
+const SECRET_KEY_PATTERN = /api[-_]?key|secret|password|token|credential/i;
+
+/**
+ * Returns a copy of the config with every set, secret-shaped value replaced by
+ * `"<omitted>"`, so config logging never writes a credential to Cloud Logging.
+ */
+export function redactSecrets(config: object): Record<string, unknown> {
+  const redacted: Record<string, unknown> = { ...config };
+  for (const key of Object.keys(redacted)) {
+    if (SECRET_KEY_PATTERN.test(key) && redacted[key] !== undefined) {
+      redacted[key] = "<omitted>";
+    }
+  }
+  return redacted;
+}
+
 export const messages = {
   complete: () => "Completed execution of extension",
   documentCreatedNoInput: () =>
@@ -31,15 +47,15 @@ export const messages = {
   error: (err: Error) => ["Failed execution of extension", err],
   fieldNamesNotDifferent: () =>
     "The `Input` and `Output` field names must be different for this extension to function correctly",
-  init: (config = {}) => [
+  init: (config: object = {}) => [
     "Initializing extension with the parameter values",
-    config,
+    redactSecrets(config),
   ],
   inputFieldNameIsOutputPath: () =>
     "The `Input` field name must not be the same as an `Output` path for this extension to function correctly",
-  start: (config = {}) => [
+  start: (config: object = {}) => [
     "Started execution of extension with configuration",
-    config,
+    redactSecrets(config),
   ],
   translateStringComplete: (
     string: string,

--- a/kits/firestore-translate-text/src/logs/messages.ts
+++ b/kits/firestore-translate-text/src/logs/messages.ts
@@ -17,13 +17,15 @@
 const SECRET_KEY_PATTERN = /api[-_]?key|secret|password|token|credential/i;
 
 /**
- * Returns a copy of the config with every set, secret-shaped value replaced by
- * `"<omitted>"`, so config logging never writes a credential to Cloud Logging.
+ * Returns a copy of the config with every non-empty, secret-shaped value
+ * replaced by `"<omitted>"`, so config logging never writes a credential to
+ * Cloud Logging. Empty values pass through untouched: they carry no secret,
+ * and masking them would misreport an unconfigured secret as set.
  */
 export function redactSecrets(config: object): Record<string, unknown> {
   const redacted: Record<string, unknown> = { ...config };
   for (const key of Object.keys(redacted)) {
-    if (SECRET_KEY_PATTERN.test(key) && redacted[key] !== undefined) {
+    if (SECRET_KEY_PATTERN.test(key) && redacted[key]) {
       redacted[key] = "<omitted>";
     }
   }

--- a/kits/firestore-translate-text/tests/handlers.test.ts
+++ b/kits/firestore-translate-text/tests/handlers.test.ts
@@ -36,6 +36,7 @@ import {
   testTranslations,
 } from "./helpers";
 import { logger, resetLoggerMocks } from "./mocks/firebase-functions";
+import { googleAI, resetGoogleGenaiMocks } from "./mocks/google-genai";
 import {
   resetTranslateMocks,
   translateClass,
@@ -61,6 +62,7 @@ describe("handleDocumentWrite", () => {
     vi.clearAllMocks();
     resetLoggerMocks();
     resetTranslateMocks();
+    resetGoogleGenaiMocks();
     firestore = makeFirestore();
   });
 
@@ -375,14 +377,36 @@ describe("handleDocumentWrite", () => {
       makeEvent(makeSnapshot(), makeSnapshot({ input: "hello" })),
       {
         firestore: firestore.firestore,
-        config: makeConfig({ googleAiApiKey: "from-config" }),
+        config: makeConfig({
+          provider: "gemini-googleai",
+          googleAiApiKey: "from-config",
+        }),
         googleAiApiKey: "from-secret",
       }
     );
 
+    expect(googleAI).toHaveBeenCalledWith({ apiKey: "from-secret" });
+  });
+
+  test("redacts the Google AI API key from the start log", async () => {
+    const ctx = {
+      firestore: firestore.firestore,
+      config: makeConfig(),
+      googleAiApiKey: "super-secret",
+    };
+
+    await handleDocumentWrite(
+      makeEvent(makeSnapshot(), makeSnapshot({ input: "hello" })),
+      ctx
+    );
+
     expect(logger.log).toHaveBeenCalledWith(
       "Started execution of extension with configuration",
-      expect.objectContaining({ googleAiApiKey: "from-secret" })
+      expect.objectContaining({
+        collectionPath: ctx.config.collectionPath,
+        googleAiApiKey: "<omitted>",
+      })
     );
+    expect(JSON.stringify(logger.log.mock.calls)).not.toContain("super-secret");
   });
 });

--- a/kits/firestore-translate-text/tests/index.test.ts
+++ b/kits/firestore-translate-text/tests/index.test.ts
@@ -208,6 +208,22 @@ describe("index", () => {
     );
   });
 
+  test("redacts the Google AI API key from the init log", async () => {
+    await importIndex({ ...baseConfig, googleAiApiKey: "super-secret" });
+    const [, handler] = onDocumentWritten.mock.calls[0];
+
+    await handler(makeEvent(makeSnapshot(), makeSnapshot({ input: "hello" })));
+
+    expect(logger.log).toHaveBeenCalledWith(
+      "Initializing extension with the parameter values",
+      expect.objectContaining({
+        collectionPath: baseConfig.collectionPath,
+        googleAiApiKey: "<omitted>",
+      })
+    );
+    expect(JSON.stringify(logger.log.mock.calls)).not.toContain("super-secret");
+  });
+
   test("does not read the secret for the Google Translate provider", async () => {
     await importIndex({ ...baseConfig, provider: "translate" });
     const [, handler] = onDocumentWritten.mock.calls[0];

--- a/kits/firestore-translate-text/tests/logs.test.ts
+++ b/kits/firestore-translate-text/tests/logs.test.ts
@@ -55,6 +55,15 @@ describe("config log redaction", () => {
     });
   });
 
+  test("an empty or null secret is not reported as omitted", () => {
+    const [, payload] = messages.init({
+      googleAiApiKey: "",
+      accessToken: null,
+    });
+
+    expect(payload).toEqual({ googleAiApiKey: "", accessToken: null });
+  });
+
   test("init masks the Google AI API key when it is set", () => {
     const [, payload] = messages.init({ googleAiApiKey: "super-secret" });
 

--- a/kits/firestore-translate-text/tests/logs.test.ts
+++ b/kits/firestore-translate-text/tests/logs.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, test } from "vitest";
+import { messages } from "../src/logs/messages";
+
+// The redaction lives in the message builders so no caller of `start`/`init`
+// can log a credential, regardless of where the config picks the secret up.
+describe("config log redaction", () => {
+  test("start masks secret-shaped values and keeps the rest", () => {
+    const [text, payload] = messages.start({
+      collectionPath: "translations",
+      googleAiApiKey: "super-secret",
+      somePassword: "hunter2",
+      accessToken: "tok",
+      clientSecret: "sec",
+      serviceCredential: "cred",
+    });
+
+    expect(text).toBe("Started execution of extension with configuration");
+    expect(payload).toEqual({
+      collectionPath: "translations",
+      googleAiApiKey: "<omitted>",
+      somePassword: "<omitted>",
+      accessToken: "<omitted>",
+      clientSecret: "<omitted>",
+      serviceCredential: "<omitted>",
+    });
+    expect(JSON.stringify([text, payload])).not.toContain("super-secret");
+  });
+
+  test("init masks the Google AI API key only when it is set", () => {
+    const [text, payload] = messages.init({
+      collectionPath: "translations",
+      googleAiApiKey: undefined,
+    });
+
+    expect(text).toBe("Initializing extension with the parameter values");
+    expect(payload).toEqual({
+      collectionPath: "translations",
+      googleAiApiKey: undefined,
+    });
+  });
+
+  test("init masks the Google AI API key when it is set", () => {
+    const [, payload] = messages.init({ googleAiApiKey: "super-secret" });
+
+    expect(payload).toEqual({ googleAiApiKey: "<omitted>" });
+  });
+
+  test("redaction does not mutate the caller's config", () => {
+    const config = { googleAiApiKey: "super-secret" };
+
+    messages.start(config);
+
+    expect(config.googleAiApiKey).toBe("super-secret");
+  });
+});


### PR DESCRIPTION
The kit logs the full config object via `logs.init` at startup and `logs.start` on every invocation, and the config can carry `googleAiApiKey`, so the secret lands in Cloud Logging in cleartext per event.

The fix masks secret-shaped config values as `<omitted>` inside the `start`/`init` message builders, following the firestore-send-email / bigquery-firestore-export convention. Redaction sits at the logging site rather than at the config merge, so it is order-independent with #3075 (still open), which changes where the config picks up the secret inside `getContext()`: whichever PR lands second cannot reintroduce the leak. The handlers test that previously asserted the merged secret appears in `logger.log` now observes merge precedence through the `googleAI` plugin mock instead.

Repro-first tests cover both `start` and `init` paths (red on the old code, green now); full vitest suite (95 tests) and `tsc -b` pass.

Fixes #3076