### PR TITLE
fix(firestore-vector-search): guard queryOnWrite with the extension's status

### DIFF
--- a/kits/firestore-vector-search/README.md
+++ b/kits/firestore-vector-search/README.md
@@ -251,9 +251,9 @@ longer written, only `COMPLETED` and `ERROR`. Anything reading
 `status.<instance id>.state`, or a security rule or index keyed to it, needs
 updating. The field name is still `STATUS_FIELD_NAME`, defaulting to `status`.
 
-Query documents no longer get a status field at all. They previously carried
-`status.textQuery`, so if you were waiting on that to know a query had finished,
-wait for `result` instead.
+This applies to the documents in your indexed collection only. Query documents
+keep the extension's nested shape, `status.textQuery`, with the same states and
+timestamps, so anything waiting on that path still works.
 
 ### Editing a document's input re-embeds it
 
@@ -307,7 +307,11 @@ for; the Firebase CLI grants these for you.
   `status`, and embeddings are still written as native Firestore vectors.
 - Querying by writing a document to `_<instance id>/index/queries` still works
   the same way, with `query`, an optional `limit` and optional `prefilters`, and
-  the matching document ids written back to the document under `result`.
+  the matching document ids written back to the document under `result`. A query
+  document is still run once: writes that leave `query` and `limit` untouched are
+  ignored, as is any write to a document whose `status.textQuery.state` is
+  already set, so editing a completed query document does not re-run it and a
+  failed one is not retried. Write a new document for a new query.
 - `queryCallable` still requires an authenticated caller, still validates its
   argument with the same schema, still rejects a `limit` that is not an integer
   above zero, and still returns `{ ids: [...] }`.

--- a/kits/firestore-vector-search/README.md
+++ b/kits/firestore-vector-search/README.md
@@ -253,7 +253,8 @@ updating. The field name is still `STATUS_FIELD_NAME`, defaulting to `status`.
 
 This applies to the documents in your indexed collection only. Query documents
 keep the extension's nested shape, `status.textQuery`, with the same states and
-timestamps, so anything waiting on that path still works.
+timestamps, so anything waiting on that path still works. As in the extension,
+that path is always literally `status`, whatever `STATUS_FIELD_NAME` is set to.
 
 ### Editing a document's input re-embeds it
 

--- a/kits/firestore-vector-search/src/handlers.ts
+++ b/kits/firestore-vector-search/src/handlers.ts
@@ -117,25 +117,88 @@ export async function handleEmbedOnWrite(
   }
 }
 
