### PR TITLE
fix(bigquery-firestore-export): write BigQuery TIME values as strings

### DIFF
--- a/kits/bigquery-firestore-export/CHANGELOG.md
+++ b/kits/bigquery-firestore-export/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Initial release of kit, see README for differences between the legacy extension and this kit
+- A BigQuery `TIME` column no longer crashes a run: its value is written to Firestore as the string BigQuery returned (`"10:30:00"`) rather than passed to `Timestamp.fromDate`, which threw and lost the whole run. This is a deliberate divergence from the legacy extension, which throws on the same line

--- a/kits/bigquery-firestore-export/README.md
+++ b/kits/bigquery-firestore-export/README.md
@@ -224,7 +224,21 @@ position, `{ "0": ..., "1": ... }`, because the conversion treated every
 non-scalar value as an object. The kit writes a real Firestore array instead.
 Anything reading those fields by numeric string key needs updating, and rows
 written before and after the change are not the same shape. Scalars, timestamps,
-dates, times, datetimes, bytes and geography values convert exactly as before.
+dates, datetimes, bytes and geography values convert exactly as before.
+
+### A TIME column is written as a string
+
+A `TIME` value arrives from BigQuery as `"10:30:00"`, and the extension passed it
+to `Timestamp.fromDate(new Date(...))`, which throws `Value for argument "seconds"
+is not a valid integer.` A run whose results included a `TIME` column therefore
+wrote nothing at all: no rows, no run document, no `latest`. The kit stores the
+string BigQuery returned instead, so the run completes.
+
+Firestore has no time-of-day type, and any `Timestamp` would have to invent a date
+to attach the time to. The string also keeps the microsecond precision a
+`Timestamp` cannot hold. This is the one type whose value differs from the
+extension, and no installed instance can have stored one, because the run crashed
+before the write.
 
 ### The scheduled query runs as a different service account
 

--- a/kits/bigquery-firestore-export/README.md
+++ b/kits/bigquery-firestore-export/README.md
@@ -236,9 +236,9 @@ string BigQuery returned instead, so the run completes.
 
 Firestore has no time-of-day type, and any `Timestamp` would have to invent a date
 to attach the time to. The string also keeps the microsecond precision a
-`Timestamp` cannot hold. This is the one type whose value differs from the
-extension, and no installed instance can have stored one, because the run crashed
-before the write.
+`Timestamp` cannot hold. This is the only scalar type whose value differs from
+the extension, and no installed instance can have stored one, because the run
+crashed before the write.
 
 ### The scheduled query runs as a different service account
 

--- a/kits/bigquery-firestore-export/src/helper.ts
+++ b/kits/bigquery-firestore-export/src/helper.ts
@@ -178,10 +178,12 @@ export function convertUnsupportedDataTypes(
     return row as FirestoreRowValue;
   }
 
+  // A TIME is a time of day with no date, so no Timestamp can hold it without
+  // inventing one. BigQuery's own "HH:MM:SS[.ffffff]" string is kept instead.
+  if (row instanceof BigQueryTime) return row.value;
   if (
     row instanceof BigQueryTimestamp ||
     row instanceof BigQueryDate ||
-    row instanceof BigQueryTime ||
     row instanceof BigQueryDatetime
   ) {
     return Timestamp.fromDate(new Date(row.value));

--- a/kits/bigquery-firestore-export/tests/helper-values.test.ts
+++ b/kits/bigquery-firestore-export/tests/helper-values.test.ts
@@ -110,10 +110,46 @@ describe("convertUnsupportedDataTypes", () => {
     );
   });
 
-  test("throws on a TIME value, which no Date can represent", () => {
-    expect(() =>
-      convertUnsupportedDataTypes({ time: new BigQueryTime("10:30:00") })
-    ).toThrow('Value for argument "seconds" is not a valid integer.');
+  // The strings here are the values a live query returns for
+  // TIME "10:30:00", TIME "10:30:00.123456" and TIME "00:00:00".
+  test("keeps a TIME value as the string BigQuery returned", () => {
+    expect(
+      convertUnsupportedDataTypes({
+        plain: new BigQueryTime("10:30:00"),
+        micros: new BigQueryTime("10:30:00.123456"),
+        midnight: new BigQueryTime("00:00:00"),
+      })
+    ).toEqual({
+      plain: "10:30:00",
+      micros: "10:30:00.123456",
+      midnight: "00:00:00",
+    });
+  });
+
+  test("keeps TIME values nested in arrays and structs", () => {
+    expect(
+      convertUnsupportedDataTypes({
+        times: [new BigQueryTime("01:02:03"), new BigQueryTime("04:05:06")],
+        outer: { inner: new BigQueryTime("07:08:09") },
+      })
+    ).toEqual({
+      times: ["01:02:03", "04:05:06"],
+      outer: { inner: "07:08:09" },
+    });
+  });
+
+  test("still converts the other temporal types alongside a TIME", () => {
+    const converted = convertUnsupportedDataTypes({
+      time: new BigQueryTime("10:30:00"),
+      timestamp: new BigQueryTimestamp("2023-01-15T10:30:00.000Z"),
+      date: new BigQueryDate("2023-01-15"),
+      datetime: new BigQueryDatetime("2023-01-15T10:30:00"),
+    });
+
+    expect(converted.time).toBe("10:30:00");
+    expect(converted.timestamp).toBeInstanceOf(Timestamp);
+    expect(converted.date).toBeInstanceOf(Timestamp);
+    expect(converted.datetime).toBeInstanceOf(Timestamp);
   });
 
   test("converts a plain Date to a Firestore Timestamp", () => {


### PR DESCRIPTION
Fixes #3068.

**What was broken.** A BigQuery `TIME` column arrives as `{ value: "10:30:00" }`, so `new Date(row.value)` is invalid and `Timestamp.fromDate` throws `Value for argument "seconds" is not a valid integer.` The throw happens inside the write loop in `writeRunResultsToFirestore`, before any `add()` promise exists, so the whole run is lost: no output rows, no run document, no `latest`.

**What changed.** `convertUnsupportedDataTypes` returns the string BigQuery gave us for a `TIME`, the same way it already does for `Geography`. Firestore has no time-of-day type, so any `Timestamp` would have to invent a date to hold the time, and the string keeps the microsecond precision a `Timestamp` cannot. `TIMESTAMP`, `DATE` and `DATETIME` are untouched.

**How it was verified.** Against a live BigQuery table with `TIME`, fractional-second `TIME`, `NULL`, arrays and structs, running `writeRunResultsToFirestore` into the Firestore emulator: before, it threw and wrote nothing; after, all three rows land with the times as strings. Unit tests cover the plain, microsecond, midnight, nested and null cases.

This diverges from the extension, which throws on the same line, so no installed instance can have stored a `TIME` value. Documented in the README and CHANGELOG.
