### PR TITLE
fix(firestore-vector-search): map vector-store errors to HttpsError codes

### DIFF
--- a/kits/firestore-vector-search/src/vector-store/firestore.ts
+++ b/kits/firestore-vector-search/src/vector-store/firestore.ts
@@ -16,15 +16,83 @@
 
 import type { Query, VectorQuery } from "@google-cloud/firestore";
 import type { Firestore } from "firebase-admin/firestore";
+import { FirebaseFirestoreError } from "firebase-admin/firestore";
 import { https } from "firebase-functions/v1";
 import type { ResolvedVectorSearchConfig } from "../export-config";
 import type { Prefilter } from "../queries";
+
+/**
+ * Firestore error codes that map one-to-one onto callable function error
+ * codes. Anything outside this set is reported as `unknown`, with the original
+ * Firestore code attached as details.
+ */
+const ALLOWED_ERROR_CODES = new Set<https.FunctionsErrorCode>([
+  "cancelled",
+  "unknown",
+  "invalid-argument",
+  "deadline-exceeded",
+  "not-found",
+  "already-exists",
+  "permission-denied",
+  "resource-exhausted",
+  "aborted",
+  "out-of-range",
+  "unimplemented",
+  "internal",
+  "unavailable",
+  "data-loss",
+  "unauthenticated",
+]);
 
 export class FirestoreVectorStoreClient {
   constructor(
     private readonly firestore: Firestore,
     private readonly distanceMeasure: ResolvedVectorSearchConfig["distanceMeasure"]
   ) {}
+
+  /** Converts thrown Firestore or general errors into structured HttpsError objects. */
+  private toHttpsError(error: unknown, context?: string): https.HttpsError {
+    if (error instanceof https.HttpsError) {
+      return error;
+    }
+
+    if (error instanceof FirebaseFirestoreError) {
+      const message = context || error.message;
+
+      // the code is of the form firestore/code
+      const [prefix, code] = error.code.split("/");
+
+      // check the prefix is firestore anyway
+      if (prefix !== "firestore") {
+        return new https.HttpsError("unknown", message);
+      }
+
+      if (ALLOWED_ERROR_CODES.has(code as https.FunctionsErrorCode)) {
+        return new https.HttpsError(code as https.FunctionsErrorCode, message);
+      }
+      return new https.HttpsError("unknown", message, {
+        firestoreCode: error.code,
+      });
+    }
+
+    if (error instanceof Error) {
+      if (error.message.toLowerCase().includes("opstr")) {
+        return new https.HttpsError(
+          "invalid-argument",
+          context
+            ? `Invalid operator in query: ${context}`
+            : "Invalid operator in Firestore query"
+        );
+      }
+
+      return new https.HttpsError("unknown", error.message);
+    }
+
+    return new https.HttpsError(
+      "unknown",
+      "An unexpected error occurred performing your query"
+    );
+  }
 
   async query(
     query: number[],
@@ -37,26 +105,33 @@ export class FirestoreVectorStoreClient {
       const collectionRef = this.firestore.collection(collection);
       let firestoreQuery: Query | VectorQuery = collectionRef;
       for (const prefilter of prefilters) {
-        firestoreQuery = firestoreQuery.where(
-          prefilter.field,
-          prefilter.operator,
-          prefilter.value
-        );
+        try {
+          firestoreQuery = firestoreQuery.where(
+            prefilter.field,
+            prefilter.operator,
+            prefilter.value
+          );
+        } catch (filterError) {
+          throw this.toHttpsError(
+            filterError,
+            `${prefilter.operator} for ${prefilter.field}`
+          );
+        }
       }
 
-      firestoreQuery = firestoreQuery.findNearest(outputField, query, {
-        limit,
-        distanceMeasure: this.distanceMeasure,
-      });
+      try {
+        firestoreQuery = firestoreQuery.findNearest(outputField, query, {
+          limit,
+          distanceMeasure: this.distanceMeasure,
+        });
+      } catch (findNearestError) {
+        throw this.toHttpsError(findNearestError);
+      }
 
       const result = await firestoreQuery.get();
       return { ids: result.docs.map((doc) => doc.ref.id) };
-    } catch (err) {
-      if (err instanceof https.HttpsError) throw err;
-      throw new https.HttpsError(
-        "unknown",
-        err instanceof Error ? err.message : "Vector query failed"
-      );
+    } catch (error) {
+      throw this.toHttpsError(error);
     }
   }
 }

--- a/kits/firestore-vector-search/tests/vector-store.test.ts
+++ b/kits/firestore-vector-search/tests/vector-store.test.ts
@@ -15,6 +15,7 @@
  */
 
 import type { Firestore } from "firebase-admin/firestore";
