### PR TITLE
fix(firestore-send-email): restore the TESTING env path

### DIFF
--- a/kits/firestore-send-email/src/config.ts
+++ b/kits/firestore-send-email/src/config.ts
@@ -344,6 +344,9 @@ export function configFromEnv(): SendEmailConfig {
     defaultReplyTo: params.defaultReplyTo.value(),
     usersCollection: params.usersCollection.value(),
     templatesCollection: params.templatesCollection.value(),
+    // Read straight from the environment, not declared as a param: the
+    // extension never surfaced TESTING in extension.yaml either.
+    testing: process.env.TESTING === "true",
     ttlExpireType:
       params.ttlExpireType.value() as SendEmailConfig["ttlExpireType"],
     ttlExpireValue: params.ttlExpireValue.value(),

--- a/kits/firestore-send-email/tests/config.test.ts
+++ b/kits/firestore-send-email/tests/config.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 
 interface StringParamOpts {
   default?: string;
@@ -67,6 +67,34 @@ describe("configFromEnv", () => {
     expect(config.defaultReplyTo).toBe("");
     expect(typeof config.smtpPassword).toBe("object");
     expect(config.clientId).toBeUndefined();
+  });
+});
+
+describe("configFromEnv TESTING", () => {
+  const original = process.env.TESTING;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.TESTING;
+    else process.env.TESTING = original;
+  });
+
+  test('enables testing mode when TESTING is "true"', () => {
+    process.env.TESTING = "true";
+    expect(configFromEnv().testing).toBe(true);
+    expect(resolveConfig(configFromEnv()).testing).toBe(true);
+  });
+
+  test("leaves testing mode off when TESTING is unset", () => {
+    delete process.env.TESTING;
+    expect(configFromEnv().testing).toBe(false);
+    expect(resolveConfig(configFromEnv()).testing).toBe(false);
+  });
+
+  test('only the exact string "true" enables testing mode', () => {
+    for (const value of ["TRUE", "1", "yes", ""]) {
+      process.env.TESTING = value;
+      expect(configFromEnv().testing).toBe(false);
+    }
   });
 });
 


### PR DESCRIPTION
The kit already carries the extension's testing transport — `transportLayer` returns a `127.0.0.1:8132` nodemailer transport when `config.testing` is set (`src/helpers.ts`) — but nothing ever set `testing` from the environment. It was reachable only by a programmatic caller passing `SendEmailConfig.testing`, so the env-driven path (deploy, emulator, the extension's own `_emulator` style setup) could not enter testing mode at all. The extension read it in `firestore-send-email/functions/src/config.ts:30`.

This adds `testing: process.env.TESTING === "true"` to `configFromEnv()`. Read from `process.env` rather than declared as a param, matching the extension: `TESTING` never appeared in its `extension.yaml`, only in the config read. Putting it in `configFromEnv` rather than `resolveConfig` keeps the resolver pure, so library consumers who build a `SendEmailConfig` themselves are unaffected and an explicit `testing: false` still wins.

The strict `=== "true"` comparison is the extension's, so `TRUE` / `1` / `yes` stay off; there is a test pinning that. `resolveConfig` already collapsed the optional flag to a boolean, so no type changes were needed.

3 tests added, 124 pass, `tsc --noEmit` clean. No live SMTP run.

Fixes #3107
Parity ledger: #2974, firestore-send-email params table.
