### PR TITLE
chore(firestore-bigquery-export): bump the change tracker to 2.1.0

### DIFF
--- a/kits/firestore-bigquery-export/npm-shrinkwrap.json
+++ b/kits/firestore-bigquery-export/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
       "version": "0.0.2-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@firebaseextensions/firestore-bigquery-change-tracker": "^2.0.4",
+        "@firebaseextensions/firestore-bigquery-change-tracker": "^2.1.0",
         "@google-cloud/bigquery": "^7.6.0",
         "firebase-admin": "^13.6.0",
         "firebase-functions": "^7.3.2",
@@ -590,9 +590,9 @@
       }
     },
     "node_modules/@firebaseextensions/firestore-bigquery-change-tracker": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@firebaseextensions/firestore-bigquery-change-tracker/-/firestore-bigquery-change-tracker-2.0.4.tgz",
-      "integrity": "sha512-62iCf9hCzav8j4HxOPg94fVTDjO00CaoWQcQduq2+I2YNhPgRASXQCPcvJM/NuSdYqq/FUW/zbwtItn0K8Q4og==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@firebaseextensions/firestore-bigquery-change-tracker/-/firestore-bigquery-change-tracker-2.1.0.tgz",
+      "integrity": "sha512-gb4o9yFH5RnaH10n0SY97MXJFrfwG8Q7u8jPlgVduzq7nJfCeD4TsHGMYv+lwKqsfog8UUdRzns/aFEJo0w/fQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/bigquery": "^7.6.0",

--- a/kits/firestore-bigquery-export/package.json
+++ b/kits/firestore-bigquery-export/package.json
@@ -31,7 +31,7 @@
     "serve": "firebase emulators:start --only functions"
   },
   "dependencies": {
-    "@firebaseextensions/firestore-bigquery-change-tracker": "^2.0.4",
+    "@firebaseextensions/firestore-bigquery-change-tracker": "^2.1.0",
     "@google-cloud/bigquery": "^7.6.0",
     "firebase-admin": "^13.6.0",
     "firebase-functions": "^7.3.2",


### PR DESCRIPTION
Bumps @firebaseextensions/firestore-bigquery-change-tracker from ^2.0.4 to ^2.1.0 (shrinkwrap regenerated via npm, locks 2.1.0 exactly).

What 2.1.0 changes for operators of this kit: insert failures that the broken 2.0.4 retry guard silently converted into successes (dropping unrecognised fields) now fail terminally - rows land intact in BACKUP_COLLECTION and the error is rethrown to the trigger's retry policy. Schema-lag windows retry by stripping only the tracker's own columns, logged at warn. The backup path no longer breaks after the first failure per instance, and backup documents carry error_details. The spurious every-cold-start table update is fixed, and clustering changes on existing tables now actually apply. Full details in the tracker CHANGELOG.

Kit suite passes against the published 2.1.0 (45/45), tsc clean. Not verified against live BigQuery from this kit; the tracker's own fixes were live-tested extensively before publish.