### PR TITLE
fix(kits): declare the Cloud Firestore API in every kit that uses it

### DIFF
--- a/kits/bigquery-firestore-export/src/index.ts
+++ b/kits/bigquery-firestore-export/src/index.ts
@@ -56,6 +56,10 @@ const REQUIRED_ROLES: ReadonlyArray<Role> = [
 ];
 const REQUIRED_APIS = [
   {
+    api: "firestore.googleapis.com",
+    reason: "Writes BigQuery export run state to Cloud Firestore.",
+  },
+  {
     api: "bigquery.googleapis.com",
     reason: "Runs scheduled queries and reads their destination tables.",
   },

--- a/kits/delete-user-data/src/index.ts
+++ b/kits/delete-user-data/src/index.ts
@@ -18,7 +18,7 @@ import { PubSub } from "@google-cloud/pubsub";
 import * as admin from "firebase-admin";
 import { getFirestore } from "firebase-admin/firestore";
 import type { Role } from "firebase-functions/v2";
-import { requiresRole } from "firebase-functions/v2";
+import { requiresAPI, requiresRole } from "firebase-functions/v2";
 import { onUserDeleted } from "firebase-functions/v2/identity";
 import { onMessagePublished } from "firebase-functions/v2/pubsub";
 import { CONFIG_EXPRESSIONS, configFromEnv } from "./config";
@@ -43,9 +43,19 @@ const REQUIRED_ROLES: ReadonlyArray<Role> = [
   "roles/eventarc.eventReceiver",
   "roles/run.invoker",
 ];
+const REQUIRED_APIS = [
+  {
+    api: "firestore.googleapis.com",
+    reason: "Deletes user data from Cloud Firestore.",
+  },
+] as const;
 
 for (const role of REQUIRED_ROLES) {
   requiresRole(role);
+}
+
+for (const { api, reason } of REQUIRED_APIS) {
+  requiresAPI(api, reason);
 }
 
 let ctx: HandlerContext | undefined;

--- a/kits/firestore-bigquery-export/src/index.ts
+++ b/kits/firestore-bigquery-export/src/index.ts
@@ -65,6 +65,10 @@ const REQUIRED_ROLES: ReadonlyArray<Role> = [
 ];
 const REQUIRED_APIS = [
   {
+    api: "firestore.googleapis.com",
+    reason: "Receives document change events from Cloud Firestore.",
+  },
+  {
     api: "bigquery.googleapis.com",
     reason: "Mirrors data from your Cloud Firestore collection in BigQuery.",
   },

--- a/kits/firestore-bundle-builder/src/index.ts
+++ b/kits/firestore-bundle-builder/src/index.ts
@@ -29,7 +29,7 @@ import * as admin from "firebase-admin";
 import { logger } from "firebase-functions";
 import { onRequest } from "firebase-functions/https";
 import type { Role } from "firebase-functions/v2";
-import { requiresRole } from "firebase-functions/v2";
+import { requiresAPI, requiresRole } from "firebase-functions/v2";
 import type { BundleSpec } from "./build-bundle";
 import { configFromEnv } from "./config";
 import { resolveConfig } from "./export-config";
@@ -45,9 +45,20 @@ const REQUIRED_ROLES: ReadonlyArray<Role> = [
   "roles/eventarc.eventReceiver",
   "roles/run.invoker",
 ];
+const REQUIRED_APIS = [
+  {
+    api: "firestore.googleapis.com",
+    reason:
+      "Reads bundle specifications and document data from Cloud Firestore.",
+  },
+] as const;
 
 for (const role of REQUIRED_ROLES) {
   requiresRole(role);
+}
+
+for (const { api, reason } of REQUIRED_APIS) {
+  requiresAPI(api, reason);
 }
 
 if (admin.apps.length === 0) {

--- a/kits/firestore-bundle-builder/tests/index.test.ts
+++ b/kits/firestore-bundle-builder/tests/index.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { BundleBuilderConfig } from "../src/export-config";
+
+// `firebase-functions` and `firebase-functions/v2` resolve to the same module,
+// so the logger and the deploy-time declarations share one mock. The spies are
+// hoisted because this suite calls `vi.resetModules()` between imports of
+// `../src/index`.
+const { logger, requiresAPI, requiresRole } = vi.hoisted(() => ({
+  logger: { debug: vi.fn(), error: vi.fn() },
+  requiresAPI: vi.fn(),
+  requiresRole: vi.fn(),
+}));
+
+vi.mock("firebase-functions", () => ({ logger, requiresAPI, requiresRole }));
+
+const onRequest = vi.fn((options: unknown, handler: unknown) => ({
+  options,
+  handler,
+}));
+
+vi.mock("firebase-functions/https", () => ({ onRequest }));
+
+const initializeApp = vi.fn();
+
+vi.mock("firebase-admin", () => ({
+  apps: [],
+  initializeApp,
+  firestore: vi.fn(() => ({ collection: vi.fn() })),
+}));
+
+vi.mock("@google-cloud/storage", () => ({
+  Storage: vi.fn(() => ({ bucket: vi.fn() })),
+}));
+
+const configFromEnv = vi.fn<() => BundleBuilderConfig>(() => ({
+  bundleSpecCollection: "bundles",
+  bundleStorageBucket: "",
+  storagePrefix: "bundles",
+}));
+
+vi.mock("../src/config", () => ({ configFromEnv }));
+
+async function importIndex() {
+  vi.resetModules();
+  return import("../src/index");
+}
+
+describe("index", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The kit reaches Firestore from an HTTPS function with no Firestore trigger,
+  // so nothing at deploy time infers the dependency: without this declaration
+  // `serve` fails at runtime on a project where the API is disabled.
+  test("declares the Cloud Firestore API requirement", async () => {
+    await importIndex();
+
+    expect(requiresAPI).toHaveBeenCalledWith(
+      "firestore.googleapis.com",
+      "Reads bundle specifications and document data from Cloud Firestore."
+    );
+  });
+
+  test("registers the HTTPS serve function", async () => {
+    const { serve } = await importIndex();
+
+    expect(onRequest).toHaveBeenCalledWith(
+      { region: "us-central1" },
+      expect.any(Function)
+    );
+    expect(serve).toBeDefined();
+  });
+});

--- a/kits/firestore-counter/src/index.ts
+++ b/kits/firestore-counter/src/index.ts
@@ -20,7 +20,7 @@ import { onDocumentWritten } from "firebase-functions/firestore";
 import { expr } from "firebase-functions/params";
 import { onSchedule } from "firebase-functions/scheduler";
 import type { Role } from "firebase-functions/v2";
-import { requiresRole } from "firebase-functions/v2";
+import { requiresAPI, requiresRole } from "firebase-functions/v2";
 import { CONFIG_EXPRESSIONS, configFromEnv } from "./config";
 import * as events from "./events";
 import { resolveCounterConfig } from "./export-config";
@@ -40,9 +40,19 @@ const REQUIRED_ROLES: ReadonlyArray<Role> = [
   "roles/eventarc.eventReceiver",
   "roles/run.invoker",
 ];
+const REQUIRED_APIS = [
+  {
+    api: "firestore.googleapis.com",
+    reason: "Reads and writes counter shards in Cloud Firestore.",
+  },
+] as const;
 
 for (const role of REQUIRED_ROLES) {
   requiresRole(role);
+}
+
+for (const { api, reason } of REQUIRED_APIS) {
+  requiresAPI(api, reason);
 }
 
 let ctx: HandlerContext | undefined;

--- a/kits/firestore-genai-chatbot/src/index.ts
+++ b/kits/firestore-genai-chatbot/src/index.ts
@@ -42,6 +42,11 @@ const REQUIRED_ROLES: ReadonlyArray<Role> = [
 ];
 const REQUIRED_APIS = [
   {
+    api: "firestore.googleapis.com",
+    reason:
+      "Receives document change events from Cloud Firestore and writes generated responses back.",
+  },
+  {
     api: "aiplatform.googleapis.com",
     reason:
       "For access to the Vertex AI Gemini API if this provider is chosen.",

--- a/kits/firestore-incremental-capture/src/index.ts
+++ b/kits/firestore-incremental-capture/src/index.ts
@@ -37,11 +37,8 @@ import { onDocumentWritten } from "firebase-functions/firestore";
 import { onRequest } from "firebase-functions/https";
 import { expr } from "firebase-functions/params";
 import { onTaskDispatched } from "firebase-functions/tasks";
-// Imported from the narrow subpath, not the `firebase-functions/v2` barrel: the
-// barrel pulls in the RTDB provider, whose firebase-admin dependency fails to
-// load without @firebase/app installed.
-import type { Role } from "firebase-functions/v2/options";
-import { requiresRole } from "firebase-functions/v2/options";
+import type { Role } from "firebase-functions/v2";
+import { requiresAPI, requiresRole } from "firebase-functions/v2";
 import {
   afterFirstDeploy,
   afterRedeploy,
@@ -95,9 +92,20 @@ const REQUIRED_ROLES: ReadonlyArray<Role> = [
   // Reads the staged flex template spec from Cloud Storage.
   "roles/storage.objectViewer",
 ];
+const REQUIRED_APIS = [
+  {
+    api: "firestore.googleapis.com",
+    reason:
+      "Receives document change events and writes restoration run status to Cloud Firestore.",
+  },
+] as const;
 
 for (const role of REQUIRED_ROLES) {
   requiresRole(role);
+}
+
+for (const { api, reason } of REQUIRED_APIS) {
+  requiresAPI(api, reason);
 }
 
 // The empty data envelope is required: the CLI enqueues the hook body

--- a/kits/firestore-incremental-capture/src/index.ts
+++ b/kits/firestore-incremental-capture/src/index.ts
@@ -98,6 +98,16 @@ const REQUIRED_APIS = [
     reason:
       "Receives document change events and writes restoration run status to Cloud Firestore.",
   },
+  {
+    api: "bigquery.googleapis.com",
+    reason:
+      "Stores the changelog of captured Firestore document changes in BigQuery.",
+  },
+  {
+    api: "dataflow.googleapis.com",
+    reason:
+      "Runs the restoration flex template that replays the changelog into the target database.",
+  },
 ] as const;
 
 for (const role of REQUIRED_ROLES) {

--- a/kits/firestore-incremental-capture/tests/required-apis.test.ts
+++ b/kits/firestore-incremental-capture/tests/required-apis.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeAll, expect, test, vi } from "vitest";
+
+// Only `requiresAPI` is stubbed; the rest of the barrel stays real so importing
+// the entry point still registers the functions the way a deploy would.
+const { requiresAPI } = vi.hoisted(() => ({ requiresAPI: vi.fn() }));
+
+vi.mock("firebase-functions/v2", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("firebase-functions/v2")>()),
+  requiresAPI,
+}));
+
+beforeAll(async () => {
+  await import("../src/index");
+});
+
+test.each([
+  [
+    "firestore.googleapis.com",
+    "Receives document change events and writes restoration run status to Cloud Firestore.",
+  ],
+  [
+    "bigquery.googleapis.com",
+    "Stores the changelog of captured Firestore document changes in BigQuery.",
+  ],
+  [
+    "dataflow.googleapis.com",
+    "Runs the restoration flex template that replays the changelog into the target database.",
+  ],
+])("declares %s", (api, reason) => {
+  expect(requiresAPI).toHaveBeenCalledWith(api, reason);
+});

--- a/kits/firestore-send-email/src/index.ts
+++ b/kits/firestore-send-email/src/index.ts
@@ -18,7 +18,7 @@ import { getApp, initializeApp } from "firebase-admin/app";
 import { getFirestore } from "firebase-admin/firestore";
 import { onDocumentWritten } from "firebase-functions/firestore";
 import type { Role } from "firebase-functions/v2";
-import { requiresRole } from "firebase-functions/v2";
+import { requiresAPI, requiresRole } from "firebase-functions/v2";
 import { configFromEnv, envDeployOptions, secretParams } from "./config";
 import * as events from "./events";
 import { resolveConfig } from "./export-config";
@@ -35,9 +35,20 @@ const REQUIRED_ROLES: ReadonlyArray<Role> = [
   "roles/eventarc.eventReceiver",
   "roles/run.invoker",
 ];
+const REQUIRED_APIS = [
+  {
+    api: "firestore.googleapis.com",
+    reason:
+      "Reads the mail queue and writes delivery state in Cloud Firestore.",
+  },
+] as const;
 
 for (const role of REQUIRED_ROLES) {
   requiresRole(role);
+}
+
+for (const { api, reason } of REQUIRED_APIS) {
+  requiresAPI(api, reason);
 }
 
 const deploy = envDeployOptions();

--- a/kits/firestore-translate-text/src/index.ts
+++ b/kits/firestore-translate-text/src/index.ts
@@ -39,6 +39,11 @@ const REQUIRED_ROLES: ReadonlyArray<Role> = [
 ];
 const REQUIRED_APIS = [
   {
+    api: "firestore.googleapis.com",
+    reason:
+      "Reads source strings and writes translations back to Cloud Firestore.",
+  },
+  {
     api: "translate.googleapis.com",
     reason:
       "To use Google Translate to translate strings into the specified target languages.",

--- a/kits/firestore-translate-text/tests/index.test.ts
+++ b/kits/firestore-translate-text/tests/index.test.ts
@@ -125,6 +125,15 @@ describe("index", () => {
     ]);
   });
 
+  test("declares the Cloud Firestore API requirement", async () => {
+    await importIndex();
+
+    expect(requiresAPI).toHaveBeenCalledWith(
+      "firestore.googleapis.com",
+      "Reads source strings and writes translations back to Cloud Firestore."
+    );
+  });
+
   test("declares the Cloud Translation API requirement", async () => {
     await importIndex();
 

--- a/kits/firestore-vector-search/src/index.ts
+++ b/kits/firestore-vector-search/src/index.ts
@@ -68,6 +68,11 @@ const REQUIRED_ROLES: ReadonlyArray<Role> = [
 ];
 const REQUIRED_APIS = [
   {
+    api: "firestore.googleapis.com",
+    reason:
+      "Reads document data and writes embeddings back to Cloud Firestore.",
+  },
+  {
     api: "aiplatform.googleapis.com",
     reason:
       "This extension uses Vertex AI for embedding and vector search when configured.",

--- a/kits/speech-to-text/src/index.ts
+++ b/kits/speech-to-text/src/index.ts
@@ -40,6 +40,10 @@ const REQUIRED_ROLES: ReadonlyArray<Role> = [
 ];
 const REQUIRED_APIS = [
   {
+    api: "firestore.googleapis.com",
+    reason: "Writes transcription results to Cloud Firestore.",
+  },
+  {
     api: "speech.googleapis.com",
     reason: "Used for transcribing audio files with Cloud Speech-to-Text.",
   },


### PR DESCRIPTION
Reported in #3116 against `firestore-bundle-builder`, which returns an HTTP 500 `PERMISSION_DENIED` on a project where `firestore.googleapis.com` is disabled.

**What was broken.** No kit declared `firestore.googleapis.com`, so a functions deploy never enables it. `wantBackend.requiredAPIs` is populated only from `requiresAPI()` declarations, and the API is in neither the gen2 always-enabled set nor `STANDARD_APIS`. Most kits have a Firestore trigger, so `ensureTriggerRegions` looks the database up at deploy time and fails early with a usable message. Four kits use Firestore without a Firestore trigger (`firestore-bundle-builder`, `bigquery-firestore-export`, `delete-user-data`, `speech-to-text`), so nothing checked them and the failure landed at runtime.

**What changed.** Adds `firestore.googleapis.com` to `REQUIRED_APIS` in the 11 kits that use Firestore. `rtdb-limit-child-nodes` and `storage-resize-images` do not touch it and are unchanged. `firestore-genai-chatbot` is included: it never constructs a client, but it writes through the trigger event `DocumentReference`.

`firestore-incremental-capture` also moves off the narrow `firebase-functions/v2/options` import, since `requiresAPI` is only exported from the v2 barrel. The comment there said the barrel fails to load without `@firebase/app`; that does not reproduce on firebase-functions 7.3.2, verified by loading the compiled `lib/index.js` with `@firebase/app` unresolvable.

**Verification.** All 11 kits build and their suites pass. Added an assertion in `firestore-translate-text`, the one kit with an existing `requiresAPI` test harness, and confirmed it fails when the declaration is removed. The firebase-tools behaviour above comes from reading the installed 15.29.0 source, not from a live deploy.

**For the reviewer.** Enabling the API does not provision a Firestore database, so this does not by itself make a deploy succeed on a project that has none. It makes the dependency visible at install and turns a silent runtime 500 into an explicit declaration. Whether the CLI should also check for a database on non-triggered functions is a firebase-tools question, not addressed here.