### PR TITLE
fix(release-kit): prune dev entries from the published shrinkwrap

### DIFF
--- a/.github/workflows/release-kit.yaml
+++ b/.github/workflows/release-kit.yaml
@@ -318,6 +318,32 @@ jobs:
           echo "$NOTES"
           echo "=========================================================="
 
+      # npm expands a dependency's npm-shrinkwrap.json verbatim into the
+      # consumer's install, so dev-only entries (the esbuild platform binaries
+      # among them) fail consumer `npm ci` under npm 10 with EBADPLATFORM -
+      # which is what the Cloud Functions buildpack runs. The committed
+      # shrinkwrap keeps its dev pins for local `npm ci`; only the published
+      # copy is pruned, keeping the exact prod versions the tests ran against.
+      # Runs after Commit & Tag so the release commit stays unpruned.
+      - name: Prune dev entries from the published package
+        working-directory: ${{ inputs.target_kit }}
+        run: |
+          node - <<'EOF'
+          const fs = require("fs");
+          const lock = JSON.parse(fs.readFileSync("npm-shrinkwrap.json", "utf8"));
+          for (const [path, entry] of Object.entries(lock.packages)) {
+            if (entry.dev) delete lock.packages[path];
+          }
+          delete lock.packages[""].devDependencies;
+          fs.writeFileSync("npm-shrinkwrap.json", JSON.stringify(lock, null, 2) + "\n");
+          const remaining = Object.values(lock.packages).filter((p) => p.dev).length;
+          if (remaining > 0) {
+            throw new Error(`${remaining} dev entries survived the prune`);
+          }
+          console.log(`Pruned shrinkwrap to ${Object.keys(lock.packages).length} entries`);
+          EOF
+          npm pkg delete devDependencies
+
       - name: Publish to NPM
         working-directory: ${{ inputs.target_kit }}
         env:

--- a/.github/workflows/release-kit.yaml
+++ b/.github/workflows/release-kit.yaml
@@ -330,17 +330,24 @@ jobs:
         run: |
           node - <<'EOF'
           const fs = require("fs");
+          if (!fs.existsSync("npm-shrinkwrap.json")) {
+            console.log("No npm-shrinkwrap.json; nothing to prune.");
+            process.exit(0);
+          }
           const lock = JSON.parse(fs.readFileSync("npm-shrinkwrap.json", "utf8"));
           for (const [path, entry] of Object.entries(lock.packages)) {
             if (entry.dev) delete lock.packages[path];
           }
           delete lock.packages[""].devDependencies;
           fs.writeFileSync("npm-shrinkwrap.json", JSON.stringify(lock, null, 2) + "\n");
-          const remaining = Object.values(lock.packages).filter((p) => p.dev).length;
-          if (remaining > 0) {
-            throw new Error(`${remaining} dev entries survived the prune`);
+          const written = JSON.parse(fs.readFileSync("npm-shrinkwrap.json", "utf8"));
+          const leftovers = Object.keys(written.packages).filter(
+            (path) => written.packages[path].dev || path.includes("node_modules/@esbuild/")
+          );
+          if (leftovers.length > 0) {
+            throw new Error(`dev entries survived the prune: ${leftovers.join(", ")}`);
           }
-          console.log(`Pruned shrinkwrap to ${Object.keys(lock.packages).length} entries`);
+          console.log(`Pruned shrinkwrap to ${Object.keys(written.packages).length} entries`);
           EOF
           npm pkg delete devDependencies
 


### PR DESCRIPTION
The published kit tarballs ship the committed npm-shrinkwrap.json verbatim, and that file locks the kit's devDependencies - vite, esbuild, and all 26 @esbuild/* platform binaries. npm expands a dependency's shrinkwrap into the consumer's install, and the Cloud Functions buildpack (npm 10) then fails every function build with EBADPLATFORM ("Unsupported platform for @esbuild/aix-ppc64"). npm 11 tolerates the entries, which is why local installs and our own testing never hit it. Found by a live E2E install of firestore-bigquery-export@0.0.2-rc.3 on a fresh project; retry does not help and patching the consumer lockfile does not either, since npm ci re-expands the dependency shrinkwrap.

The fix adds a publish-time step that deletes every dev-flagged entry from the shrinkwrap and drops devDependencies from package.json, after the release commit is created, so the committed shrinkwrap keeps its dev pins for local npm ci and the published copy keeps the exact prod versions the tests ran against. Verified locally: npm@10 install of the published rc.3 reproduces EBADPLATFORM; the same install against a tarball packed from the pruned tree completes cleanly with zero esbuild entries and change-tracker 2.1.0 resolved.

Not verified live: an actual workflow run (needs a dispatch); the dry-run path exercises the new step identically. Applies to all kits; firestore-bigquery-export needs an rc.4 once this lands.