### PR TITLE
fix(bigquery-firestore-export): stop retrying the two failures the extension treated as terminal

### DIFF
--- a/kits/bigquery-firestore-export/src/handlers.ts
+++ b/kits/bigquery-firestore-export/src/handlers.ts
@@ -23,6 +23,7 @@ import {
   createTransferConfig,
   type DataTransferClient,
   getTransferConfig,
+  PARTITIONING_FIELD_REMOVAL_ERROR_PREFIX,
   updateTransferConfig,
 } from "./dts";
 import type { ResolvedBigqueryFirestoreExportConfig } from "./export-config";
@@ -62,6 +63,13 @@ async function ensureNotificationTopic(ctx: HandlerContext): Promise<void> {
       throw err;
     }
   }
+}
+
+function isPartitioningFieldRemovalError(err: unknown): err is Error {
+  return (
+    err instanceof Error &&
+    err.message.includes(PARTITIONING_FIELD_REMOVAL_ERROR_PREFIX)
+  );
 }
 
 async function storeTransferConfig(
@@ -105,9 +113,10 @@ export async function handleUpsertTransferConfig(
       ctx.config.transferConfigName
     );
     if (!linked) {
-      throw new Error(
-        `Transfer config not found: ${ctx.config.transferConfigName}`
-      );
+      // Only a redeploy with a corrected TRANSFER_CONFIG_NAME can resolve this,
+      // so retrying the task cannot help.
+      logs.linkedTransferConfigMissing(ctx.config.transferConfigName);
+      return;
     }
     await storeTransferConfig(ctx, linked);
     return;
@@ -128,14 +137,21 @@ export async function handleUpsertTransferConfig(
   const transferConfigName = existing.docs[0].data().name;
   if (typeof transferConfigName !== "string" || !transferConfigName) {
     throw new Error(
-      `Existing transfer config document in ${ctx.config.firestoreCollection} is missing required 'name' field.`
+      `Existing transfer config document in ${ctx.config.firestoreCollection} is missing required 'name' field. Delete the document so a new scheduled query is created, then redeploy.`
     );
   }
 
-  const updated = await updateTransferConfig(
-    ctx.dataTransfer,
-    transferConfigName,
-    ctx.config
-  );
-  await storeTransferConfig(ctx, updated);
+  try {
+    const updated = await updateTransferConfig(
+      ctx.dataTransfer,
+      transferConfigName,
+      ctx.config
+    );
+    await storeTransferConfig(ctx, updated);
+  } catch (err) {
+    if (!isPartitioningFieldRemovalError(err)) throw err;
+    // The guard rejects the update while building the request, so nothing was
+    // sent, and no retry can clear a partitioning field once it is set.
+    logs.partitioningFieldRemovalAborted(err.message);
+  }
 }

--- a/kits/bigquery-firestore-export/src/handlers.ts
+++ b/kits/bigquery-firestore-export/src/handlers.ts
@@ -151,7 +151,7 @@ export async function handleUpsertTransferConfig(
   } catch (err) {
     if (!isPartitioningFieldRemovalError(err)) throw err;
     // The guard rejects the update while building the request, so nothing was
-    // sent, and no retry can clear a partitioning field once it is set.
+    // sent and a retry hits the same guard.
     logs.partitioningFieldRemovalAborted(err.message);
   }
 }

--- a/kits/bigquery-firestore-export/src/logs.ts
+++ b/kits/bigquery-firestore-export/src/logs.ts
@@ -140,6 +140,19 @@ export function partitioningFieldRemovalAttempted(
   });
 }
 
+export function linkedTransferConfigMissing(name: string): void {
+  logger.error(
+    "The scheduled query named by TRANSFER_CONFIG_NAME does not exist, so nothing was linked. Set it to a scheduled query that exists in this project and redeploy, or clear it to have this deployment create its own.",
+    { name }
+  );
+}
+
+// The reason carries the remediation, and an Error passed as structured data
+// serialises to {}, so it goes in the message.
+export function partitioningFieldRemovalAborted(reason: string): void {
+  logger.error(`Stopped without updating the scheduled query. ${reason}`);
+}
+
 export function topicCreated(name: string): void {
   logger.info("Created Pub/Sub topic for transfer notifications", { name });
 }