+/**
+ * The extension ran the query through a `FirestoreOnWriteProcessor` built with
+ * no `statusField`, so query documents used the processor's literal `status`
+ * default rather than `STATUS_FIELD_NAME`, under the process id `textQuery`.
+ */
+const QUERY_STATUS_PATH = "status.textQuery";
+
+/** The fields the extension's `fieldDependencyArray` watched. */
+const QUERY_INPUT_FIELDS = ["query", "limit"] as const;
+
+/**
+ * States the extension's processor treated as final: a query document in any of
+ * them is never processed again. `PROCESSING` is one of them, so neither of the
+ * status writes below can re-trigger a run.
+ */
+const FINAL_QUERY_STATES = new Set([
+  "PROCESSING",
+  "COMPLETED",
+  "ERROR",
+  "BACKFILLED",
+]);
+
 export async function handleQueryOnWrite(
   event: VectorWriteEvent,
   ctx: HandlerContext
 ): Promise<void> {
   if (!event.data?.after.exists) return;
-  const data = event.data.after.data() ?? {};
+  const after = event.data.after;
+  const data = after.data() ?? {};
   const query = data.query;
   if (typeof query !== "string") return;
 
-  const result = await performTextQuery({
-    query,
-    limit: data.limit ? parseLimit(data.limit) : ctx.config.defaultQueryLimit,
-    prefilters: (data.prefilters as Prefilter[] | undefined) ?? [],
-    embedClient: embedClient(ctx),
-    vectorStore: vectorStore(ctx),
-    config: ctx.config,
+  // The result write below re-fires this trigger. Skipping documents whose
+  // status is already final stops the loop, and matches the extension: a query
+  // document runs once and is never re-run, not even when its inputs change.
+  const state = after.get(`${QUERY_STATUS_PATH}.state`);
+  if (typeof state === "string" && FINAL_QUERY_STATES.has(state)) return;
+
+  const before = event.data.before.exists
+    ? event.data.before.data()
+    : undefined;
+  const inputsChanged = QUERY_INPUT_FIELDS.some(
+    (field) => data[field] !== before?.[field]
+  );
+  if (!inputsChanged) return;
+
+  const startTime = FieldValue.serverTimestamp();
+  await after.ref.update({
+    [QUERY_STATUS_PATH]: {
+      state: "PROCESSING",
+      startTime,
+      createTime:
+        after.get(`${QUERY_STATUS_PATH}.createTime`) || after.createTime,
+      updateTime: startTime,
+    },
   });
 
-  await event.data.after.ref.set(result, { merge: true });
+  try {
+    const result = await performTextQuery({
+      query,
+      limit: data.limit ? parseLimit(data.limit) : ctx.config.defaultQueryLimit,
+      prefilters: (data.prefilters as Prefilter[] | undefined) ?? [],
+      embedClient: embedClient(ctx),
+      vectorStore: vectorStore(ctx),
+      config: ctx.config,
+    });
+    const completeTime = FieldValue.serverTimestamp();
+    await after.ref.update({
+      ...result,
+      [`${QUERY_STATUS_PATH}.state`]: "COMPLETED",
+      [`${QUERY_STATUS_PATH}.updateTime`]: completeTime,
+      [`${QUERY_STATUS_PATH}.completeTime`]: completeTime,
+    });
+  } catch (err) {
+    // The extension's `errorFn` logged and swallowed, so a failed query marks
+    // the document ERROR and the invocation succeeds rather than retrying.
+    logs.error("queryOnWrite", err);
+    await after.ref.update({
+      [`${QUERY_STATUS_PATH}.state`]: "ERROR",
+      [`${QUERY_STATUS_PATH}.updateTime`]: FieldValue.serverTimestamp(),
+    });
+  }
 }
 
 export async function handleQueryCall(

--- a/kits/firestore-vector-search/src/handlers.ts
+++ b/kits/firestore-vector-search/src/handlers.ts
@@ -174,21 +174,18 @@ export async function handleQueryOnWrite(
     },
   });
 
+  // Only the query itself is guarded, as in the extension, where the status
+  // writes sat outside the processor's try block. A failed status write still
+  // fails the invocation; the retry sees PROCESSING and skips.
+  let result: Awaited<ReturnType<typeof performTextQuery>>;
   try {
-    const result = await performTextQuery({
+    result = await performTextQuery({
       query,
       limit: data.limit ? parseLimit(data.limit) : ctx.config.defaultQueryLimit,
       prefilters: (data.prefilters as Prefilter[] | undefined) ?? [],
       embedClient: embedClient(ctx),
       vectorStore: vectorStore(ctx),
       config: ctx.config,
-    });
-    const completeTime = FieldValue.serverTimestamp();
-    await after.ref.update({
-      ...result,
-      [`${QUERY_STATUS_PATH}.state`]: "COMPLETED",
-      [`${QUERY_STATUS_PATH}.updateTime`]: completeTime,
-      [`${QUERY_STATUS_PATH}.completeTime`]: completeTime,
     });
   } catch (err) {
     // The extension's `errorFn` logged and swallowed, so a failed query marks
@@ -198,7 +195,16 @@ export async function handleQueryOnWrite(
       [`${QUERY_STATUS_PATH}.state`]: "ERROR",
       [`${QUERY_STATUS_PATH}.updateTime`]: FieldValue.serverTimestamp(),
     });
+    return;
   }
+
+  const completeTime = FieldValue.serverTimestamp();
+  await after.ref.update({
+    ...result,
+    [`${QUERY_STATUS_PATH}.state`]: "COMPLETED",
+    [`${QUERY_STATUS_PATH}.updateTime`]: completeTime,
+    [`${QUERY_STATUS_PATH}.completeTime`]: completeTime,
+  });
 }
 
 export async function handleQueryCall(

--- a/kits/firestore-vector-search/tests/handlers.test.ts
+++ b/kits/firestore-vector-search/tests/handlers.test.ts
@@ -399,6 +399,20 @@ describe("handleQueryOnWrite", () => {
     expect(failure.result).toBeUndefined();
   });
 
+  test("propagates a failed result write instead of marking it ERROR", async () => {
+    const { ctx } = makeCtx();
+    const after = snapshot({ query: "test query" });
+    after.update
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("Document does not exist"));
+
+    await expect(
+      handleQueryOnWrite(writeEvent(snapshot(undefined), after), ctx)
+    ).rejects.toThrow("Document does not exist");
+
+    expect(after.update).toHaveBeenCalledTimes(2);
+  });
+
   test("ignores a document without a string query", async () => {
     const { ctx } = makeCtx();
     const after = snapshot({ query: 42 });

--- a/kits/firestore-vector-search/tests/handlers.test.ts
+++ b/kits/firestore-vector-search/tests/handlers.test.ts
@@ -36,7 +36,12 @@ vi.mock("../src/embeddings", () => ({
 // handler never needs it.
 vi.mock("../src/queries/setup", () => ({ createIndex: vi.fn() }));
 
-import { type HandlerContext, handleQueryCall } from "../src/handlers";
+import {
+  type HandlerContext,
+  type VectorWriteEvent,
+  handleQueryCall,
+  handleQueryOnWrite,
+} from "../src/handlers";
 import { resolveVectorSearchConfig } from "../src/export-config";
 
 const config = resolveVectorSearchConfig({
@@ -203,5 +208,217 @@ describe("handleQueryCall", () => {
 
     expect((err as { code: string }).code).toBe("unknown");
     expect((err as Error).message).toBe("Query failed");
+  });
+});
+
+/**
+ * A DocumentSnapshot stand-in. `undefined` data means the snapshot does not
+ * exist, matching a create's `before` or a delete's `after`.
+ */
+function snapshot(
+  data: Record<string, unknown> | undefined,
+  createTime: unknown = "doc-create-time"
+) {
+  const update = vi.fn().mockResolvedValue(undefined);
+  return {
+    exists: data !== undefined,
+    createTime,
+    data: () => data,
+    get: (path: string) =>
+      path
+        .split(".")
+        .reduce<unknown>(
+          (acc, key) =>
+            acc == null ? undefined : (acc as Record<string, unknown>)[key],
+          data
+        ),
+    ref: { path: "queries/query-1", update },
+    update,
+  };
+}
+
+function writeEvent(
+  before: ReturnType<typeof snapshot>,
+  after: ReturnType<typeof snapshot>
+) {
+  return {
+    data: { before, after },
+    params: { queryId: "query-1" },
+  } as unknown as VectorWriteEvent;
+}
+
+const COMPLETED_STATUS = {
+  status: { textQuery: { state: "COMPLETED" } },
+};
+
+describe("handleQueryOnWrite", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSingleEmbedding.mockResolvedValue(EMBEDDING);
+  });
+
+  test("runs the query on create and writes the result with a status", async () => {
+    const { ctx, chain } = makeCtx();
+    const after = snapshot({ query: "test query" });
+
+    await handleQueryOnWrite(writeEvent(snapshot(undefined), after), ctx);
+
+    expect(getSingleEmbedding).toHaveBeenCalledWith("test query");
+    expect(chain.findNearest).toHaveBeenCalledWith(
+      config.outputFieldName,
+      EMBEDDING,
+      {
+        limit: config.defaultQueryLimit,
+        distanceMeasure: config.distanceMeasure,
+      }
+    );
+    expect(after.update).toHaveBeenCalledTimes(2);
+
+    const start = after.update.mock.calls[0][0];
+    expect(start["status.textQuery"]).toMatchObject({
+      state: "PROCESSING",
+      createTime: "doc-create-time",
+    });
+    expect(start["status.textQuery"].startTime).toBeDefined();
+    expect(start["status.textQuery"].updateTime).toBeDefined();
+
+    const complete = after.update.mock.calls[1][0];
+    expect(complete.result).toEqual({ ids: IDS });
+    expect(complete["status.textQuery.state"]).toBe("COMPLETED");
+    expect(complete["status.textQuery.updateTime"]).toBeDefined();
+    expect(complete["status.textQuery.completeTime"]).toBeDefined();
+  });
+
+  test("keeps an existing status order field across a re-run", async () => {
+    const { ctx } = makeCtx();
+    const after = snapshot({
+      query: "second query",
+      status: { textQuery: { createTime: "first-run-create-time" } },
+    });
+
+    await handleQueryOnWrite(
+      writeEvent(snapshot({ query: "first query" }), after),
+      ctx
+    );
+
+    expect(after.update.mock.calls[0][0]["status.textQuery"].createTime).toBe(
+      "first-run-create-time"
+    );
+  });
+
+  test("ignores the result write it makes itself", async () => {
+    const { ctx } = makeCtx();
+    const after = snapshot({
+      query: "test query",
+      result: { ids: IDS },
+      ...COMPLETED_STATUS,
+    });
+
+    await handleQueryOnWrite(
+      writeEvent(snapshot({ query: "test query" }), after),
+      ctx
+    );
+
+    expect(getSingleEmbedding).not.toHaveBeenCalled();
+    expect(after.update).not.toHaveBeenCalled();
+  });
+
+  test.each(["PROCESSING", "COMPLETED", "ERROR", "BACKFILLED"])(
+    "never re-runs a document whose status is %s, even when the query changes",
+    async (state) => {
+      const { ctx } = makeCtx();
+      const after = snapshot({
+        query: "changed query",
+        status: { textQuery: { state } },
+      });
+
+      await handleQueryOnWrite(
+        writeEvent(snapshot({ query: "original query" }), after),
+        ctx
+      );
+
+      expect(getSingleEmbedding).not.toHaveBeenCalled();
+      expect(after.update).not.toHaveBeenCalled();
+    }
+  );
+
+  test("ignores a write that changes neither the query nor the limit", async () => {
+    const { ctx } = makeCtx();
+    const after = snapshot({ query: "test query", unrelated: "b" });
+
+    await handleQueryOnWrite(
+      writeEvent(snapshot({ query: "test query", unrelated: "a" }), after),
+      ctx
+    );
+
+    expect(getSingleEmbedding).not.toHaveBeenCalled();
+    expect(after.update).not.toHaveBeenCalled();
+  });
+
+  test("runs when the limit changes on a document with no status", async () => {
+    const { ctx, chain } = makeCtx();
+    const after = snapshot({ query: "test query", limit: "5" });
+
+    await handleQueryOnWrite(
+      writeEvent(snapshot({ query: "test query", limit: "3" }), after),
+      ctx
+    );
+
+    expect(chain.findNearest).toHaveBeenCalledWith(
+      config.outputFieldName,
+      EMBEDDING,
+      { limit: 5, distanceMeasure: config.distanceMeasure }
+    );
+  });
+
+  test("applies the document prefilters", async () => {
+    const { ctx, chain } = makeCtx();
+    const after = snapshot({
+      query: "test query",
+      prefilters: [{ field: "category", operator: "==", value: "test" }],
+    });
+
+    await handleQueryOnWrite(writeEvent(snapshot(undefined), after), ctx);
+
+    expect(chain.where).toHaveBeenCalledWith("category", "==", "test");
+  });
+
+  test("marks the document ERROR and succeeds when the query fails", async () => {
+    const { ctx } = makeCtx();
+    getSingleEmbedding.mockRejectedValue(new Error("Embedding failed"));
+    const after = snapshot({ query: "test query" });
+
+    await expect(
+      handleQueryOnWrite(writeEvent(snapshot(undefined), after), ctx)
+    ).resolves.toBeUndefined();
+
+    expect(after.update).toHaveBeenCalledTimes(2);
+    const failure = after.update.mock.calls[1][0];
+    expect(failure["status.textQuery.state"]).toBe("ERROR");
+    expect(failure["status.textQuery.updateTime"]).toBeDefined();
+    expect(failure.result).toBeUndefined();
+  });
+
+  test("ignores a document without a string query", async () => {
+    const { ctx } = makeCtx();
+    const after = snapshot({ query: 42 });
+
+    await handleQueryOnWrite(writeEvent(snapshot(undefined), after), ctx);
+
+    expect(getSingleEmbedding).not.toHaveBeenCalled();
+    expect(after.update).not.toHaveBeenCalled();
+  });
+
+  test("ignores a delete", async () => {
+    const { ctx } = makeCtx();
+    const after = snapshot(undefined);
+
+    await handleQueryOnWrite(
+      writeEvent(snapshot({ query: "test query" }), after),
+      ctx
+    );
+
+    expect(getSingleEmbedding).not.toHaveBeenCalled();
+    expect(after.update).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
`handleQueryOnWrite` wrote its result back onto the document it watches with no status or idempotency guard, so the write re-fired `onDocumentWritten`, whose `data.query` was still a string, and the handler queried again — a self-sustaining loop billing one embedding call plus one vector query per pass (parity ledger #2974, `firestore-vector-search` §7).

The extension ran the query as a `FirestoreOnWriteProcess` (`id: 'textQuery'`, `fieldDependencyArray: ['query', 'limit']`, `errorFn: console.error`) through a `FirestoreOnWriteProcessor`. That processor is `firebase-functions` v1-tied, so the kit cannot consume it, but its behaviour ports directly and this PR ports it rather than inventing a stronger guard: skip any document whose status state is already `PROCESSING`, `COMPLETED`, `ERROR` or `BACKFILLED`, and otherwise run only when `query` or `limit` changed. A query document therefore runs exactly once — editing a completed one does not re-run it, and a failed one is not retried — which is the extension's behaviour, and it is why no race window exists for a stale result to overwrite a newer one.

Two parity details worth calling out. The extension built the query processor without a `statusField`, so query documents used the processor's literal `status` default rather than `STATUS_FIELD_NAME`; that is kept as-is. And the extension's `errorFn` logged and swallowed, so a failed query marks the document `ERROR` and the invocation succeeds rather than throwing out of the handler (§7c).

Out of scope and still tracked separately: the unvalidated `prefilters` cast (§7b, #3065) and the flat status shape on the *indexed* collection's documents (§6).

## Changes

- `handleQueryOnWrite` skips a document whose `status.textQuery.state` is `PROCESSING`, `COMPLETED`, `ERROR` or `BACKFILLED`, and skips any write that changes neither `query` nor `limit`.
- Writes `status.textQuery` as `PROCESSING` before running the query, carrying over an existing `createTime` as the order field, so neither status write can re-trigger a run.
- Writes the result together with `status.textQuery.state: COMPLETED` and `updateTime`/`completeTime`, via `update()` with the extension's dotted field paths.
- A failed query logs, writes `status.textQuery.state: ERROR` with an `updateTime`, and resolves instead of throwing.
- README: query documents keep the extension's nested `status.textQuery` shape, and the "Unchanged" section documents the run-once rule.
- Tests: 13 cases covering the create path, the echo write, all four final states with a changed query, an unchanged-inputs write, a `limit` change, prefilters, the error path, a non-string query, a delete, and the preserved `createTime`.


## Testing

- `vitest run` in `kits/firestore-vector-search`: 63 passed (5 files), up from 49. `tsc --noEmit` clean, prettier clean.
- Mutation-checked the three guards the fix rests on. Removing the final-state check fails 4 tests; removing the changed-inputs check fails 1; widening the `try` back over the result write fails the propagation test.
- Repacked the kit and deployed it to `corie-testing` as a throwaway instance, `firestore-vector-search-pr3095` (gemini / COSINE / `fxkits_pr3095`, its own query collection, its own queues), so the shared vector-search codebase and its data were left alone. All eight functions created, `Deploy complete!`. The instance, its functions, secrets, index and documents have since been deleted.
- `embedOnWrite` (indirectly affected): three seeded documents each got a 768-dimension embedding and `status: { state: "COMPLETED" }`.
- **Success path.** A query document `{ query: "a pet animal" }` came back with `result.ids: ["smoke-0", "smoke-2", "smoke-1"]` — the cat document first — and `status.textQuery` = `{ state: "COMPLETED", startTime: 15:17:41.316Z, createTime: 15:17:41.104Z, updateTime = completeTime = 15:17:42.277Z }`. `createTime` is the document's own create time and `updateTime` equals `completeTime` from a single server timestamp, both as the extension wrote them.
- **The loop is closed.** Exactly two writes for that run, and the timestamps were still unchanged on re-reads minutes later — the result write no longer re-fires the trigger.
- **A completed document is not re-run.** Editing `query` to `"a vehicle with wheels"` left the state, all four timestamps and the ids untouched, matching the extension, which never re-ran a completed query document.
- **Failure path.** The first two query documents ran while the vector index was still building, so `findNearest` failed with `FAILED_PRECONDITION`. Each wrote `status.textQuery` = `{ state: "ERROR", startTime, createTime, updateTime }` — no `completeTime`, no `result` — logged one `Failed firestore-vector-search queryOnWrite` line, and the invocation succeeded rather than throwing.
- **An errored document is not retried.** Editing `query` on one left its `ERROR` state and timestamps unchanged, again matching the extension.
