### PR TITLE
chore(kits): align firebase-functions on 7.3.3-rc.1

### DIFF
--- a/kits/bigquery-firestore-export/npm-shrinkwrap.json
+++ b/kits/bigquery-firestore-export/npm-shrinkwrap.json
@@ -14,7 +14,7 @@
         "@google-cloud/bigquery-data-transfer": "^5.0.1",
         "@google-cloud/pubsub": "^4.11.0",
         "firebase-admin": "^14.1.0",
-        "firebase-functions": "^7.3.3-rc.0"
+        "firebase-functions": "^7.3.3-rc.1"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -2318,9 +2318,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "7.3.3-rc.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.0.tgz",
-      "integrity": "sha512-yMVax5196sPp150ySihdXrhWtepeQ0yRmSBl3GoIogzy6DFoEi5CQbvMuFjTPz65MacRrNiJ55HS3oIlHUO/wg==",
+      "version": "7.3.3-rc.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.1.tgz",
+      "integrity": "sha512-jD+Z8PYQ/iWE0bLJ0lb+od6p1wW9+8Aj7mjhd6ZIRrPYVqrEYpvtGKTC273rteMUKBPHStcOBcf1b8VfrNvbaA==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",

--- a/kits/bigquery-firestore-export/package.json
+++ b/kits/bigquery-firestore-export/package.json
@@ -37,7 +37,7 @@
     "@google-cloud/bigquery-data-transfer": "^5.0.1",
     "@google-cloud/pubsub": "^4.11.0",
     "firebase-admin": "^14.1.0",
-    "firebase-functions": "^7.3.3-rc.0"
+    "firebase-functions": "^7.3.3-rc.1"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/kits/delete-user-data/npm-shrinkwrap.json
+++ b/kits/delete-user-data/npm-shrinkwrap.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@google-cloud/pubsub": "^4.3.3",
         "firebase-admin": "^13.2.0",