--- a/kits/bigquery-firestore-export/tests/handlers.test.ts
+++ b/kits/bigquery-firestore-export/tests/handlers.test.ts
@@ -23,12 +23,16 @@ const mocks = vi.hoisted(() => ({
   getTransferConfig: vi.fn(),
   updateTransferConfig: vi.fn(),
   handleTransferRunMessage: vi.fn(),
+  linkedTransferConfigMissing: vi.fn(),
+  partitioningFieldRemovalAborted: vi.fn(),
 }));
 
 vi.mock("../src/dts", () => ({
   createTransferConfig: mocks.createTransferConfig,
   getTransferConfig: mocks.getTransferConfig,
   updateTransferConfig: mocks.updateTransferConfig,
+  PARTITIONING_FIELD_REMOVAL_ERROR_PREFIX:
+    "Cannot remove partitioning_field from an existing transfer config",
 }));
 
 vi.mock("../src/helper", () => ({
@@ -41,6 +45,8 @@ vi.mock("../src/helper", () => ({
 vi.mock("../src/logs", () => ({
   complete: vi.fn(),
   error: vi.fn(),
+  linkedTransferConfigMissing: mocks.linkedTransferConfigMissing,
+  partitioningFieldRemovalAborted: mocks.partitioningFieldRemovalAborted,
   start: vi.fn(),
   topicCreated: vi.fn(),
 }));
@@ -166,5 +172,73 @@ describe("handleUpsertTransferConfig", () => {
       extInstanceId: "users-export",
       ...linked,
     });
+  });
+
+  test("reports a missing linked transfer config without retrying", async () => {
+    mocks.getTransferConfig.mockResolvedValue(null);
+    const { ctx, set } = makeContext({
+      transferConfigName: "projects/p/locations/us/transferConfigs/gone",
+    });
+
+    await expect(handleUpsertTransferConfig(ctx)).resolves.toBeUndefined();
+
+    expect(mocks.linkedTransferConfigMissing).toHaveBeenCalledWith(
+      "projects/p/locations/us/transferConfigs/gone"
+    );
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  test("reports a rejected partitioning-field removal without retrying", async () => {
+    mocks.updateTransferConfig.mockRejectedValue(
+      new Error(
+        "Cannot remove partitioning_field from an existing transfer config. The BigQuery Data Transfer API does not support clearing this parameter once it has been set."
+      )
+    );
+    const { ctx, set } = makeContext({
+      existing: {
+        empty: false,
+        docs: [
+          {
+            data: () => ({
+              name: "projects/p/locations/us/transferConfigs/config-1",
+            }),
+          },
+        ],
+      },
+    });
+
+    await expect(handleUpsertTransferConfig(ctx)).resolves.toBeUndefined();
+
+    expect(mocks.partitioningFieldRemovalAborted).toHaveBeenCalledWith(
+      expect.stringContaining("Cannot remove partitioning_field")
+    );
+    expect(set).not.toHaveBeenCalled();
+  });
+
+  test("rethrows any other update failure so the task retries", async () => {
+    mocks.updateTransferConfig.mockRejectedValue(
+      new Error(
+        "bigquerydatatransfer.googleapis.com is temporarily unavailable"
+      )
+    );
+    const { ctx, set } = makeContext({
+      existing: {
+        empty: false,
+        docs: [
+          {
+            data: () => ({
+              name: "projects/p/locations/us/transferConfigs/config-1",
+            }),
+          },
+        ],
+      },
+    });
+
+    await expect(handleUpsertTransferConfig(ctx)).rejects.toThrow(
+      "temporarily unavailable"
+    );
+
+    expect(mocks.partitioningFieldRemovalAborted).not.toHaveBeenCalled();
+    expect(set).not.toHaveBeenCalled();
   });
 });

--- a/kits/bigquery-firestore-export/tests/handlers.test.ts
+++ b/kits/bigquery-firestore-export/tests/handlers.test.ts
@@ -27,13 +27,19 @@ const mocks = vi.hoisted(() => ({
   partitioningFieldRemovalAborted: vi.fn(),
 }));
 
-vi.mock("../src/dts", () => ({
-  createTransferConfig: mocks.createTransferConfig,
-  getTransferConfig: mocks.getTransferConfig,
-  updateTransferConfig: mocks.updateTransferConfig,
-  PARTITIONING_FIELD_REMOVAL_ERROR_PREFIX:
-    "Cannot remove partitioning_field from an existing transfer config",
-}));
+// The error constants come from the real module so the handler's prefix match
+// is tested against the message the guard actually throws.
+vi.mock("../src/dts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/dts")>();
+  return {
+    createTransferConfig: mocks.createTransferConfig,
+    getTransferConfig: mocks.getTransferConfig,
+    updateTransferConfig: mocks.updateTransferConfig,
+    PARTITIONING_FIELD_REMOVAL_ERROR: actual.PARTITIONING_FIELD_REMOVAL_ERROR,
+    PARTITIONING_FIELD_REMOVAL_ERROR_PREFIX:
+      actual.PARTITIONING_FIELD_REMOVAL_ERROR_PREFIX,
+  };
+});
 
 vi.mock("../src/helper", () => ({
   handleTransferRunMessage: mocks.handleTransferRunMessage,
@@ -51,6 +57,7 @@ vi.mock("../src/logs", () => ({
   topicCreated: vi.fn(),
 }));
 
+import { PARTITIONING_FIELD_REMOVAL_ERROR } from "../src/dts";
 import { handleUpsertTransferConfig } from "../src/handlers";
 
 const config = resolveConfig({
@@ -190,9 +197,7 @@ describe("handleUpsertTransferConfig", () => {
 
   test("reports a rejected partitioning-field removal without retrying", async () => {
     mocks.updateTransferConfig.mockRejectedValue(
-      new Error(
-        "Cannot remove partitioning_field from an existing transfer config. The BigQuery Data Transfer API does not support clearing this parameter once it has been set."
-      )
+      new Error(PARTITIONING_FIELD_REMOVAL_ERROR)
     );
     const { ctx, set } = makeContext({
       existing: {
@@ -210,7 +215,7 @@ describe("handleUpsertTransferConfig", () => {
     await expect(handleUpsertTransferConfig(ctx)).resolves.toBeUndefined();
 
     expect(mocks.partitioningFieldRemovalAborted).toHaveBeenCalledWith(
-      expect.stringContaining("Cannot remove partitioning_field")
+      PARTITIONING_FIELD_REMOVAL_ERROR
     );
     expect(set).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
### What was broken

`upsertTransferConfig` throws on two failures the extension deliberately did not fail on, so Cloud Tasks retries them five times and then dead-letters:

- `TRANSFER_CONFIG_NAME` names a scheduled query that does not exist.
- An update tries to clear `PARTITIONING_FIELD` and the guard rejects it.

The extension called `setProcessingState('PROCESSING_COMPLETE')` and returned on both. That logic lived in its `index.ts` and was dropped in the port; `dts.ts` itself is a faithful port and is unchanged here.

### What changed

Both paths log at error level and return. Every other reachable failure still throws and still retries, matching the extension: a stored document missing `name`, the structure guards, and a stored scheduled query that has since been deleted all retry there too.

The extension has a third non-throwing termination, when the re-read after a successful update comes back empty. The kit stores the update response instead of re-reading it, so that path does not exist here.

Kits have no status channel, so the console message the extension showed becomes a Cloud Logging line, and it now carries the remediation.

### How it was verified

68 unit tests and a clean `tsc -b`. The two new behaviour tests fail against the unfixed handler and pass with it; the third pins the case that must keep retrying, so it passes either way.

The handler matches the guard's error on a message prefix, so the test resolves both constants from `dts` through `importOriginal` rather than copying them. Confirmed by mutation: breaking the prefix relationship in `dts.ts` fails the partitioning test, where copies left the suite green.

Not exercised against a live project.

### Notes

`retryConfig: { maxAttempts: 5, minBackoffSeconds: 30 }` stays as-is. `taskQueueTrigger: {}` gives the extension the queue defaults, which would mean a 0.1s minimum backoff, too short to ride out a Data Transfer blip. That divergence is deliberate.

The partitioning swallow matches the extension today, but #2985 argues the guard itself is wrong. If that lands, this goes with it.

Supersedes #2983, which classified four more paths as permanent. Three of those retry in the extension, so they are out of scope while parity is the goal.