+import { FirebaseFirestoreError } from "firebase-admin/firestore";
 import { https } from "firebase-functions/v1";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -45,6 +46,11 @@ function fakeFirestore(
     collection,
     chain,
   };
+}
+
+/** A real `FirebaseFirestoreError`, whose code is prefixed with `firestore/`. */
+function firestoreError(code: string, message: string) {
+  return new FirebaseFirestoreError({ code, message });
 }
 
 describe("FirestoreVectorStoreClient", () => {
@@ -188,6 +194,139 @@ describe("FirestoreVectorStoreClient", () => {
       .catch((e: unknown) => e);
 
     expect(err).toBeInstanceOf(https.HttpsError);
-    expect((err as https.HttpsError).message).toBe("Vector query failed");
+    expect((err as https.HttpsError).message).toBe(
+      "An unexpected error occurred performing your query"
+    );
+  });
+
+  test.each([
+    "cancelled",
+    "unknown",
+    "invalid-argument",
+    "deadline-exceeded",
+    "not-found",
+    "already-exists",
+    "permission-denied",
+    "resource-exhausted",
+    "aborted",
+    "out-of-range",
+    "unimplemented",
+    "internal",
+    "unavailable",
+    "data-loss",
+    "unauthenticated",
+  ])(
+    "maps the Firestore code %s onto the matching HttpsError code",
+    async (code) => {
+      const { firestore } = fakeFirestore();
+      (
+        firestore.collection as unknown as ReturnType<typeof vi.fn>
+      ).mockImplementation(() => {
+        throw firestoreError(code, "Firestore said no.");
+      });
+      const client = new FirestoreVectorStoreClient(firestore, "COSINE");
+
+      const err = await client
+        .query(query, "test-collection", [], limit, outputField)
+        .catch((e: unknown) => e);
+
+      expect(err).toBeInstanceOf(https.HttpsError);
+      expect((err as https.HttpsError).code).toBe(code);
+      expect((err as https.HttpsError).message).toBe("Firestore said no.");
+    }
+  );
+
+  test("reports an unmapped Firestore code as unknown with details", async () => {
+    const { firestore } = fakeFirestore();
+    (
+      firestore.collection as unknown as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => {
+      throw firestoreError("failed-precondition", "Index missing.");
+    });
+    const client = new FirestoreVectorStoreClient(firestore, "COSINE");
+
+    const err = await client
+      .query(query, "test-collection", [], limit, outputField)
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(https.HttpsError);
+    expect((err as https.HttpsError).code).toBe("unknown");
+    expect((err as https.HttpsError).message).toBe("Index missing.");
+    expect((err as https.HttpsError).details).toEqual({
+      firestoreCode: "firestore/failed-precondition",
+    });
+  });
+
+  test("reports a non-firestore error prefix as unknown", async () => {
+    const { firestore } = fakeFirestore();
+    const error = firestoreError("not-found", "Nope.");
+    (error as { code: string }).code = "auth/user-not-found";
+    (
+      firestore.collection as unknown as ReturnType<typeof vi.fn>
+    ).mockImplementation(() => {
+      throw error;
+    });
+    const client = new FirestoreVectorStoreClient(firestore, "COSINE");
+
+    const err = await client
+      .query(query, "test-collection", [], limit, outputField)
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(https.HttpsError);
+    expect((err as https.HttpsError).code).toBe("unknown");
+    expect((err as https.HttpsError).message).toBe("Nope.");
+    expect((err as https.HttpsError).details).toBeUndefined();
+  });
+
+  test("uses the prefilter as context for a Firestore error from where()", async () => {
+    const { firestore, chain } = fakeFirestore();
+    chain.where.mockImplementation(() => {
+      throw firestoreError("invalid-argument", "Bad filter.");
+    });
+    const client = new FirestoreVectorStoreClient(firestore, "COSINE");
+
+    const err = await client
+      .query(query, "test-collection", prefilters, limit, outputField)
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(https.HttpsError);
+    expect((err as https.HttpsError).code).toBe("invalid-argument");
+    expect((err as https.HttpsError).message).toBe("== for category");
+  });
+
+  test("maps an opStr failure from where() to invalid-argument with context", async () => {
+    const { firestore, chain } = fakeFirestore();
+    chain.where.mockImplementation(() => {
+      throw new Error('Value for argument "opStr" is invalid.');
+    });
+    const client = new FirestoreVectorStoreClient(firestore, "COSINE");
+
+    const err = await client
+      .query(query, "test-collection", prefilters, limit, outputField)
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(https.HttpsError);
+    expect((err as https.HttpsError).code).toBe("invalid-argument");
+    expect((err as https.HttpsError).message).toBe(
+      "Invalid operator in query: == for category"
+    );
+  });
+
+  test("maps an opStr failure without context to a generic invalid-argument", async () => {
+    const { firestore, chain } = fakeFirestore();
+    chain.findNearest.mockImplementation(() => {
+      throw new Error('Value for argument "opStr" is invalid.');
+    });
+    const client = new FirestoreVectorStoreClient(firestore, "COSINE");
+
+    const err = await client
+      .query(query, "test-collection", [], limit, outputField)
+      .catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(https.HttpsError);
+    expect((err as https.HttpsError).code).toBe("invalid-argument");
+    expect((err as https.HttpsError).message).toBe(
+      "Invalid operator in Firestore query"
+    );
   });
 });


