### PR TITLE
fix(firestore-send-email): keep SMTP_PASSWORD available so SendGrid works with AUTH_TYPE=OAuth2

### DIFF
--- a/kits/firestore-send-email/CHANGELOG.md
+++ b/kits/firestore-send-email/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Initial release of kit, see README for differences between the legacy extension and this kit
+- SendGrid sends now work with `AUTH_TYPE=OAuth2`: the `SMTP_PASSWORD` secret is no longer dropped from the config under OAuth2, so the SendGrid transport receives its API key

--- a/kits/firestore-send-email/CHANGELOG.md
+++ b/kits/firestore-send-email/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Initial release of kit, see README for differences between the legacy extension and this kit
 - SendGrid sends now work with `AUTH_TYPE=OAuth2`: the `SMTP_PASSWORD` secret is no longer dropped from the config under OAuth2, so the SendGrid transport receives its API key
+- SendGrid delivery no longer fails with `sgMail.setApiKey is not a function`: the transport imports `@sendgrid/mail` in a form that survives the compiled output

--- a/kits/firestore-send-email/README.md
+++ b/kits/firestore-send-email/README.md
@@ -154,7 +154,10 @@ picked up. All four are attached to the function whatever `AUTH_TYPE` is set to,
 and were optional in the extension. If a secret does not exist, `firebase deploy`
 prompts you for a value, and fails outright when running non-interactively (CI).
 On username/password auth create the three OAuth2 secrets with a placeholder
-value, and on OAuth2 auth do the same for `SMTP_PASSWORD`.
+value. On OAuth2 auth do the same for `SMTP_PASSWORD`, unless you send through
+SendGrid: the SendGrid transport reads `SMTP_PASSWORD` as its API key whatever
+`AUTH_TYPE` is set to, so a connection URI pointing at `smtp.sendgrid.net` needs
+your real API key there and a placeholder fails every send with a 401.
 
 ### DATABASE_REGION now decides where the function runs
 

