### PR TITLE
fix(firestore-translate-text): stop coercing non-string input before translation

### DIFF
--- a/kits/firestore-translate-text/src/translate/translateDocument.ts
+++ b/kits/firestore-translate-text/src/translate/translateDocument.ts
@@ -50,5 +50,7 @@ export const translateDocument = async (
     );
   }
 
-  await translateSingle(String(input), languages, snapshot, service);
+  // Passed through uncoerced: the extension hands the raw field value to the
+  // translation API, so a numeric input arrives as a number, not "42".
+  await translateSingle(input as string, languages, snapshot, service);
 };

--- a/kits/firestore-translate-text/tests/translate-document.test.ts
+++ b/kits/firestore-translate-text/tests/translate-document.test.ts
@@ -78,7 +78,7 @@ describe("translateDocument", () => {
     });
   });
 
-  test("coerces a non-string, non-object input to a string", async () => {
+  test("passes a non-string, non-object input through uncoerced", async () => {
     const snapshot = makeSnapshot({ input: 42 });
 
     await translateDocument(
@@ -87,10 +87,24 @@ describe("translateDocument", () => {
       makeConfig()
     );
 
-    expect(translateString).toHaveBeenCalledWith("42", "en");
+    expect(translateString).toHaveBeenCalledWith(42, "en");
   });
 
-  test("treats a null input as a single string translation", async () => {
+  test("logs a non-string input without coercing it", async () => {
+    const snapshot = makeSnapshot({ input: 42 });
+
+    await translateDocument(
+      snapshot,
+      makeService({ extractLanguages: vi.fn(() => ["en"]) }),
+      makeConfig()
+    );
+
+    expect(logger.log).toHaveBeenCalledWith(
+      messages.translateInputStringToAllLanguages(42 as never, ["en"])
+    );
+  });
+
+  test("treats a null input as a single translation, uncoerced", async () => {
     const snapshot = makeSnapshot({ input: null });
 
     await translateDocument(
@@ -99,7 +113,7 @@ describe("translateDocument", () => {
       makeConfig()
     );
 
-    expect(translateString).toHaveBeenCalledWith("null", "en");
+    expect(translateString).toHaveBeenCalledWith(null, "en");
   });
 
   test("exits early when the input field is a translation output path", async () => {


### PR DESCRIPTION
The kit's `translateDocument` called `translateSingle(String(input), …)`, so a document whose input field is `42` sent the string `"42"` to the translation API and logged `"42"`. The extension passes the raw field value straight through (`firestore-translate-text/functions/src/translate/translateDocument.ts:68`). This drops the coercion so the value reaches `translateString` and the log line unchanged.

Only the create path can reach this: `handleUpdateDocument` deletes any existing translations and returns for a non-string, non-object input, and `handleCreateDocument`'s `if (input)` truthiness check lets `42` through. Nothing else in the kit depends on the input being a string by the time it gets here — `translateSingle` only forwards it to `service.translateString` and the log helper.

The kit's extra `input !== null` guard in the object branch (§4a) is untouched, so `null` still routes to `translateSingle` rather than throwing in `Object.entries` the way the extension does. That is a separate divergence and not in scope here; the null test now asserts the uncoerced `null` instead of `"null"`.

Two existing tests asserted the coercion and are inverted; a third covers the log line. 98 tests and `tsc --noEmit` pass. No live translation run.

Fixes #3106
Parity ledger: #2974, firestore-translate-text §4b.
