### PR TITLE
fix(firestore-bigquery-change-tracker): preserve BigQuery project on view updates, release 2.2.1

### DIFF
--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/CHANGELOG.md
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.1
+
+- Updating an existing `_raw_latest` view now builds the snapshot query with the configured BigQuery project. That path dropped `bqProjectId`, so the query fell back to `process.env.PROJECT_ID`, which is only set for extensions. On a kit or any other plain Cloud Function the view was written as `undefined.<dataset>.<table>` and the update failed.
+
 ## 2.2.0
 
 - Works on `firebase-admin` 14. 2.1.1 widened the range but the package still used the namespaced API (`admin.apps`, `admin.firestore.Timestamp`), which firebase-admin 14 removes, so it threw at import wherever it was resolved against admin 14. Every use is now the modular API from `firebase-admin/app` and `firebase-admin/firestore`, which works on 13 and 14 alike.

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/CHANGELOG.md
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.2.1
 
-- Updating an existing `_raw_latest` view now builds the snapshot query with the configured BigQuery project. That path dropped `bqProjectId`, so the query fell back to `process.env.PROJECT_ID`, which is only set for extensions. On a kit or any other plain Cloud Function the view was written as `undefined.<dataset>.<table>` and the update failed.
+- Updating an existing `_raw_latest` view now builds the snapshot query with the configured BigQuery project. That path dropped `bqProjectId`, so the query fell back to `process.env.PROJECT_ID`, which is only set for extensions. On a kit, or any caller that passes `bqProjectId` but does not set `PROJECT_ID`, the query referenced `undefined.<dataset>.<table>` and BigQuery rejected the update. For an extension whose `BIGQUERY_PROJECT_ID` differs from `PROJECT_ID`, the update previously built the view against the functions project instead of the BigQuery project.
 
 ## 2.2.0
 

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/package-lock.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@firebaseextensions/firestore-bigquery-change-tracker",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@firebaseextensions/firestore-bigquery-change-tracker",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/bigquery": "^7.6.0",

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
@@ -5,7 +5,7 @@
     "url": "git+https://github.com/firebase/extensions.git",
     "directory": "firestore-bigquery-export/firestore-bigquery-change-tracker"
   },
-  "version": "2.2.0",
+  "version": "2.2.1",
   "engines": {
     "node": ">=18"
   },

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/materializedViews/initializeLatestView.test.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/__tests__/bigquery/materializedViews/initializeLatestView.test.ts
@@ -80,5 +80,44 @@ describe("initializeLatestView", () => {
 
       expect(initializeLatestMaterializedView).not.toHaveBeenCalled();
     });
+
+    it("uses the BigQuery project when updating an existing view", async () => {
+      const originalProjectId = process.env.PROJECT_ID;
+      process.env.PROJECT_ID = "function-project";
+      const metadata = {
+        schema: {
+          fields: [{ name: "document_id" }, { name: "old_data" }],
+        },
+        view: { query: "SELECT FIRST_VALUE(data)" },
+      };
+      mockView.getMetadata.mockResolvedValueOnce([metadata]);
+
+      try {
+        await initializeLatestView({
+          bq: { projectId: "bigquery-project" } as any,
+          dataset: { id: "test_dataset" } as any,
+          view: mockView as any,
+          viewExists: true,
+          rawChangeLogTableName: "test_raw_table",
+          rawLatestViewName: "test_raw_view",
+          changeTrackerConfig: {
+            ...mockConfig,
+            useNewSnapshotQuerySyntax: true,
+          },
+        });
+
+        expect(mockView.setMetadata).toHaveBeenCalledWith(metadata);
+        expect(metadata.view.query).toContain(
+          "`bigquery-project.test_dataset.test_raw_table`"
+        );
+        expect(metadata.view.query).not.toContain("function-project");
+      } finally {
+        if (originalProjectId === undefined) {
+          delete process.env.PROJECT_ID;
+        } else {
+          process.env.PROJECT_ID = originalProjectId;
+        }
+      }
+    });
   });
 });

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/initializeLatestView.ts
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/src/bigquery/initializeLatestView.ts
@@ -104,6 +104,7 @@ export async function initializeLatestView({
         datasetId: config.datasetId,
         tableName: rawChangeLogTableName,
         schema,
+        bqProjectId: bq.projectId,
         useLegacyQuery: !config.useNewSnapshotQuerySyntax,
       });
 


### PR DESCRIPTION
Cherry-pick of da219826 from #3121 (Corie's fix, approved by Izaak) onto `next`, plus the 2.2.1 version bump and changelog entry. #3121 targets `kits`, but the tracker is published from `next`, so the fix never reached npm from there.

The bug: `initializeLatestView` builds the snapshot query for an existing `_raw_latest` view without `bqProjectId`, so `buildLatestSnapshotViewQuery` falls back to `process.env.PROJECT_ID`. That variable is only set for extensions. On a kit the view query became `undefined.<dataset>.<table>` and the `initBigQuerySync` task failed in `afterFirstDeploy`. The create path already passed the project. The fix passes `bq.projectId` on the update path too, matching the create path.

Tests: the materializedViews suites pass locally (20 tests), including the new one that sets `process.env.PROJECT_ID` to a decoy and asserts the query uses the BigQuery project. Not verified against a live redeploy.

After merge, dispatch `npm_publish_bq_scripts.yml` for 2.2.1, then regenerate the kit shrinkwrap in the stack so the rc pins it.

Fixes #3120