-        "firebase-functions": "^7.3.3-rc.0",
+        "firebase-functions": "^7.3.3-rc.1",
         "lodash.chunk": "^4.2.0"
       },
       "devDependencies": {
@@ -1882,9 +1882,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "7.3.3-rc.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.0.tgz",
-      "integrity": "sha512-yMVax5196sPp150ySihdXrhWtepeQ0yRmSBl3GoIogzy6DFoEi5CQbvMuFjTPz65MacRrNiJ55HS3oIlHUO/wg==",
+      "version": "7.3.3-rc.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.1.tgz",
+      "integrity": "sha512-jD+Z8PYQ/iWE0bLJ0lb+od6p1wW9+8Aj7mjhd6ZIRrPYVqrEYpvtGKTC273rteMUKBPHStcOBcf1b8VfrNvbaA==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",

--- a/kits/delete-user-data/package.json
+++ b/kits/delete-user-data/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@google-cloud/pubsub": "^4.3.3",
     "firebase-admin": "^13.2.0",
-    "firebase-functions": "^7.3.3-rc.0",
+    "firebase-functions": "^7.3.3-rc.1",
     "lodash.chunk": "^4.2.0"
   },
   "devDependencies": {

--- a/kits/firestore-bundle-builder/npm-shrinkwrap.json
+++ b/kits/firestore-bundle-builder/npm-shrinkwrap.json
@@ -12,7 +12,7 @@
         "@google-cloud/firestore": "^7.11.0",
         "@google-cloud/storage": "^7.19.0",
         "firebase-admin": "^13.2.0",
-        "firebase-functions": "^7.3.3-rc.0"
+        "firebase-functions": "^7.3.3-rc.1"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -1776,9 +1776,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "7.3.3-rc.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.0.tgz",
-      "integrity": "sha512-yMVax5196sPp150ySihdXrhWtepeQ0yRmSBl3GoIogzy6DFoEi5CQbvMuFjTPz65MacRrNiJ55HS3oIlHUO/wg==",
+      "version": "7.3.3-rc.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.1.tgz",
+      "integrity": "sha512-jD+Z8PYQ/iWE0bLJ0lb+od6p1wW9+8Aj7mjhd6ZIRrPYVqrEYpvtGKTC273rteMUKBPHStcOBcf1b8VfrNvbaA==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",

--- a/kits/firestore-bundle-builder/package.json
+++ b/kits/firestore-bundle-builder/package.json
@@ -34,7 +34,7 @@
     "@google-cloud/firestore": "^7.11.0",
     "@google-cloud/storage": "^7.19.0",
     "firebase-admin": "^13.2.0",
-    "firebase-functions": "^7.3.3-rc.0"
+    "firebase-functions": "^7.3.3-rc.1"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/kits/firestore-counter/npm-shrinkwrap.json
+++ b/kits/firestore-counter/npm-shrinkwrap.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "deep-equal": "^1.0.1",
         "firebase-admin": "^14.1.0",
-        "firebase-functions": "^7.3.3-rc.0",
+        "firebase-functions": "^7.3.3-rc.1",
         "uuid": "^11.0.5"
       },
       "devDependencies": {
@@ -1973,9 +1973,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "7.3.3-rc.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.0.tgz",
-      "integrity": "sha512-yMVax5196sPp150ySihdXrhWtepeQ0yRmSBl3GoIogzy6DFoEi5CQbvMuFjTPz65MacRrNiJ55HS3oIlHUO/wg==",
+      "version": "7.3.3-rc.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.1.tgz",
+      "integrity": "sha512-jD+Z8PYQ/iWE0bLJ0lb+od6p1wW9+8Aj7mjhd6ZIRrPYVqrEYpvtGKTC273rteMUKBPHStcOBcf1b8VfrNvbaA==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",

--- a/kits/firestore-counter/package.json
+++ b/kits/firestore-counter/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "deep-equal": "^1.0.1",
     "firebase-admin": "^14.1.0",
-    "firebase-functions": "^7.3.3-rc.0",
+    "firebase-functions": "^7.3.3-rc.1",
     "uuid": "^11.0.5"
   },
   "devDependencies": {

--- a/kits/firestore-genai-chatbot/npm-shrinkwrap.json
+++ b/kits/firestore-genai-chatbot/npm-shrinkwrap.json
@@ -14,7 +14,7 @@
         "@google/genai": "^1.52.0",
         "@google/generative-ai": "^0.1.1",
         "firebase-admin": "^14.1.0",
-        "firebase-functions": "^7.3.3-rc.0",
+        "firebase-functions": "^7.3.3-rc.1",
         "genkit": "^1.24.0",
         "google-gax": "^4.3.2",
         "zod": "^3.23.0"
@@ -4861,9 +4861,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "7.3.3-rc.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.0.tgz",
-      "integrity": "sha512-yMVax5196sPp150ySihdXrhWtepeQ0yRmSBl3GoIogzy6DFoEi5CQbvMuFjTPz65MacRrNiJ55HS3oIlHUO/wg==",
+      "version": "7.3.3-rc.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.1.tgz",
+      "integrity": "sha512-jD+Z8PYQ/iWE0bLJ0lb+od6p1wW9+8Aj7mjhd6ZIRrPYVqrEYpvtGKTC273rteMUKBPHStcOBcf1b8VfrNvbaA==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",

--- a/kits/firestore-genai-chatbot/package.json
+++ b/kits/firestore-genai-chatbot/package.json
@@ -37,7 +37,7 @@
     "@google/genai": "^1.52.0",
     "@google/generative-ai": "^0.1.1",
     "firebase-admin": "^14.1.0",
-    "firebase-functions": "^7.3.3-rc.0",
+    "firebase-functions": "^7.3.3-rc.1",
     "genkit": "^1.24.0",
     "google-gax": "^4.3.2",
     "zod": "^3.23.0"

--- a/kits/firestore-incremental-capture/CHANGELOG.md
+++ b/kits/firestore-incremental-capture/CHANGELOG.md
@@ -1,4 +1,4 @@
-- chore: run on firebase-functions ^7.3.3-rc.0, the same release candidate as the other kits
+- chore: run on firebase-functions ^7.3.3-rc.1, the same release candidate as the other kits
 - The instance id now comes from `FIREBASE_KIT_INSTANCE_ID`, which the Firebase CLI (15.27.0 or later) provides to each kit instance; `INSTANCE_ID` is no longer a configuration parameter
 - Fixed task dispatch failing with "Queue does not exist": the kit prefixed queue names with `kit-<instance id>-` itself, which the Admin SDK then prefixed again from `FIREBASE_KIT_INSTANCE_ID`. Changelog rows never reached BigQuery and restorations never started
 - Full implementation, replacing the skeleton package: Firestore capture to a BigQuery changelog, Dataflow-based point-in-time restoration, and first-deploy provisioning. See the README for differences between the legacy extension and this kit.

--- a/kits/firestore-incremental-capture/npm-shrinkwrap.json
+++ b/kits/firestore-incremental-capture/npm-shrinkwrap.json
@@ -12,7 +12,7 @@
         "@google-cloud/bigquery": "^7.6.0",
         "@google-cloud/dataflow": "^3.2.0",
         "firebase-admin": "^14.2.0",
-        "firebase-functions": "^7.3.3-rc.0"
+        "firebase-functions": "^7.3.3-rc.1"
       },
       "devDependencies": {
         "@types/node": "^26.2.0",
@@ -2828,9 +2828,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "7.3.3-rc.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.0.tgz",
-      "integrity": "sha512-yMVax5196sPp150ySihdXrhWtepeQ0yRmSBl3GoIogzy6DFoEi5CQbvMuFjTPz65MacRrNiJ55HS3oIlHUO/wg==",
+      "version": "7.3.3-rc.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.1.tgz",
+      "integrity": "sha512-jD+Z8PYQ/iWE0bLJ0lb+od6p1wW9+8Aj7mjhd6ZIRrPYVqrEYpvtGKTC273rteMUKBPHStcOBcf1b8VfrNvbaA==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",

--- a/kits/firestore-incremental-capture/package.json
+++ b/kits/firestore-incremental-capture/package.json
@@ -35,7 +35,7 @@
     "@google-cloud/bigquery": "^7.6.0",
     "@google-cloud/dataflow": "^3.2.0",
     "firebase-admin": "^14.2.0",
-    "firebase-functions": "^7.3.3-rc.0"
+    "firebase-functions": "^7.3.3-rc.1"
   },
   "devDependencies": {
     "@types/node": "^26.2.0",

--- a/kits/firestore-send-email/CHANGELOG.md
+++ b/kits/firestore-send-email/CHANGELOG.md
@@ -1,5 +1,5 @@
 - fix: restore the extension's `Yes` / `No` option labels on the `OAUTH_SECURE` deploy-time prompt. The stored values are unchanged (`true`/`false`), so this is a label-only fix and no `.env` from an earlier deploy needs editing.
-- chore: run on firebase-functions ^7.3.3-rc.0, the same release candidate as the other kits
+- chore: run on firebase-functions ^7.3.3-rc.1, the same release candidate as the other kits
 - fix: map `DATABASE_REGION` to a valid Cloud Run region before using it as the function region. Firestore multi-region locations (`nam5`, `nam7`) now deploy the function to `us-central1` and `eur3` to `europe-west1` instead of failing the deploy; regional locations pass through unchanged. The value is matched case-insensitively. With the parameter unset or empty the function declares no region and the Firebase CLI resolves one at deploy time.
 - Initial release of kit, see README for differences between the legacy extension and this kit
 - SendGrid sends now work with `AUTH_TYPE=OAuth2`: the `SMTP_PASSWORD` secret is no longer dropped from the config under OAuth2, so the SendGrid transport receives its API key

--- a/kits/firestore-translate-text/npm-shrinkwrap.json
+++ b/kits/firestore-translate-text/npm-shrinkwrap.json
@@ -12,7 +12,7 @@
         "@genkit-ai/google-genai": "^1.31.0",
         "@google-cloud/translate": "^8.2.0",
         "firebase-admin": "^14.1.0",
-        "firebase-functions": "^7.3.3-rc.0",
+        "firebase-functions": "^7.3.3-rc.1",
         "genkit": "^1.31.0"
       },
       "devDependencies": {
@@ -5145,9 +5145,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "7.3.3-rc.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.0.tgz",
-      "integrity": "sha512-yMVax5196sPp150ySihdXrhWtepeQ0yRmSBl3GoIogzy6DFoEi5CQbvMuFjTPz65MacRrNiJ55HS3oIlHUO/wg==",
+      "version": "7.3.3-rc.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.1.tgz",
+      "integrity": "sha512-jD+Z8PYQ/iWE0bLJ0lb+od6p1wW9+8Aj7mjhd6ZIRrPYVqrEYpvtGKTC273rteMUKBPHStcOBcf1b8VfrNvbaA==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",

--- a/kits/firestore-translate-text/package.json
+++ b/kits/firestore-translate-text/package.json
@@ -34,7 +34,7 @@
     "@genkit-ai/google-genai": "^1.31.0",
     "@google-cloud/translate": "^8.2.0",
     "firebase-admin": "^14.1.0",
-    "firebase-functions": "^7.3.3-rc.0",
+    "firebase-functions": "^7.3.3-rc.1",
     "genkit": "^1.31.0"
   },
   "devDependencies": {

--- a/kits/firestore-vector-search/CHANGELOG.md
+++ b/kits/firestore-vector-search/CHANGELOG.md
@@ -1,4 +1,4 @@
-- chore: run on firebase-functions ^7.3.3-rc.0, the same release candidate as the other kits
+- chore: run on firebase-functions ^7.3.3-rc.1, the same release candidate as the other kits
 - The instance id now comes from `FIREBASE_KIT_INSTANCE_ID`, which the Firebase CLI (15.27.0 or later) provides to each kit instance; `INSTANCE_ID` is no longer a configuration parameter
 - fix: restore the extension's `Yes` / `No` option labels on the `DO_BACKFILL` and `UPDATE_ON_CONFIGURE` deploy-time prompts. The stored values are unchanged (`true`/`false`), so this is a label-only fix and no `.env` from an earlier deploy needs editing.
 - Fixed the backfill and update task dispatch failing with "Queue does not exist": the kit prefixed queue names with `kit-<instance id>-` itself, which the Admin SDK then prefixed again from `FIREBASE_KIT_INSTANCE_ID`. The four `*_QUEUE_NAME` settings now take the deployed function name without that prefix

--- a/kits/firestore-vector-search/npm-shrinkwrap.json
+++ b/kits/firestore-vector-search/npm-shrinkwrap.json
@@ -13,7 +13,7 @@
         "@google-cloud/firestore": "^7.6.0",
         "@google-cloud/vertexai": "^0.1.3",
         "firebase-admin": "^14.1.0",
-        "firebase-functions": "^7.3.3-rc.0",
+        "firebase-functions": "^7.3.3-rc.1",
         "genkit": "^1.27.0",
         "openai": "^4.20.1",
         "zod": "^3.22.4"
@@ -5220,9 +5220,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "7.3.3-rc.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.0.tgz",
-      "integrity": "sha512-yMVax5196sPp150ySihdXrhWtepeQ0yRmSBl3GoIogzy6DFoEi5CQbvMuFjTPz65MacRrNiJ55HS3oIlHUO/wg==",
+      "version": "7.3.3-rc.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.1.tgz",
+      "integrity": "sha512-jD+Z8PYQ/iWE0bLJ0lb+od6p1wW9+8Aj7mjhd6ZIRrPYVqrEYpvtGKTC273rteMUKBPHStcOBcf1b8VfrNvbaA==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",

--- a/kits/firestore-vector-search/package.json
+++ b/kits/firestore-vector-search/package.json
@@ -35,7 +35,7 @@
     "@google-cloud/firestore": "^7.6.0",
     "@google-cloud/vertexai": "^0.1.3",
     "firebase-admin": "^14.1.0",
-    "firebase-functions": "^7.3.3-rc.0",
+    "firebase-functions": "^7.3.3-rc.1",
     "genkit": "^1.27.0",
     "openai": "^4.20.1",
     "zod": "^3.22.4"

--- a/kits/rtdb-limit-child-nodes/npm-shrinkwrap.json
+++ b/kits/rtdb-limit-child-nodes/npm-shrinkwrap.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "firebase-admin": "^14.1.0",
-        "firebase-functions": "^7.3.3-rc.0"
+        "firebase-functions": "^7.3.3-rc.1"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -1891,9 +1891,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "7.3.3-rc.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.0.tgz",
-      "integrity": "sha512-yMVax5196sPp150ySihdXrhWtepeQ0yRmSBl3GoIogzy6DFoEi5CQbvMuFjTPz65MacRrNiJ55HS3oIlHUO/wg==",
+      "version": "7.3.3-rc.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.1.tgz",
+      "integrity": "sha512-jD+Z8PYQ/iWE0bLJ0lb+od6p1wW9+8Aj7mjhd6ZIRrPYVqrEYpvtGKTC273rteMUKBPHStcOBcf1b8VfrNvbaA==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",

--- a/kits/rtdb-limit-child-nodes/package.json
+++ b/kits/rtdb-limit-child-nodes/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "firebase-admin": "^14.1.0",
-    "firebase-functions": "^7.3.3-rc.0"
+    "firebase-functions": "^7.3.3-rc.1"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/kits/speech-to-text/npm-shrinkwrap.json
+++ b/kits/speech-to-text/npm-shrinkwrap.json
@@ -12,7 +12,7 @@
         "@google-cloud/speech": "^7.1.0",
         "@google-cloud/storage": "^7.0.0",
         "firebase-admin": "^14.1.0",
-        "firebase-functions": "^7.3.3-rc.0",
+        "firebase-functions": "^7.3.3-rc.1",
         "fluent-ffmpeg": "^2.1.3",
         "mkdirp": "^3.0.1"
       },