### PR DESCRIPTION
Closes #3015

`FirestoreVectorStoreClient.query` collapsed every failure into an `unknown` `HttpsError`, so callers of the `queryCallable` could not branch on the cause. This ports the extension's `toHttpsError` so the kit reports the same codes.

## Changes

- Port `toHttpsError` into `FirestoreVectorStoreClient`, mapping a `FirebaseFirestoreError` whose code carries the `firestore/` prefix onto the 15 matching `HttpsError` codes (`cancelled`, `unknown`, `invalid-argument`, `deadline-exceeded`, `not-found`, `already-exists`, `permission-denied`, `resource-exhausted`, `aborted`, `out-of-range`, `unimplemented`, `internal`, `unavailable`, `data-loss`, `unauthenticated`).
- Report an unmapped Firestore code as `unknown` with `{ firestoreCode }` in the error details, and a non-`firestore/` prefix as a plain `unknown`.
- Map an `opStr` validation failure to `invalid-argument`, naming the offending prefilter as `Invalid operator in query: <operator> for <field>` when the failure came from `where()`, and `Invalid operator in Firestore query` otherwise.
- Wrap the `where()` and `findNearest()` calls individually so a prefilter failure carries its `<operator> for <field>` context, as the extension does.
- Restore the extension's non-`Error` fallback message, `An unexpected error occurred performing your query`, replacing the kit's `Vector query failed`.
- Extend `tests/vector-store.test.ts`: a case per mapped code, plus unmapped-code details, non-`firestore/` prefix, prefilter context, and both `opStr` paths.

## Testing

`pnpm test` in `kits/firestore-vector-search` — 73 tests pass across 5 files, 24 of them in `tests/vector-store.test.ts`, including one case per mapped Firestore code plus the unmapped-code details payload, the non-`firestore/` prefix, the prefilter context, and both `opStr` paths.

Deployed to `corie-testing` from a throwaway codebase under instance id `firestore-vector-search-hterr` (collection `fxkits_hterr_vs`, `EMBEDDING_PROVIDER=gemini`), so the kit's existing instances in that project were left untouched. Three documents embedded to 768 dimensions and reached `status.state: COMPLETED`, then the callable was exercised with an authenticated ID token:

| Case | Result |
| --- | --- |
| No bearer token | `401 UNAUTHENTICATED` — "The function must be called while authenticated." |
| Query, no prefilters | `200` — `{"ids":["doc-1","doc-2"]}` |
| Prefilter `category != …`, operator `!!` | `400 INVALID_ARGUMENT` — "Invalid operator in query: !! for category" |
| Prefilter on `input`, operator `~=` | `400 INVALID_ARGUMENT` — "Invalid operator in query: ~= for input" |
| Valid prefilter, no composite vector index | `500 UNKNOWN` — Firestore's own `FAILED_PRECONDITION` text, since the client throws a plain `Error` rather than a `FirebaseFirestoreError` |

Same request run against a still-deployed baseline instance for a direct before/after on the changed behaviour:

```
baseline    http=500 status=UNKNOWN
            "Value for argument \"opStr\" is invalid. Acceptable values are: <, <=, ==, !=, >, >=, ..."
this PR     http=400 status=INVALID_ARGUMENT
            "Invalid operator in query: !! for category"
```

`queryOnWrite`, which shares the same vector store, was checked too: a valid query document received `result: {"ids":["doc-1","doc-2"]}`, and a bad-operator query document produced no result, with the function log showing `Error: Invalid operator in query: !! for category` thrown from `FirestoreVectorStoreClient.toHttpsError`.

The test instance, its secrets, its Firestore documents and the throwaway codebase were deleted afterwards.
