### PR TITLE
fix(firestore-vector-search): stop re-embedding documents in a final state

### DIFF
--- a/kits/firestore-vector-search/src/handlers.ts
+++ b/kits/firestore-vector-search/src/handlers.ts
@@ -69,6 +69,30 @@ function vectorStore(ctx: HandlerContext) {
   );
 }
 
+/**
+ * States the extension treated as final. Its processor skipped any document
+ * already carrying one of these, so a document was embedded at most once --
+ * editing the input afterwards, or writing to a document that had failed, did
+ * not trigger another embedding.
+ */
+const TERMINAL_STATES = new Set([
+  "PROCESSING",
+  "COMPLETED",
+  "ERROR",
+  "BACKFILLED",
+]);
+
+/** Reads the document's embedding state, if it has been embedded before. */
+function embeddingState(
+  data: Record<string, unknown>,
+  statusFieldName: string
+): string | undefined {
+  const status = data[statusFieldName];
+  if (typeof status !== "object" || status === null) return undefined;
+  const state = (status as { state?: unknown }).state;
+  return typeof state === "string" ? state : undefined;
+}
+
 export async function handleEmbedOnWrite(
   event: VectorWriteEvent,
   ctx: HandlerContext
@@ -84,6 +108,12 @@ export async function handleEmbedOnWrite(
     ? event.data.before.get(ctx.config.inputFieldName)
     : undefined;
   if (beforeInput === input && data[ctx.config.outputFieldName]) return;
+
+  // Parity with the extension: a document that already reached a final state
+  // is never embedded again, even if its input changed or the previous attempt
+  // errored.
+  const state = embeddingState(data, ctx.config.statusFieldName);
+  if (state !== undefined && TERMINAL_STATES.has(state)) return;
 
   try {
     const embedding = await embedClient(ctx).getSingleEmbedding(input);

--- a/kits/firestore-vector-search/tests/handlers.test.ts
+++ b/kits/firestore-vector-search/tests/handlers.test.ts
@@ -36,7 +36,12 @@ vi.mock("../src/embeddings", () => ({
 // handler never needs it.
 vi.mock("../src/queries/setup", () => ({ createIndex: vi.fn() }));
 
-import { type HandlerContext, handleQueryCall } from "../src/handlers";
+import {
+  type HandlerContext,
+  type VectorWriteEvent,
+  handleEmbedOnWrite,
+  handleQueryCall,
+} from "../src/handlers";
 import { resolveVectorSearchConfig } from "../src/export-config";
 
 const config = resolveVectorSearchConfig({
@@ -203,5 +208,60 @@ describe("handleQueryCall", () => {
 
     expect((err as { code: string }).code).toBe("unknown");
     expect((err as Error).message).toBe("Query failed");
+  });
+});
+
+describe("handleEmbedOnWrite terminal states", () => {
+  /** A write event whose after-snapshot carries `data`. */
+  function writeEvent(
+    data: Record<string, unknown>,
+    before?: Record<string, unknown>
+  ) {
+    const set = vi.fn().mockResolvedValue(undefined);
+    const event = {
+      params: {},
+      data: {
+        before: before
+          ? { exists: true, get: (f: string) => before[f], data: () => before }
+          : { exists: false, get: () => undefined },
+        after: {
+          exists: true,
+          data: () => data,
+          ref: { path: "products/doc-1", set },
+        },
+      },
+    } as unknown as VectorWriteEvent;
+    return { event, set };
+  }
+
+  const ctx = () => ({ firestore: {}, config } as unknown as HandlerContext);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSingleEmbedding.mockResolvedValue(EMBEDDING);
+  });
+
+  test.each(["PROCESSING", "COMPLETED", "ERROR", "BACKFILLED"])(
+    "skips a document already in the %s state",
+    async (state) => {
+      const { event, set } = writeEvent({
+        input: "changed text",
+        status: { state },
+      });
+
+      await handleEmbedOnWrite(event, ctx());
+
+      expect(getSingleEmbedding).not.toHaveBeenCalled();
+      expect(set).not.toHaveBeenCalled();
+    }
+  );
+
+  test("embeds a document that has no prior state", async () => {
+    const { event, set } = writeEvent({ input: "new text" });
+
+    await handleEmbedOnWrite(event, ctx());
+
+    expect(getSingleEmbedding).toHaveBeenCalledWith("new text");
+    expect(set).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Checklist items covered

From #2974's *Remaining parity work*:

- `firestore-vector-search`: re-embed-on-update flipped (the extension never re-embeds terminal docs) + ERROR-retry flipped (§6a/6b) — **fixed here**

Related items in the same cluster, deliberately **not** in this PR:

- `queryOnWrite` self-retrigger loop (§7) — already open as #3038
- Status field shape change (§6) and backfill metadata-doc gate (§9d) — both need the status-shape decision first (see below)

## Summary

- The extension ran embeddings through a processor that skipped any document already in `PROCESSING`, `COMPLETED`, `ERROR`, or `BACKFILLED`. A document was embedded **at most once**: editing the input afterwards did nothing, and a document that had errored was never retried.
- The kit only skipped when the input was unchanged *and* an embedding already existed. So it re-embedded on every input edit, and retried failed documents on every subsequent write — extra embedding API calls and cost against the same document.
- Adds the terminal-state guard on the `onWrite` path, reading the state the kit already writes to the status field. No new state is written and the status shape is untouched.
- Five new tests: one per terminal state asserting no embedding call and no write, plus one asserting a document with no prior state still embeds.

### Why the rest of the cluster is separate

The extension nested status per instance with timestamps (`status.<instanceId>.state`, with `startTime`/`updateTime`/`completeTime`), and its backfill gated on a metadata document at `_<instanceId>/index`. The kit writes a flat `{ state }`. Restoring the nested shape changes a consumer-visible contract for anyone already reading kit status documents, so it wants an explicit decision rather than being folded into this fix. The guard added here works with either shape.

## Testing

- `tsc --noEmit` clean; full suite passes 54/54 (49 existing + 5 new).
- Deploy and smoke testing against `corie-testing` to follow in a later commit on this branch.