@@ -2013,9 +2013,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "7.3.3-rc.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.0.tgz",
-      "integrity": "sha512-yMVax5196sPp150ySihdXrhWtepeQ0yRmSBl3GoIogzy6DFoEi5CQbvMuFjTPz65MacRrNiJ55HS3oIlHUO/wg==",
+      "version": "7.3.3-rc.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.3-rc.1.tgz",
+      "integrity": "sha512-jD+Z8PYQ/iWE0bLJ0lb+od6p1wW9+8Aj7mjhd6ZIRrPYVqrEYpvtGKTC273rteMUKBPHStcOBcf1b8VfrNvbaA==",
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.5",

--- a/kits/speech-to-text/package.json
+++ b/kits/speech-to-text/package.json
@@ -34,7 +34,7 @@
     "@google-cloud/speech": "^7.1.0",
     "@google-cloud/storage": "^7.0.0",
     "firebase-admin": "^14.1.0",
-    "firebase-functions": "^7.3.3-rc.0",
+    "firebase-functions": "^7.3.3-rc.1",
     "fluent-ffmpeg": "^2.1.3",
     "mkdirp": "^3.0.1"
   },


### PR DESCRIPTION
## Changes

- 11 kits: `firebase-functions` `^7.3.3-rc.0` -> `^7.3.3-rc.1` in `package.json` and `npm-shrinkwrap.json`.
- `kits/firestore-bigquery-export` and `kits/storage-resize-images` unchanged; already on `^7.3.3-rc.1`.

## Why rc.1 and not 7.3.2

`7.3.3-rc.1` is the newest published `firebase-functions` (npm `next`). The npm `latest` tag is `7.3.2`, older than the rc line every kit already uses, so moving there would be a downgrade and would revert the rc pins `release-kit.yaml` applies via `use_firebase_functions_rc`.

## Risk

`rc.0` -> `rc.1` changes no transitive requirements. Comparing the two shrinkwrap entries already on this branch, `dependencies`, `peerDependencies`, `peerDependenciesMeta`, `engines`, `bin` and `license` are identical. Every lockfile diff is therefore limited to `version`, `resolved` and `integrity`, and the integrity matches the value already committed for the two kits on rc.1.

## Verification

`npm ci && npm run build && npm test` pass locally for all 11 changed kits. Emulator suites left to CI.

The root `pnpm-lock.yaml` is not touched here; it is stale against `kits` independently of this change and is refreshed separately.