### PR TITLE
fix(kits): resolve the Vertex AI location consistently across kits

### DIFF
--- a/kits/firestore-genai-chatbot/src/config.ts
+++ b/kits/firestore-genai-chatbot/src/config.ts
@@ -29,6 +29,16 @@ import {
   type SafetySetting,
 } from "./export-config";
 
+/**
+ * Region used for Vertex AI when the function's own region is unavailable.
+ *
+ * Kits read their region from `FUNCTION_REGION`, which the extension got from
+ * its install-time `LOCATION` param. That variable is absent outside a
+ * deployed function (emulator runs, library consumers), so fall back rather
+ * than leaving the SDK to pick a region.
+ */
+const DEFAULT_VERTEX_LOCATION = "us-central1";
+
 const GENERATIVE_AI_PROVIDER_OPTIONS = ["google-ai", "vertex-ai"] as const;
 const VERTEX_MODEL_LOCATION_OPTIONS = [
   "null",
@@ -354,8 +364,13 @@ export function configFromEnv(): GenaiChatbotConfig {
       GenerativeAIProvider.GOOGLE_AI,
     apiKey: params.apiKey.value(),
     model: params.model.value(),
+    // "null" is the param's "Same as Cloud Functions Location" option. The
+    // extension resolved it to the install LOCATION; FUNCTION_REGION is the
+    // kit's equivalent, since kits take their region from the deployment.
     vertexModelLocation:
-      vertexModelLocation === "null" ? undefined : vertexModelLocation,
+      vertexModelLocation === "null"
+        ? process.env.FUNCTION_REGION || DEFAULT_VERTEX_LOCATION
+        : vertexModelLocation,
     projectId: getProjectId(),
     collectionName: optional(params.collectionName.value()),
     promptField: optional(params.promptField.value()),

--- a/kits/firestore-translate-text/src/translate/common.ts
+++ b/kits/firestore-translate-text/src/translate/common.ts
@@ -22,6 +22,16 @@ import * as events from "../events";
 import type { ResolvedTranslateConfig } from "../export-config";
 import * as logs from "../logs";
 
+/**
+ * Region used for Vertex AI when the function's own region is unavailable.
+ *
+ * Kits read their region from `FUNCTION_REGION`, which the extension got from
+ * its install-time `LOCATION` param. That variable is absent outside a
+ * deployed function (emulator runs, library consumers), so fall back rather
+ * than leaving the SDK to pick a region or failing the call.
+ */
+const DEFAULT_VERTEX_LOCATION = "us-central1";
+
 export type Translation = {
   language: string;
   output: string;
@@ -72,7 +82,7 @@ export class GenkitTranslator implements Translator {
 
     const plugins =
       config.geminiProvider === "vertexai"
-        ? [vertexAI(config.region ? { location: config.region } : {})]
+        ? [vertexAI({ location: config.region || DEFAULT_VERTEX_LOCATION })]
         : [googleAI({ apiKey: config.googleAiApiKey })];
 
     this.client = genkit({ plugins });

--- a/kits/firestore-translate-text/tests/translation-service.test.ts
+++ b/kits/firestore-translate-text/tests/translation-service.test.ts
@@ -125,12 +125,12 @@ describe("GenkitTranslator", () => {
     expect(vertexAI.model).toHaveBeenCalledWith("gemini-2.5-pro");
   });
 
-  test("registers the vertexai plugin without a location when no region is set", () => {
+  test("falls back to the default location when no region is set", () => {
     new GenkitTranslator(
       makeConfig({ provider: "gemini-vertexai", region: "" })
     );
 
-    expect(vertexAI).toHaveBeenCalledWith({});
+    expect(vertexAI).toHaveBeenCalledWith({ location: "us-central1" });
   });
 
   test("returns the structured translation and logs completion", async () => {

--- a/kits/firestore-vector-search/src/embeddings/client/genkit.ts
+++ b/kits/firestore-vector-search/src/embeddings/client/genkit.ts
@@ -19,6 +19,16 @@ import { type EmbedderReference, type Genkit, genkit } from "genkit";
 import type { ResolvedVectorSearchConfig } from "../../export-config";
 import { BaseEmbedClient } from "./base_class";
 
+/**
+ * Region used for Vertex AI when the function's own region is unavailable.
+ *
+ * Kits read their region from `FUNCTION_REGION`, which the extension got from
+ * its install-time `LOCATION` param. That variable is absent outside a
+ * deployed function (emulator runs, library consumers), so fall back rather
+ * than leaving the SDK to pick a region or failing the call.
+ */
+const DEFAULT_VERTEX_LOCATION = "us-central1";
+
 export class GenkitEmbedClient extends BaseEmbedClient {
   private readonly client: Genkit;
   private readonly embedder: EmbedderReference;
@@ -38,7 +48,7 @@ export class GenkitEmbedClient extends BaseEmbedClient {
     this.client = genkit({
       plugins: [
         isVertex
-          ? vertexAI(config.region ? { location: config.region } : {})
+          ? vertexAI({ location: config.region || DEFAULT_VERTEX_LOCATION })
           : googleAI({ apiKey: config.geminiApiKey }),
       ],
     });

--- a/kits/firestore-vector-search/tests/embeddings.test.ts
+++ b/kits/firestore-vector-search/tests/embeddings.test.ts
@@ -70,12 +70,12 @@ describe("GenkitEmbedClient", () => {
       expect(genkit).toHaveBeenCalledWith({ plugins: [undefined] });
     });
 
-    test("omits the location when no region is configured", () => {
+    test("falls back to the default location when no region is configured", () => {
       new GenkitEmbedClient(
         config({ embeddingProvider: "vertex", region: undefined })
       );
 
-      expect(vertexAI).toHaveBeenCalledWith({});
+      expect(vertexAI).toHaveBeenCalledWith({ location: "us-central1" });
     });
 
     test("initializes with the Google AI provider", () => {

--- a/kits/storage-resize-images/src/content-filter.ts
+++ b/kits/storage-resize-images/src/content-filter.ts
@@ -21,6 +21,16 @@ import type { SafetyThreshold } from "./export-config";
 import { GLOBAL_RETRY_QUEUE } from "./global";
 import * as log from "./logs";
 
+/**
+ * Region used for Vertex AI when the function's own region is unavailable.
+ *
+ * Kits read their region from `FUNCTION_REGION`, which the extension got from
+ * its install-time `LOCATION` param. That variable is absent outside a
+ * deployed function (emulator runs, library consumers), so fall back rather
+ * than leaving the SDK to pick a region or failing the call.
+ */
+const DEFAULT_VERTEX_LOCATION = "us-central1";
+
 const HARM_CATEGORIES = [
   "HARM_CATEGORY_HATE_SPEECH",
   "HARM_CATEGORY_DANGEROUS_CONTENT",
@@ -78,16 +88,13 @@ export async function checkImageContent(
   if (filterLevel === null && prompt === null) {
     return true;
   }
-  if (!location) {
-    throw new Error("FUNCTION_REGION is required for Vertex AI filtering.");
-  }
 
   const imageBuffer = fs.readFileSync(localOriginalFile);
   const dataUrl = createImageDataUrl(imageBuffer, contentType);
   const ai = genkit({
     plugins: [
       vertexAI({
-        location,
+        location: location || DEFAULT_VERTEX_LOCATION,
         models: ["gemini-2.5-flash"],
       }),
     ],

--- a/kits/storage-resize-images/tests/content-filter.test.ts
+++ b/kits/storage-resize-images/tests/content-filter.test.ts
@@ -49,6 +49,7 @@ vi.mock("../src/logs", () => ({
   retryScheduled: vi.fn(),
 }));
 
+import vertexAI from "@genkit-ai/vertexai";
 import { checkImageContent } from "../src/content-filter";
 import * as log from "../src/logs";
 
@@ -77,11 +78,24 @@ describe("checkImageContent with mocks", () => {
     expect(result).toBe(true);
   });
 
-  it("should throw when no region is available", async () => {
-    // The extension falls back to "us-central1"; the kit refuses to guess.
-    await expect(
-      checkImageContent(imagePath, "BLOCK_ONLY_HIGH", null, "image/png")
-    ).rejects.toThrow("FUNCTION_REGION is required for Vertex AI filtering.");
+  it("should fall back to the default region when none is available", async () => {
+    // Matches the extension, which read `process.env.LOCATION ?? "us-central1"`.
+    const mockGenerate = vi
+      .fn()
+      .mockResolvedValue({ output: { response: "no" } });
+    genkitMock.mockImplementation(() => ({ generate: mockGenerate }));
+
+    const result = await checkImageContent(
+      imagePath,
+      "BLOCK_ONLY_HIGH",
+      null,
+      "image/png"
+    );
+
+    expect(vertexAI).toHaveBeenCalledWith(
+      expect.objectContaining({ location: "us-central1" })
+    );
+    expect(result).toBe(true);
   });
 
   it("should return true when the API response is positive", async () => {


### PR DESCRIPTION
## Checklist items covered

From #2974's *Remaining parity work*:

- Cross-kit: AI-provider location fallback — `firestore-genai-chatbot` `VERTEX_AI_MODEL_LOCATION=null` no longer meaning "function region" (§3), `firestore-translate-text` vertex region (§2), `firestore-vector-search` same class (§5)
- `storage-resize-images`: content-filter region reads `FUNCTION_REGION` and throws when absent; the extension fell back to `us-central1` (§5)

## Summary

- Removing the `LOCATION` param left each kit to substitute `process.env.FUNCTION_REGION` independently, with four different fallbacks. All four now apply one rule: **use the function's own region, fall back to `us-central1`, never throw and never leave the SDK to choose.**
- `firestore-genai-chatbot`: the `VERTEX_AI_MODEL_LOCATION` option labelled "Same as Cloud Functions Location" resolved to `undefined`, so it no longer meant the function's region at all. It now resolves to `FUNCTION_REGION`, matching the extension's resolution to the install `LOCATION`.
- `firestore-translate-text` / `firestore-vector-search`: passed `{}` to the Vertex Genkit plugin when the region was unset, leaving it to pick a location implicitly. Both now pass an explicit location.
- `storage-resize-images`: `checkImageContent` threw `"FUNCTION_REGION is required for Vertex AI filtering."`; the extension read `process.env.LOCATION ?? "us-central1"` and carried on. The throw is removed in favour of the same fallback.
- The fallback only engages outside a deployed function — emulator runs and library consumers — where `FUNCTION_REGION` is absent.
- Uses a truthy check rather than `??`, preserving the previous treatment of an empty `FUNCTION_REGION` as "no region"; `??` would have passed `""` through to the SDK.
- Three tests asserted the old behaviour (two "omits the location", one "should throw when no region is available") and now assert the fallback.

## Testing

- `tsc --noEmit` clean across the four affected kits.
- Full suites pass: `firestore-genai-chatbot` 47, `firestore-translate-text` 89, `firestore-vector-search` 49, `storage-resize-images` 178.
- Deploy and smoke testing against the `corie-testing` project to follow in a later commit on this branch.
