### PR TITLE
fix(bigquery): preserve project on view updates

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/materializedViews/initializeLatestView.test.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/materializedViews/initializeLatestView.test.ts
@@ -80,5 +80,44 @@ describe("initializeLatestView", () => {
 
       expect(initializeLatestMaterializedView).not.toHaveBeenCalled();
     });
+
+    it("uses the BigQuery project when updating an existing view", async () => {
+      const originalProjectId = process.env.PROJECT_ID;
+      process.env.PROJECT_ID = "function-project";
+      const metadata = {
+        schema: {
+          fields: [{ name: "document_id" }, { name: "old_data" }],
+        },
+        view: { query: "SELECT FIRST_VALUE(data)" },
+      };
+      mockView.getMetadata.mockResolvedValueOnce([metadata]);
+
+      try {
+        await initializeLatestView({
+          bq: { projectId: "bigquery-project" } as any,
+          dataset: { id: "test_dataset" } as any,
+          view: mockView as any,
+          viewExists: true,
+          rawChangeLogTableName: "test_raw_table",
+          rawLatestViewName: "test_raw_view",
+          changeTrackerConfig: {
+            ...mockConfig,
+            useNewSnapshotQuerySyntax: true,
+          },
+        });
+
+        expect(mockView.setMetadata).toHaveBeenCalledWith(metadata);
+        expect(metadata.view.query).toContain(
+          "`bigquery-project.test_dataset.test_raw_table`"
+        );
+        expect(metadata.view.query).not.toContain("function-project");
+      } finally {
+        if (originalProjectId === undefined) {
+          delete process.env.PROJECT_ID;
+        } else {
+          process.env.PROJECT_ID = originalProjectId;
+        }
+      }
+    });
   });
 });

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/initializeLatestView.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/initializeLatestView.ts
@@ -104,6 +104,7 @@ export async function initializeLatestView({
         datasetId: config.datasetId,
         tableName: rawChangeLogTableName,
         schema,
+        bqProjectId: bq.projectId,
         useLegacyQuery: !config.useNewSnapshotQuerySyntax,
       });
 


### PR DESCRIPTION
## Changes

- Pass the BigQuery client's project ID when regenerating an existing snapshot view.
- Add regression coverage proving the configured BigQuery project wins over the function runtime project.

## Testing

- `npm run compile`
- `jest --runInBand src/__tests__/bigquery/materializedViews/initializeLatestView.test.ts`

Closes #3120