--- a/kits/firestore-send-email/src/config.ts
+++ b/kits/firestore-send-email/src/config.ts
@@ -311,7 +311,14 @@ export const secretParams = [
 export function secretParamsForAuthType(authType?: string) {
   switch (authType || AuthenticatonType.UsernamePassword) {
     case AuthenticatonType.OAuth2:
-      return [params.clientId, params.clientSecret, params.refreshToken];
+      // The SendGrid transport reads SMTP_PASSWORD as its API key regardless
+      // of auth type, so it must stay bound under OAuth2.
+      return [
+        params.smtpPassword,
+        params.clientId,
+        params.clientSecret,
+        params.refreshToken,
+      ];
     case AuthenticatonType.UsernamePassword:
     case AuthenticatonType.ApiKey:
       return [params.smtpPassword];
@@ -336,10 +343,9 @@ export function configFromEnv(): SendEmailConfig {
     databaseRegion: params.databaseRegion.value(),
     mailCollection: params.mailCollection.value(),
     smtpConnectionUri: params.smtpConnectionUri.value(),
-    smtpPassword:
-      authType === AuthenticatonType.OAuth2
-        ? undefined
-        : optionalSecret(params.smtpPassword),
+    // Not gated on auth type: the SendGrid transport reads it as its API key
+    // even when AUTH_TYPE is OAuth2.
+    smtpPassword: optionalSecret(params.smtpPassword),
     defaultFrom: params.defaultFrom.value(),
     defaultReplyTo: params.defaultReplyTo.value(),
     usersCollection: params.usersCollection.value(),

--- a/kits/firestore-send-email/src/nodemailer-sendgrid/index.ts
+++ b/kits/firestore-send-email/src/nodemailer-sendgrid/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import * as sgMail from "@sendgrid/mail";
+import sgMail from "@sendgrid/mail";
 import type {
   Address,
   MailSource,

--- a/kits/firestore-send-email/tests/build-interop.test.ts
+++ b/kits/firestore-send-email/tests/build-interop.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createRequire } from "node:module";
+import { describe, expect, test } from "vitest";
+
+// The subject is the compiled output, not src: only tsc's esModuleInterop
+// helper drops the prototype methods off the instance @sendgrid/mail exports,
+// and vitest's own transform does not reproduce that. Needs `npm run build`,
+// which CI runs before `npm test`.
+const requireBuilt = createRequire(import.meta.url);
+
+describe("built SendGridTransport", () => {
+  test("reaches the methods on the @sendgrid/mail instance", () => {
+    const { SendGridTransport } = requireBuilt("../lib/nodemailer-sendgrid");
+    expect(() => new SendGridTransport({ apiKey: "SG.test" })).not.toThrow();
+  });
+});

--- a/kits/firestore-send-email/tests/config.test.ts
+++ b/kits/firestore-send-email/tests/config.test.ts
@@ -26,10 +26,15 @@ const { stringParamOpts } = vi.hoisted(() => ({
 }));
 
 vi.mock("firebase-functions/params", () => ({
+  // Only stubbed names may read the env: ambient shell vars (USER, HOST)
+  // collide with real param names and would make results machine-dependent.
   defineString: (name: string, opts?: StringParamOpts) => {
     stringParamOpts.set(name, opts);
     return {
-      value: () => process.env[name] ?? opts?.default ?? "",
+      value: () =>
+        (name === "AUTH_TYPE" ? process.env[name] : undefined) ??
+        opts?.default ??
+        "",
     };
   },
   defineInt: (_name: string, opts?: { default?: number }) => ({

--- a/kits/firestore-send-email/tests/config.test.ts
+++ b/kits/firestore-send-email/tests/config.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 interface StringParamOpts {
   default?: string;
@@ -29,7 +29,7 @@ vi.mock("firebase-functions/params", () => ({
   defineString: (name: string, opts?: StringParamOpts) => {
     stringParamOpts.set(name, opts);
     return {
-      value: () => opts?.default ?? "",
+      value: () => process.env[name] ?? opts?.default ?? "",
     };
   },
   defineInt: (_name: string, opts?: { default?: number }) => ({
@@ -60,6 +60,10 @@ import { resolveConfig } from "../src/export-config";
 import { AuthenticatonType } from "../src/types";
 
 describe("configFromEnv", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   test("maps params and keeps secret-backed values deferred", () => {
     const config = configFromEnv();
     expect(config.mailCollection).toBe("mail");
@@ -67,6 +71,16 @@ describe("configFromEnv", () => {
     expect(config.defaultReplyTo).toBe("");
     expect(typeof config.smtpPassword).toBe("object");
     expect(config.clientId).toBeUndefined();
+  });
+
+  test("keeps the SMTP password for OAuth2 so SendGrid can use it as API key", () => {
+    vi.stubEnv("AUTH_TYPE", AuthenticatonType.OAuth2);
+    const config = configFromEnv();
+    expect(config.authType).toBe(AuthenticatonType.OAuth2);
+    expect(typeof config.smtpPassword).toBe("object");
+    expect(typeof config.clientId).toBe("object");
+    expect(typeof config.clientSecret).toBe("object");
+    expect(typeof config.refreshToken).toBe("object");
   });
 });
 
@@ -79,12 +93,12 @@ describe("secretParamsForAuthType", () => {
     ).toEqual(["SMTP_PASSWORD"]);
   });
 
-  test("binds only OAuth secrets for OAuth2 auth", () => {
+  test("keeps the SMTP password bound alongside OAuth secrets for OAuth2 auth", () => {
     expect(
       secretParamsForAuthType(AuthenticatonType.OAuth2).map(
         (secret) => (secret as { name: string }).name
       )
-    ).toEqual(["CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"]);
+    ).toEqual(["SMTP_PASSWORD", "CLIENT_ID", "CLIENT_SECRET", "REFRESH_TOKEN"]);
   });
 
   test("uses username/password secret binding by default", () => {

--- a/kits/firestore-send-email/tests/config.test.ts
+++ b/kits/firestore-send-email/tests/config.test.ts
@@ -21,20 +21,19 @@ interface StringParamOpts {
   input?: { text?: { validationRegex?: RegExp } };
 }
 
-const { stringParamOpts } = vi.hoisted(() => ({
+const { stringParamOpts, paramEnv } = vi.hoisted(() => ({
   stringParamOpts: new Map<string, StringParamOpts | undefined>(),
+  paramEnv: new Map<string, string>(),
 }));
 
 vi.mock("firebase-functions/params", () => ({
-  // Only stubbed names may read the env: ambient shell vars (USER, HOST)
-  // collide with real param names and would make results machine-dependent.
+  // Values come from paramEnv rather than process.env: AUTH_TYPE, USER and
+  // HOST are all real param names that collide with ambient shell vars, which
+  // would otherwise make results machine-dependent.
   defineString: (name: string, opts?: StringParamOpts) => {
     stringParamOpts.set(name, opts);
     return {
-      value: () =>
-        (name === "AUTH_TYPE" ? process.env[name] : undefined) ??
-        opts?.default ??
-        "",
+      value: () => paramEnv.get(name) ?? opts?.default ?? "",
     };
   },
   defineInt: (_name: string, opts?: { default?: number }) => ({
@@ -66,7 +65,7 @@ import { AuthenticatonType } from "../src/types";
 
 describe("configFromEnv", () => {
   afterEach(() => {
-    vi.unstubAllEnvs();
+    paramEnv.clear();
   });
 
   test("maps params and keeps secret-backed values deferred", () => {
@@ -79,7 +78,7 @@ describe("configFromEnv", () => {
   });
 
   test("keeps the SMTP password for OAuth2 so SendGrid can use it as API key", () => {
-    vi.stubEnv("AUTH_TYPE", AuthenticatonType.OAuth2);
+    paramEnv.set("AUTH_TYPE", AuthenticatonType.OAuth2);
     const config = configFromEnv();
     expect(config.authType).toBe(AuthenticatonType.OAuth2);
     expect(typeof config.smtpPassword).toBe("object");

--- a/kits/firestore-send-email/tests/helpers.test.ts
+++ b/kits/firestore-send-email/tests/helpers.test.ts
@@ -17,8 +17,15 @@
 import { logger } from "firebase-functions";
 import Mail from "nodemailer/lib/mailer";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@sendgrid/mail", () => ({
+  setApiKey: vi.fn(),
+  send: vi.fn(),
+}));
+
+import * as sgMail from "@sendgrid/mail";
 import type { ResolvedSendEmailConfig } from "../src/export-config";
-import { isSendGrid, setSmtpCredentials } from "../src/helpers";
+import { isSendGrid, setSmtpCredentials, transportLayer } from "../src/helpers";
 import { AuthenticatonType } from "../src/types";
 
 const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => undefined);
@@ -251,5 +258,20 @@ describe("isSendGrid", () => {
 
   test("returns false when no URI is configured", () => {
     expect(isSendGrid(makeConfig({}))).toBe(false);
+  });
+});
+
+describe("transportLayer", () => {
+  test("passes the SMTP password to SendGrid as the API key when AUTH_TYPE is OAuth2", async () => {
+    const transport = await transportLayer(
+      makeConfig({
+        smtpConnectionUri: "smtps://apikey@smtp.sendgrid.net:465",
+        smtpPassword: "SG.test-key",
+        authType: AuthenticatonType.OAuth2,
+      })
+    );
+
+    expect(vi.mocked(sgMail.setApiKey)).toHaveBeenCalledWith("SG.test-key");
+    expect(transport).toBeDefined();
   });
 });

--- a/kits/firestore-send-email/tests/helpers.test.ts
+++ b/kits/firestore-send-email/tests/helpers.test.ts
@@ -264,6 +264,10 @@ describe("isSendGrid", () => {
 });
 
 describe("transportLayer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   test("passes the SMTP password to SendGrid as the API key when AUTH_TYPE is OAuth2", async () => {
     const transport = await transportLayer(
       makeConfig({

--- a/kits/firestore-send-email/tests/helpers.test.ts
+++ b/kits/firestore-send-email/tests/helpers.test.ts
@@ -18,10 +18,12 @@ import { logger } from "firebase-functions";
 import Mail from "nodemailer/lib/mailer";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-vi.mock("@sendgrid/mail", () => ({
-  setApiKey: vi.fn(),
-  send: vi.fn(),
-}));
+// @sendgrid/mail exports a single MailService instance, so the mock has to be
+// reachable as both the default and the named exports.
+vi.mock("@sendgrid/mail", () => {
+  const mail = { setApiKey: vi.fn(), send: vi.fn() };
+  return { ...mail, default: mail };
+});
 
 import * as sgMail from "@sendgrid/mail";
 import type { ResolvedSendEmailConfig } from "../src/export-config";

--- a/kits/firestore-send-email/tests/nodemailer-sendgrid.test.ts
+++ b/kits/firestore-send-email/tests/nodemailer-sendgrid.test.ts
@@ -16,16 +16,21 @@
 
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-vi.mock("@sendgrid/mail", () => ({
-  setApiKey: vi.fn(),
-  send: vi.fn().mockResolvedValue([
-    {
-      headers: { "x-message-id": "test-message-id" },
-      statusCode: 202,
-    },
-    {},
-  ]),
-}));
+// @sendgrid/mail exports a single MailService instance, so the mock has to be
+// reachable as both the default and the named exports.
+vi.mock("@sendgrid/mail", () => {
+  const mail = {
+    setApiKey: vi.fn(),
+    send: vi.fn().mockResolvedValue([
+      {
+        headers: { "x-message-id": "test-message-id" },
+        statusCode: 202,
+      },
+      {},
+    ]),
+  };
+  return { ...mail, default: mail };
+});
 
 import * as sgMail from "@sendgrid/mail";
 import { SendGridTransport } from "../src/nodemailer-sendgrid";


### PR DESCRIPTION
SendGrid sends fail in the kit when AUTH_TYPE=OAuth2. configFromEnv gates secrets on the auth type and forces smtpPassword to undefined under OAuth2, but transportLayer selects the SendGrid transport purely on the SMTP URI host (smtp.sendgrid.net) and passes smtpPassword as the SendGrid API key. The transport therefore got apiKey: undefined, sgMail.setApiKey was never called, and every send failed. The legacy extension reads SMTP_PASSWORD unconditionally (firestore-send-email/functions/src/config.ts and index.ts:86-90 on master), so SendGrid + OAuth2 worked there.

The fix passes the SMTP password secret through for every auth type, and secretParamsForAuthType now keeps SMTP_PASSWORD bound under OAuth2 so a future gated deploy binding cannot reintroduce the bug. New tests pin configFromEnv keeping the secret under OAuth2 and transportLayer handing the key to setApiKey; the changelog gets an entry. Rebased onto kits after #3057 merged, folding the new tests into the ported suites. Suite: 123 tests pass, tsc --noEmit clean. An adversarial review mutation-tested both halves of the fix (reverting config.ts fails the config tests, reverting the transport apiKey fails the transportLayer test) and found no regression in any consumer of smtpPassword; the obfuscated-config log path still redacts it. Caveat: no live SendGrid send was verified; the behavior is pinned at unit level against a mocked @sendgrid/mail.

Fixes #3009
