### PR TITLE
ci(kits): put Java 21 on PATH for the emulator

### DIFF
--- a/.github/workflows/test-kits.yml
+++ b/.github/workflows/test-kits.yml
@@ -75,10 +75,13 @@ jobs:
         working-directory: ${{ matrix.kit }}
         run: npm test
 
-      # firebase-tools 15 requires Java 21+ for the emulator; the runner's
-      # default JAVA_HOME is 17, with 21 preinstalled alongside.
+      # firebase-tools 15 requires Java 21+ and resolves `java` from PATH
+      # rather than JAVA_HOME; the runner defaults to 17, with 21 preinstalled
+      # alongside.
       - name: Use Java 21 for the emulator
-        run: echo "JAVA_HOME=$JAVA_HOME_21_X64" >> "$GITHUB_ENV"
+        run: |
+          echo "JAVA_HOME=$JAVA_HOME_21_X64" >> "$GITHUB_ENV"
+          echo "$JAVA_HOME_21_X64/bin" >> "$GITHUB_PATH"
 
       - name: Install Firebase CLI
         run: npm install -g firebase-tools@15


### PR DESCRIPTION
**What was wrong**

The `Use Java 21 for the emulator` step sets `JAVA_HOME`, but firebase-tools never reads it: `checkJavaMajorVersion` spawns a bare `java` (confirmed in firebase-tools 15.28.2, `lib/emulator/commandUtils.js`, where `JAVA_HOME` appears nowhere in the package). The runner's default Java 17 stayed in front on PATH, so every emulator-gated kit suite failed with "firebase-tools no longer supports Java version before 21".

**What changed**

The step now also appends `$JAVA_HOME_21_X64/bin` to `GITHUB_PATH`, so the `java` firebase-tools resolves is 21. `JAVA_HOME` is kept for anything else that honours it.

**How it was verified**

Read against the published firebase-tools 15 source to confirm the version check reads PATH only, and traced the failure to that step in the run for #3087. `prettier --check` passes and the workflow still parses as YAML. Java is referenced in no other live workflow, and the two steps after this one (Firebase CLI install, emulator tests) are the only consumers in the job, so nothing else moves off 17.

CI on this PR does not exercise the fix, since no kit changes here and the emulator job only runs for changed kits. Retargeting a kit PR at this branch, or merging and re-running #3087, is what proves it.