### PR TITLE
chore(kits): refresh the root pnpm lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         version: 29.5.0
       codecov:
         specifier: ^3.8.1
-        version: 3.8.3(encoding@0.1.13)
+        version: 3.8.3(encoding@0.1.13)(supports-color@9.4.0)
       concurrently:
         specifier: ^7.2.1
         version: 7.6.0
@@ -21,10 +21,10 @@ importers:
         version: 7.0.4
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@26.2.0)
+        version: 29.7.0(@types/node@26.2.0)(supports-color@9.4.0)
       lerna:
         specifier: ^3.4.3
-        version: 3.22.1(@octokit/core@7.0.7)(encoding@0.1.13)
+        version: 3.22.1(@octokit/core@7.0.7)(encoding@0.1.13)(supports-color@9.4.0)
       lint-staged:
         specifier: ^12.4.0
         version: 12.5.0
@@ -33,7 +33,7 @@ importers:
         version: 2.8.8
       ts-jest:
         specifier: 29.4.11
-        version: 29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@26.2.0))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@7.29.7(supports-color@9.4.0))(@jest/transform@29.7.0(supports-color@9.4.0))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@9.4.0))(supports-color@9.4.0))(esbuild@0.28.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@26.2.0)(supports-color@9.4.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -45,20 +45,23 @@ importers:
         version: 0.16.0
       "@google-cloud/bigquery":
         specifier: ^8.3.1
-        version: 8.3.1
+        version: 8.3.1(supports-color@9.4.0)
       "@google-cloud/bigquery-data-transfer":
         specifier: ^5.0.1
-        version: 5.1.3
+        version: 5.1.3(supports-color@9.4.0)
       "@google-cloud/pubsub":
         specifier: ^4.11.0
-        version: 4.11.0(encoding@0.1.13)
+        version: 4.11.0(encoding@0.1.13)(supports-color@9.4.0)
       firebase-admin:
         specifier: ^14.1.0
-        version: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)
+        version: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
       firebase-functions:
-        specifier: 7.3.2
-        version: 7.3.2(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))
+        specifier: ^7.3.3-rc.1
+        version: 7.3.3-rc.1(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
     devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(yaml@2.9.0))
@@ -67,41 +70,41 @@ importers:
     dependencies:
       "@google-cloud/pubsub":
         specifier: ^4.3.3
-        version: 4.11.0(encoding@0.1.13)
+        version: 4.11.0(encoding@0.1.13)(supports-color@9.4.0)
       firebase-admin:
         specifier: ^13.2.0
-        version: 13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)
+        version: 13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
       firebase-functions:
-        specifier: 7.3.2
-        version: 7.3.2(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13))
+        specifier: ^7.3.3-rc.1
+        version: 7.3.3-rc.1(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
       lodash.chunk:
         specifier: ^4.2.0
         version: 4.2.0
-      node-fetch:
-        specifier: ^2.6.2
-        version: 2.7.0(encoding@0.1.13)
     devDependencies:
       "@types/lodash.chunk":
         specifier: ^4.2.7
         version: 4.2.9
-      "@types/node-fetch":
-        specifier: ^2.6.2
-        version: 2.6.13
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(yaml@2.9.0))
 
   kits/firestore-bigquery-export:
     dependencies:
       "@firebaseextensions/firestore-bigquery-change-tracker":
-        specifier: ^2.0.4
-        version: 2.0.4(@firebase/app@0.16.0)(encoding@0.1.13)
+        specifier: ^2.2.1
+        version: 2.2.1(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
       "@google-cloud/bigquery":
         specifier: ^7.6.0
-        version: 7.9.4(encoding@0.1.13)
+        version: 7.9.4(encoding@0.1.13)(supports-color@9.4.0)
       firebase-admin:
-        specifier: ^14.1.0
-        version: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)
+        specifier: ^14.2.0
+        version: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
       firebase-functions:
-        specifier: 7.3.2
-        version: 7.3.2(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))
+        specifier: ^7.3.3-rc.1
+        version: 7.3.3-rc.1(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
       generate-schema:
         specifier: ^2.6.0
         version: 2.6.0
@@ -112,25 +115,31 @@ importers:
       "@types/lodash":
         specifier: ^4.17.0
         version: 4.17.25
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7(@types/node@26.2.0)(yaml@2.9.0)
+        version: 3.2.7(@types/node@26.2.0)(supports-color@9.4.0)(yaml@2.9.0)
 
   kits/firestore-bundle-builder:
     dependencies:
       "@google-cloud/firestore":
         specifier: ^7.11.0
-        version: 7.11.6(encoding@0.1.13)
+        version: 7.11.6(encoding@0.1.13)(supports-color@9.4.0)
       "@google-cloud/storage":
         specifier: ^7.19.0
-        version: 7.22.0(encoding@0.1.13)
+        version: 7.22.0(encoding@0.1.13)(supports-color@9.4.0)
       firebase-admin:
         specifier: ^13.2.0
-        version: 13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)
+        version: 13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
       firebase-functions:
-        specifier: 7.3.2
-        version: 7.3.2(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13))
+        specifier: ^7.3.3-rc.1
+        version: 7.3.3-rc.1(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
     devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(yaml@2.9.0))
@@ -142,10 +151,10 @@ importers:
         version: 1.1.2
       firebase-admin:
         specifier: ^14.1.0
-        version: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)
+        version: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
       firebase-functions:
-        specifier: 7.3.2
-        version: 7.3.2(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))
+        specifier: ^7.3.3-rc.1
+        version: 7.3.3-rc.1(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
       uuid:
         specifier: ^11.0.5
         version: 11.1.1
@@ -153,54 +162,86 @@ importers:
       "@types/deep-equal":
         specifier: ^1.0.1
         version: 1.0.4
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(yaml@2.9.0))
 
   kits/firestore-genai-chatbot:
     dependencies:
       "@genkit-ai/firebase":
         specifier: ^1.24.0
-        version: 1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))
+        version: 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)
       "@genkit-ai/google-genai":
         specifier: ^1.24.0
-        version: 1.41.0(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))
-      "@google-cloud/vertexai":
-        specifier: ^1.1.0
-        version: 1.12.0(encoding@0.1.13)
+        version: 1.41.0(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)
+      "@google/genai":
+        specifier: ^1.52.0
+        version: 1.52.0(supports-color@9.4.0)
       "@google/generative-ai":
         specifier: ^0.1.1
         version: 0.1.3
       firebase-admin:
         specifier: ^14.1.0
-        version: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)
+        version: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
       firebase-functions:
-        specifier: 7.3.2
-        version: 7.3.2(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))
+        specifier: ^7.3.3-rc.1
+        version: 7.3.3-rc.1(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
       genkit:
         specifier: ^1.24.0
-        version: 1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))
+        version: 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
       google-gax:
         specifier: ^4.3.2
-        version: 4.6.1(encoding@0.1.13)
+        version: 4.6.1(encoding@0.1.13)(supports-color@9.4.0)
       zod:
         specifier: ^3.23.0
         version: 3.25.76
     devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(yaml@2.9.0))
 
-  kits/firestore-incremental-capture: {}
+  kits/firestore-incremental-capture:
+    dependencies:
+      "@google-cloud/bigquery":
+        specifier: ^7.6.0
+        version: 7.9.4(encoding@0.1.13)(supports-color@9.4.0)
+      "@google-cloud/dataflow":
+        specifier: ^3.2.0
+        version: 3.3.0(encoding@0.1.13)(supports-color@9.4.0)
+      firebase-admin:
+        specifier: ^14.2.0
+        version: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
+      firebase-functions:
+        specifier: ^7.3.3-rc.1
+        version: 7.3.3-rc.1(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
+    devDependencies:
+      "@types/node":
+        specifier: ^26.2.0
+        version: 26.2.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/node@26.2.0)(supports-color@9.4.0)(yaml@2.9.0)
 
   kits/firestore-send-email:
     dependencies:
       "@sendgrid/mail":
         specifier: ^8.1.4
-        version: 8.1.6
+        version: 8.1.6(debug@4.4.3(supports-color@9.4.0))(supports-color@9.4.0)
       firebase-admin:
         specifier: ^14.1.0
-        version: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)
+        version: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
       firebase-functions:
-        specifier: 7.3.2
-        version: 7.3.2(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))
+        specifier: ^7.3.3-rc.1
+        version: 7.3.3-rc.1(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
       handlebars:
         specifier: ^4.7.8
         version: 4.7.9
@@ -211,6 +252,9 @@ importers:
         specifier: ^3.25.76
         version: 3.25.76
     devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(yaml@2.9.0))
@@ -219,56 +263,73 @@ importers:
     dependencies:
       "@genkit-ai/google-genai":
         specifier: ^1.31.0
-        version: 1.41.0(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))
+        version: 1.41.0(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)
       "@google-cloud/translate":
         specifier: ^8.2.0
-        version: 8.5.1(encoding@0.1.13)
+        version: 8.5.1(encoding@0.1.13)(supports-color@9.4.0)
       firebase-admin:
         specifier: ^14.1.0
-        version: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)
+        version: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
       firebase-functions:
-        specifier: 7.3.2
-        version: 7.3.2(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))
+        specifier: ^7.3.3-rc.1
+        version: 7.3.3-rc.1(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
       genkit:
         specifier: ^1.31.0
-        version: 1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))
+        version: 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(yaml@2.9.0))
 
   kits/firestore-vector-search:
     dependencies:
       "@genkit-ai/google-genai":
         specifier: ^1.27.0
-        version: 1.41.0(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))
+        version: 1.41.0(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)
       "@google-cloud/firestore":
         specifier: ^7.6.0
-        version: 7.11.6(encoding@0.1.13)
+        version: 7.11.6(encoding@0.1.13)(supports-color@9.4.0)
       "@google-cloud/vertexai":
         specifier: ^0.1.3
-        version: 0.1.3(encoding@0.1.13)
+        version: 0.1.3(encoding@0.1.13)(supports-color@9.4.0)
       firebase-admin:
         specifier: ^14.1.0
-        version: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)
+        version: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
       firebase-functions:
-        specifier: 7.3.2
-        version: 7.3.2(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))
+        specifier: ^7.3.3-rc.1
+        version: 7.3.3-rc.1(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
       genkit:
         specifier: ^1.27.0
-        version: 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))
+        version: 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
       openai:
         specifier: ^4.20.1
         version: 4.104.0(encoding@0.1.13)(ws@8.21.3)(zod@3.25.76)
       zod:
         specifier: ^3.22.4
         version: 3.25.76
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(yaml@2.9.0))
 
   kits/rtdb-limit-child-nodes:
     dependencies:
       firebase-admin:
         specifier: ^14.1.0
-        version: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)
+        version: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
       firebase-functions:
-        specifier: 7.3.2
-        version: 7.3.2(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))
+        specifier: ^7.3.3-rc.1
+        version: 7.3.3-rc.1(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
     devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(yaml@2.9.0))
@@ -277,16 +338,16 @@ importers:
     dependencies:
       "@google-cloud/speech":
         specifier: ^7.1.0
-        version: 7.5.0
+        version: 7.5.0(supports-color@9.4.0)
       "@google-cloud/storage":
         specifier: ^7.0.0
-        version: 7.22.0(encoding@0.1.13)
+        version: 7.22.0(encoding@0.1.13)(supports-color@9.4.0)
       firebase-admin:
         specifier: ^14.1.0
-        version: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)
+        version: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
       firebase-functions:
-        specifier: 7.3.2
-        version: 7.3.2(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))
+        specifier: ^7.3.3-rc.1
+        version: 7.3.3-rc.1(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
       fluent-ffmpeg:
         specifier: ^2.1.3
         version: 2.1.3
@@ -297,6 +358,9 @@ importers:
       "@types/fluent-ffmpeg":
         specifier: ^2.1.27
         version: 2.1.28
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(yaml@2.9.0))
@@ -305,19 +369,19 @@ importers:
     dependencies:
       "@genkit-ai/vertexai":
         specifier: ^1.2.0
-        version: 1.41.0(@firebase/app@0.16.0)(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)))(ws@8.21.3)(zod@3.25.76)
+        version: 1.41.0(@firebase/app@0.16.0)(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)(ws@8.21.3)(zod@3.25.76)
       "@google-cloud/storage":
         specifier: ^7.21.0
-        version: 7.22.0(encoding@0.1.13)
+        version: 7.22.0(encoding@0.1.13)(supports-color@9.4.0)
       firebase-admin:
         specifier: ^13.2.0
-        version: 13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)
+        version: 13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
       firebase-functions:
-        specifier: 7.3.2
-        version: 7.3.2(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13))
+        specifier: ^7.3.3-rc.1
+        version: 7.3.3-rc.1(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
       genkit:
         specifier: ^1.2.0
-        version: 1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13))
+        version: 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
       mkdirp:
         specifier: ^3.0.1
         version: 3.0.1
@@ -330,6 +394,13 @@ importers:
       uuid:
         specifier: ^11.0.5
         version: 11.1.1
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(vite@7.3.6(@types/node@26.2.0)(yaml@2.9.0))
 
 packages:
   "@anthropic-ai/sdk@0.90.0":
@@ -1002,11 +1073,12 @@ packages:
       }
     engines: { node: ">=20.0.0" }
 
-  "@firebaseextensions/firestore-bigquery-change-tracker@2.0.4":
+  "@firebaseextensions/firestore-bigquery-change-tracker@2.2.1":
     resolution:
       {
-        integrity: sha512-62iCf9hCzav8j4HxOPg94fVTDjO00CaoWQcQduq2+I2YNhPgRASXQCPcvJM/NuSdYqq/FUW/zbwtItn0K8Q4og==,
+        integrity: sha512-hsimLUhMYEYsYUTUp8eaEM2JuurJGv8xbCvT+yWbmNEPe77pNVS1Yixe785xMFRkmDWk4dofdFW8Sb749r0x8g==,
       }
+    engines: { node: ">=18" }
 
   "@genkit-ai/ai@1.41.0":
     resolution:
@@ -1099,6 +1171,13 @@ packages:
         integrity: sha512-Ohjxjvusr65+SiEVBrilpyn1ir9CM8ZqWjcf7bA8ph1GCunxI6bbwtcl7iGl67A7Lr4Nz7WpNzITNETwggc7pw==,
       }
     engines: { node: ">=18" }
+
+  "@google-cloud/dataflow@3.3.0":
+    resolution:
+      {
+        integrity: sha512-b6ZqHP9bcmenoyKfTWfZJIv+yZYyaEY+60LOoXYOfM3wasC9jMEsILxHxAinXQZOuIM8MK2zdYRCFJUq/l2wtw==,
+      }
+    engines: { node: ">=14.0.0" }
 
   "@google-cloud/firestore@7.11.6":
     resolution:
@@ -1384,6 +1463,7 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-libvips-linux-arm@1.2.4":
     resolution:
@@ -1392,6 +1472,7 @@ packages:
       }
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-libvips-linux-ppc64@1.2.4":
     resolution:
@@ -1400,6 +1481,7 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-libvips-linux-riscv64@1.2.4":
     resolution:
@@ -1408,6 +1490,7 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-libvips-linux-s390x@1.2.4":
     resolution:
@@ -1416,6 +1499,7 @@ packages:
       }
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-libvips-linux-x64@1.2.4":
     resolution:
@@ -1424,6 +1508,7 @@ packages:
       }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-libvips-linuxmusl-arm64@1.2.4":
     resolution:
@@ -1432,6 +1517,7 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   "@img/sharp-libvips-linuxmusl-x64@1.2.4":
     resolution:
@@ -1440,6 +1526,7 @@ packages:
       }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   "@img/sharp-linux-arm64@0.34.5":
     resolution:
@@ -1449,6 +1536,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-linux-arm@0.34.5":
     resolution:
@@ -1458,6 +1546,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-linux-ppc64@0.34.5":
     resolution:
@@ -1467,6 +1556,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-linux-riscv64@0.34.5":
     resolution:
@@ -1476,6 +1566,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-linux-s390x@0.34.5":
     resolution:
@@ -1485,6 +1576,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-linux-x64@0.34.5":
     resolution:
@@ -1494,6 +1586,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   "@img/sharp-linuxmusl-arm64@0.34.5":
     resolution:
@@ -1503,6 +1596,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   "@img/sharp-linuxmusl-x64@0.34.5":
     resolution:
@@ -1512,6 +1606,7 @@ packages:
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   "@img/sharp-wasm32@0.34.5":
     resolution:
@@ -2338,6 +2433,7 @@ packages:
     engines: { node: ^22.20 || ^24.12 || >=25 }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   "@nodable/entities@3.0.0":
     resolution:
@@ -3260,6 +3356,7 @@ packages:
       }
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   "@rollup/rollup-linux-arm-musleabihf@4.62.4":
     resolution:
@@ -3268,6 +3365,7 @@ packages:
       }
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   "@rollup/rollup-linux-arm64-gnu@4.62.4":
     resolution:
@@ -3276,6 +3374,7 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   "@rollup/rollup-linux-arm64-musl@4.62.4":
     resolution:
@@ -3284,6 +3383,7 @@ packages:
       }
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   "@rollup/rollup-linux-loong64-gnu@4.62.4":
     resolution:
@@ -3292,6 +3392,7 @@ packages:
       }
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   "@rollup/rollup-linux-loong64-musl@4.62.4":
     resolution:
@@ -3300,6 +3401,7 @@ packages:
       }
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   "@rollup/rollup-linux-ppc64-gnu@4.62.4":
     resolution:
@@ -3308,6 +3410,7 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   "@rollup/rollup-linux-ppc64-musl@4.62.4":
     resolution:
@@ -3316,6 +3419,7 @@ packages:
       }
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   "@rollup/rollup-linux-riscv64-gnu@4.62.4":
     resolution:
@@ -3324,6 +3428,7 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   "@rollup/rollup-linux-riscv64-musl@4.62.4":
     resolution:
@@ -3332,6 +3437,7 @@ packages:
       }
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   "@rollup/rollup-linux-s390x-gnu@4.62.4":
     resolution:
@@ -3340,6 +3446,7 @@ packages:
       }
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   "@rollup/rollup-linux-x64-gnu@4.62.4":
     resolution:
@@ -3348,6 +3455,7 @@ packages:
       }
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   "@rollup/rollup-linux-x64-musl@4.62.4":
     resolution:
@@ -3356,6 +3464,7 @@ packages:
       }
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   "@rollup/rollup-openbsd-x64@4.62.4":
     resolution:
@@ -3566,22 +3675,10 @@ packages:
         integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==,
       }
 
-  "@types/express-serve-static-core@4.19.9":
-    resolution:
-      {
-        integrity: sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==,
-      }
-
   "@types/express-serve-static-core@5.1.3":
     resolution:
       {
         integrity: sha512-dPfW8NFiOF4wOHc7+N/QSxlY9cfSsenewGbAz8C8U/MULPd/YZ27LvJUIlzaXie7e6Ove9YunJGgC9tbHD2cKw==,
-      }
-
-  "@types/express@4.17.25":
-    resolution:
-      {
-        integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==,
       }
 
   "@types/express@5.0.6":
@@ -3672,12 +3769,6 @@ packages:
     resolution:
       {
         integrity: sha512-AM9smvZN55Gzs2wRrqeMHVP7KE8KWgCJO/XL5yCly2xF6EKa4YlbpK+cLSAH4NG/Ah64HrlegmGqW8kYws7Vxg==,
-      }
-
-  "@types/mime@1.3.5":
-    resolution:
-      {
-        integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==,
       }
 
   "@types/minimatch@6.0.0":
@@ -3779,22 +3870,10 @@ packages:
         integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==,
       }
 
-  "@types/send@0.17.6":
-    resolution:
-      {
-        integrity: sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==,
-      }
-
   "@types/send@1.2.1":
     resolution:
       {
         integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==,
-      }
-
-  "@types/serve-static@1.15.10":
-    resolution:
-      {
-        integrity: sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==,
       }
 
   "@types/serve-static@2.2.0":
@@ -6175,20 +6254,30 @@ packages:
       }
     engines: { node: ">=22" }
 
-  firebase-functions@6.6.0:
-    resolution:
-      {
-        integrity: sha512-wwfo6JF+N7HUExVs5gUFgkgVGHDEog9O+qtouh7IuJWk8TBQ+KwXEgRiXbatSj7EbTu3/yYnHuzh3XExbfF6wQ==,
-      }
-    engines: { node: ">=14.10.0" }
-    hasBin: true
-    peerDependencies:
-      firebase-admin: ^11.10.0 || ^12.0.0 || ^13.0.0
-
   firebase-functions@7.3.2:
     resolution:
       {
         integrity: sha512-DTa5CtCNxFE1gPjkjlhl5uh8AcNWXLKORAMRenfkecP8zGstbje+r2TaNh4Ehdxp0qTPvTUe/sS23VESW32Gbg==,
+      }
+    engines: { node: ">=18.0.0" }
+    hasBin: true
+    peerDependencies:
+      "@apollo/server": ^5.2.0
+      "@as-integrations/express4": ^1.1.2
+      firebase-admin: ^11.10.0 || ^12.0.0 || ^13.0.0 || ^14.0.0
+      graphql: ^16.12.0
+    peerDependenciesMeta:
+      "@apollo/server":
+        optional: true
+      "@as-integrations/express4":
+        optional: true
+      graphql:
+        optional: true
+
+  firebase-functions@7.3.3-rc.1:
+    resolution:
+      {
+        integrity: sha512-jD+Z8PYQ/iWE0bLJ0lb+od6p1wW9+8Aj7mjhd6ZIRrPYVqrEYpvtGKTC273rteMUKBPHStcOBcf1b8VfrNvbaA==,
       }
     engines: { node: ">=18.0.0" }
     hasBin: true
@@ -12280,10 +12369,10 @@ snapshots:
     optionalDependencies:
       zod: 3.25.76
 
-  "@anthropic-ai/vertex-sdk@0.16.1(encoding@0.1.13)(zod@3.25.76)":
+  "@anthropic-ai/vertex-sdk@0.16.1(encoding@0.1.13)(supports-color@9.4.0)(zod@3.25.76)":
     dependencies:
       "@anthropic-ai/sdk": 0.90.0(zod@3.25.76)
-      google-auth-library: 9.15.1(encoding@0.1.13)
+      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@9.4.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -12297,16 +12386,16 @@ snapshots:
 
   "@babel/compat-data@7.29.7": {}
 
-  "@babel/core@7.29.7":
+  "@babel/core@7.29.7(supports-color@9.4.0)":
     dependencies:
       "@babel/code-frame": 7.29.7
       "@babel/generator": 7.29.8
       "@babel/helper-compilation-targets": 7.29.7
-      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7(supports-color@9.4.0))(supports-color@9.4.0)
       "@babel/helpers": 7.29.7
       "@babel/parser": 7.29.8
       "@babel/template": 7.29.7
-      "@babel/traverse": 7.29.8
+      "@babel/traverse": 7.29.8(supports-color@9.4.0)
       "@babel/types": 7.29.8
       "@jridgewell/remapping": 2.3.5
       convert-source-map: 2.0.0
@@ -12335,19 +12424,19 @@ snapshots:
 
   "@babel/helper-globals@7.29.7": {}
 
-  "@babel/helper-module-imports@7.29.7":
+  "@babel/helper-module-imports@7.29.7(supports-color@9.4.0)":
     dependencies:
-      "@babel/traverse": 7.29.8
+      "@babel/traverse": 7.29.8(supports-color@9.4.0)
       "@babel/types": 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)":
+  "@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@9.4.0))(supports-color@9.4.0)":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-module-imports": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
+      "@babel/helper-module-imports": 7.29.7(supports-color@9.4.0)
       "@babel/helper-validator-identifier": 7.29.7
-      "@babel/traverse": 7.29.8
+      "@babel/traverse": 7.29.8(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12368,89 +12457,89 @@ snapshots:
     dependencies:
       "@babel/types": 7.29.8
 
-  "@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7(supports-color@9.4.0))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7(supports-color@9.4.0))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7(supports-color@9.4.0))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.7(supports-color@9.4.0))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7(supports-color@9.4.0))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7(supports-color@9.4.0))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7(supports-color@9.4.0))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@9.4.0))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7(supports-color@9.4.0))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7(supports-color@9.4.0))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7(supports-color@9.4.0))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7(supports-color@9.4.0))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7(supports-color@9.4.0))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7(supports-color@9.4.0))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.7(supports-color@9.4.0))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7(supports-color@9.4.0))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@9.4.0))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/helper-plugin-utils": 7.29.7
 
   "@babel/runtime@7.29.7": {}
@@ -12461,7 +12550,7 @@ snapshots:
       "@babel/parser": 7.29.8
       "@babel/types": 7.29.8
 
-  "@babel/traverse@7.29.8":
+  "@babel/traverse@7.29.8(supports-color@9.4.0)":
     dependencies:
       "@babel/code-frame": 7.29.7
       "@babel/generator": 7.29.8
@@ -12574,9 +12663,9 @@ snapshots:
   "@esbuild/win32-x64@0.28.2":
     optional: true
 
-  "@evocateur/libnpmaccess@3.1.2":
+  "@evocateur/libnpmaccess@3.1.2(supports-color@9.4.0)":
     dependencies:
-      "@evocateur/npm-registry-fetch": 4.0.0
+      "@evocateur/npm-registry-fetch": 4.0.0(supports-color@9.4.0)
       aproba: 2.1.0
       figgy-pudding: 3.5.2
       get-stream: 4.1.0
@@ -12584,9 +12673,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@evocateur/libnpmpublish@1.2.2":
+  "@evocateur/libnpmpublish@1.2.2(supports-color@9.4.0)":
     dependencies:
-      "@evocateur/npm-registry-fetch": 4.0.0
+      "@evocateur/npm-registry-fetch": 4.0.0(supports-color@9.4.0)
       aproba: 2.1.0
       figgy-pudding: 3.5.2
       get-stream: 4.1.0
@@ -12598,21 +12687,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@evocateur/npm-registry-fetch@4.0.0":
+  "@evocateur/npm-registry-fetch@4.0.0(supports-color@9.4.0)":
     dependencies:
       JSONStream: 1.3.5
       bluebird: 3.7.2
       figgy-pudding: 3.5.2
       lru-cache: 5.1.1
-      make-fetch-happen: 5.0.2
+      make-fetch-happen: 5.0.2(supports-color@9.4.0)
       npm-package-arg: 6.1.1
       safe-buffer: 5.2.1
     transitivePeerDependencies:
       - supports-color
 
-  "@evocateur/pacote@9.6.5":
+  "@evocateur/pacote@9.6.5(supports-color@9.4.0)":
     dependencies:
-      "@evocateur/npm-registry-fetch": 4.0.0
+      "@evocateur/npm-registry-fetch": 4.0.0(supports-color@9.4.0)
       bluebird: 3.7.2
       cacache: 12.0.4
       chownr: 1.1.4
@@ -12621,7 +12710,7 @@ snapshots:
       glob: 7.2.3
       infer-owner: 1.0.4
       lru-cache: 5.1.1
-      make-fetch-happen: 5.0.2
+      make-fetch-happen: 5.0.2(supports-color@9.4.0)
       minimatch: 3.1.5
       minipass: 2.9.0
       mississippi: 3.0.0
@@ -12701,23 +12790,26 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  "@firebaseextensions/firestore-bigquery-change-tracker@2.0.4(@firebase/app@0.16.0)(encoding@0.1.13)":
+  "@firebaseextensions/firestore-bigquery-change-tracker@2.2.1(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
-      "@google-cloud/bigquery": 7.9.4(encoding@0.1.13)
-      "@google-cloud/resource-manager": 5.3.1(encoding@0.1.13)
-      firebase-admin: 13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)
-      firebase-functions: 6.6.0(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13))
+      "@google-cloud/bigquery": 7.9.4(encoding@0.1.13)(supports-color@9.4.0)
+      "@google-cloud/resource-manager": 5.3.1(encoding@0.1.13)(supports-color@9.4.0)
+      firebase-admin: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
+      firebase-functions: 7.3.2(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
       sql-formatter: 2.3.4
       traverse: 0.6.11
     transitivePeerDependencies:
+      - "@apollo/server"
+      - "@as-integrations/express4"
       - "@firebase/app"
       - "@firebase/app-compat"
       - encoding
+      - graphql
       - supports-color
 
-  "@genkit-ai/ai@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))":
+  "@genkit-ai/ai@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)":
     dependencies:
-      "@genkit-ai/core": 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))
+      "@genkit-ai/core": 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)
       "@opentelemetry/api": 1.9.1
       "@types/node": 20.19.43
       colorette: 2.0.20
@@ -12738,9 +12830,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  "@genkit-ai/ai@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)))":
+  "@genkit-ai/ai@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)":
     dependencies:
-      "@genkit-ai/core": 1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)))
+      "@genkit-ai/core": 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)
       "@opentelemetry/api": 1.9.1
       "@types/node": 20.19.43
       colorette: 2.0.20
@@ -12761,30 +12853,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  "@genkit-ai/ai@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))":
-    dependencies:
-      "@genkit-ai/core": 1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))
-      "@opentelemetry/api": 1.9.1
-      "@types/node": 20.19.43
-      colorette: 2.0.20
-      dotprompt: 1.1.2
-      handlebars: 4.7.9
-      json5: 2.2.3
-      node-fetch: 3.3.2
-      partial-json: 0.1.7
-      uri-templates: 0.2.0
-      uuid: 10.0.0
-    transitivePeerDependencies:
-      - "@google-cloud/firestore"
-      - bufferutil
-      - encoding
-      - firebase
-      - firebase-admin
-      - genkit
-      - supports-color
-      - utf-8-validate
-
-  "@genkit-ai/core@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))":
+  "@genkit-ai/core@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/api-logs": 0.52.1
@@ -12792,7 +12861,7 @@ snapshots:
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/sdk-logs": 0.52.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/sdk-metrics": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/sdk-node": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/sdk-node": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/sdk-trace-base": 1.25.1(@opentelemetry/api@1.9.1)
       "@types/json-schema": 7.0.15
       ajv: 8.20.0
@@ -12800,7 +12869,7 @@ snapshots:
       async-mutex: 0.5.0
       cors: 2.8.6
       dotprompt: 1.1.2
-      express: 4.22.2
+      express: 4.22.2(supports-color@9.4.0)
       get-port: 5.1.1
       json-schema: 0.4.0
       ws: 8.21.3
@@ -12808,7 +12877,7 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@3.25.76)
     optionalDependencies:
       "@cfworker/json-schema": 4.1.1
-      "@genkit-ai/firebase": 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))
+      "@genkit-ai/firebase": 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)
     transitivePeerDependencies:
       - "@google-cloud/firestore"
       - bufferutil
@@ -12819,7 +12888,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  "@genkit-ai/core@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)))":
+  "@genkit-ai/core@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/api-logs": 0.52.1
@@ -12827,7 +12896,7 @@ snapshots:
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/sdk-logs": 0.52.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/sdk-metrics": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/sdk-node": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/sdk-node": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/sdk-trace-base": 1.25.1(@opentelemetry/api@1.9.1)
       "@types/json-schema": 7.0.15
       ajv: 8.20.0
@@ -12835,7 +12904,7 @@ snapshots:
       async-mutex: 0.5.0
       cors: 2.8.6
       dotprompt: 1.1.2
-      express: 4.22.2
+      express: 4.22.2(supports-color@9.4.0)
       get-port: 5.1.1
       json-schema: 0.4.0
       ws: 8.21.3
@@ -12843,7 +12912,7 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@3.25.76)
     optionalDependencies:
       "@cfworker/json-schema": 4.1.1
-      "@genkit-ai/firebase": 1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)))
+      "@genkit-ai/firebase": 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)
     transitivePeerDependencies:
       - "@google-cloud/firestore"
       - bufferutil
@@ -12854,93 +12923,47 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  "@genkit-ai/core@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))":
+  "@genkit-ai/firebase@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)":
     dependencies:
-      "@opentelemetry/api": 1.9.1
-      "@opentelemetry/api-logs": 0.52.1
-      "@opentelemetry/context-async-hooks": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/sdk-logs": 0.52.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/sdk-metrics": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/sdk-node": 0.52.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/sdk-trace-base": 1.25.1(@opentelemetry/api@1.9.1)
-      "@types/json-schema": 7.0.15
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      async-mutex: 0.5.0
-      cors: 2.8.6
-      dotprompt: 1.1.2
-      express: 4.22.2
-      get-port: 5.1.1
-      json-schema: 0.4.0
-      ws: 8.21.3
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
-    optionalDependencies:
-      "@cfworker/json-schema": 4.1.1
-      "@genkit-ai/firebase": 1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))
-    transitivePeerDependencies:
-      - "@google-cloud/firestore"
-      - bufferutil
-      - encoding
-      - firebase
-      - firebase-admin
-      - genkit
-      - supports-color
-      - utf-8-validate
-
-  "@genkit-ai/firebase@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))":
-    dependencies:
-      "@genkit-ai/google-cloud": 1.41.0(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))
-      "@google-cloud/firestore": 7.11.6(encoding@0.1.13)
-      firebase-admin: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)
-      genkit: 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))
+      "@genkit-ai/google-cloud": 1.41.0(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)
+      "@google-cloud/firestore": 7.11.6(encoding@0.1.13)(supports-color@9.4.0)
+      firebase-admin: 13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
+      genkit: 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
     optional: true
 
-  "@genkit-ai/firebase@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)))":
+  "@genkit-ai/firebase@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)":
     dependencies:
-      "@genkit-ai/google-cloud": 1.41.0(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)))
-      "@google-cloud/firestore": 8.7.1
-      firebase-admin: 13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)
-      genkit: 1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13))
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    optional: true
-
-  "@genkit-ai/firebase@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))":
-    dependencies:
-      "@genkit-ai/google-cloud": 1.41.0(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))
-      "@google-cloud/firestore": 8.7.1
-      firebase-admin: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)
-      genkit: 1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))
+      "@genkit-ai/google-cloud": 1.41.0(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)
+      "@google-cloud/firestore": 7.11.6(encoding@0.1.13)(supports-color@9.4.0)
+      firebase-admin: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
+      genkit: 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  "@genkit-ai/google-cloud@1.41.0(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))":
+  "@genkit-ai/google-cloud@1.41.0(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)":
     dependencies:
-      "@google-cloud/firestore": 7.11.6(encoding@0.1.13)
-      "@google-cloud/logging-winston": 6.0.2(encoding@0.1.13)(winston@3.19.0)
-      "@google-cloud/modelarmor": 0.4.1
-      "@google-cloud/opentelemetry-cloud-monitoring-exporter": 0.19.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)
-      "@google-cloud/opentelemetry-cloud-trace-exporter": 2.4.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)
-      "@google-cloud/opentelemetry-resource-util": 2.4.0(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)
+      "@google-cloud/firestore": 7.11.6(encoding@0.1.13)(supports-color@9.4.0)
+      "@google-cloud/logging-winston": 6.0.2(encoding@0.1.13)(supports-color@9.4.0)(winston@3.19.0)
+      "@google-cloud/modelarmor": 0.4.1(supports-color@9.4.0)
+      "@google-cloud/opentelemetry-cloud-monitoring-exporter": 0.19.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)(supports-color@9.4.0)
+      "@google-cloud/opentelemetry-cloud-trace-exporter": 2.4.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)(supports-color@9.4.0)
+      "@google-cloud/opentelemetry-resource-util": 2.4.0(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)(supports-color@9.4.0)
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/auto-instrumentations-node": 0.49.2(@opentelemetry/api@1.9.1)(encoding@0.1.13)
+      "@opentelemetry/auto-instrumentations-node": 0.49.2(@opentelemetry/api@1.9.1)(encoding@0.1.13)(supports-color@9.4.0)
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-pino": 0.41.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-winston": 0.39.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-pino": 0.41.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-winston": 0.39.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/resources": 1.25.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/sdk-metrics": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/sdk-node": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/sdk-node": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/sdk-trace-base": 1.25.1(@opentelemetry/api@1.9.1)
-      genkit: 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))
-      google-auth-library: 9.15.1(encoding@0.1.13)
+      genkit: 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
+      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@9.4.0)
       node-fetch: 3.3.2
       winston: 3.19.0
     transitivePeerDependencies:
@@ -12948,92 +12971,56 @@ snapshots:
       - supports-color
     optional: true
 
-  "@genkit-ai/google-cloud@1.41.0(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)))":
+  "@genkit-ai/google-cloud@1.41.0(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)":
     dependencies:
-      "@google-cloud/firestore": 7.11.6(encoding@0.1.13)
-      "@google-cloud/logging-winston": 6.0.2(encoding@0.1.13)(winston@3.19.0)
-      "@google-cloud/modelarmor": 0.4.1
-      "@google-cloud/opentelemetry-cloud-monitoring-exporter": 0.19.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)
-      "@google-cloud/opentelemetry-cloud-trace-exporter": 2.4.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)
-      "@google-cloud/opentelemetry-resource-util": 2.4.0(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)
+      "@google-cloud/firestore": 7.11.6(encoding@0.1.13)(supports-color@9.4.0)
+      "@google-cloud/logging-winston": 6.0.2(encoding@0.1.13)(supports-color@9.4.0)(winston@3.19.0)
+      "@google-cloud/modelarmor": 0.4.1(supports-color@9.4.0)
+      "@google-cloud/opentelemetry-cloud-monitoring-exporter": 0.19.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)(supports-color@9.4.0)
+      "@google-cloud/opentelemetry-cloud-trace-exporter": 2.4.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)(supports-color@9.4.0)
+      "@google-cloud/opentelemetry-resource-util": 2.4.0(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)(supports-color@9.4.0)
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/auto-instrumentations-node": 0.49.2(@opentelemetry/api@1.9.1)(encoding@0.1.13)
+      "@opentelemetry/auto-instrumentations-node": 0.49.2(@opentelemetry/api@1.9.1)(encoding@0.1.13)(supports-color@9.4.0)
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-pino": 0.41.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-winston": 0.39.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-pino": 0.41.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-winston": 0.39.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/resources": 1.25.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/sdk-metrics": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/sdk-node": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/sdk-node": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/sdk-trace-base": 1.25.1(@opentelemetry/api@1.9.1)
-      genkit: 1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13))
-      google-auth-library: 9.15.1(encoding@0.1.13)
-      node-fetch: 3.3.2
-      winston: 3.19.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    optional: true
-
-  "@genkit-ai/google-cloud@1.41.0(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))":
-    dependencies:
-      "@google-cloud/firestore": 7.11.6(encoding@0.1.13)
-      "@google-cloud/logging-winston": 6.0.2(encoding@0.1.13)(winston@3.19.0)
-      "@google-cloud/modelarmor": 0.4.1
-      "@google-cloud/opentelemetry-cloud-monitoring-exporter": 0.19.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)
-      "@google-cloud/opentelemetry-cloud-trace-exporter": 2.4.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)
-      "@google-cloud/opentelemetry-resource-util": 2.4.0(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)
-      "@opentelemetry/api": 1.9.1
-      "@opentelemetry/auto-instrumentations-node": 0.49.2(@opentelemetry/api@1.9.1)(encoding@0.1.13)
-      "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-pino": 0.41.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-winston": 0.39.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/resources": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/sdk-metrics": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/sdk-node": 0.52.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/sdk-trace-base": 1.25.1(@opentelemetry/api@1.9.1)
-      genkit: 1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))
-      google-auth-library: 9.15.1(encoding@0.1.13)
+      genkit: 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
+      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@9.4.0)
       node-fetch: 3.3.2
       winston: 3.19.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  "@genkit-ai/google-genai@1.41.0(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))":
+  "@genkit-ai/google-genai@1.41.0(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)":
     dependencies:
-      genkit: 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))
-      google-auth-library: 9.15.1(encoding@0.1.13)
+      genkit: 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
+      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@9.4.0)
       jsonpath-plus: 10.4.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  "@genkit-ai/google-genai@1.41.0(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))":
-    dependencies:
-      genkit: 1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))
-      google-auth-library: 9.15.1(encoding@0.1.13)
-      jsonpath-plus: 10.4.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
-  "@genkit-ai/vertexai@1.41.0(@firebase/app@0.16.0)(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)))(ws@8.21.3)(zod@3.25.76)":
+  "@genkit-ai/vertexai@1.41.0(@firebase/app@0.16.0)(encoding@0.1.13)(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)(ws@8.21.3)(zod@3.25.76)":
     dependencies:
       "@anthropic-ai/sdk": 0.90.0(zod@3.25.76)
-      "@anthropic-ai/vertex-sdk": 0.16.1(encoding@0.1.13)(zod@3.25.76)
-      "@google-cloud/aiplatform": 3.35.0(encoding@0.1.13)
-      "@google-cloud/vertexai": 1.12.0(encoding@0.1.13)
-      "@mistralai/mistralai-gcp": 1.7.0(encoding@0.1.13)
-      genkit: 1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13))
-      google-auth-library: 9.15.1(encoding@0.1.13)
-      googleapis: 140.0.1(encoding@0.1.13)
+      "@anthropic-ai/vertex-sdk": 0.16.1(encoding@0.1.13)(supports-color@9.4.0)(zod@3.25.76)
+      "@google-cloud/aiplatform": 3.35.0(encoding@0.1.13)(supports-color@9.4.0)
+      "@google-cloud/vertexai": 1.12.0(encoding@0.1.13)(supports-color@9.4.0)
+      "@mistralai/mistralai-gcp": 1.7.0(encoding@0.1.13)(supports-color@9.4.0)
+      genkit: 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0)
+      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@9.4.0)
+      googleapis: 140.0.1(encoding@0.1.13)(supports-color@9.4.0)
       node-fetch: 3.3.2
       openai: 4.104.0(encoding@0.1.13)(ws@8.21.3)(zod@3.25.76)
     optionalDependencies:
-      "@google-cloud/bigquery": 7.9.4(encoding@0.1.13)
-      firebase-admin: 13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)
+      "@google-cloud/bigquery": 7.9.4(encoding@0.1.13)(supports-color@9.4.0)
+      firebase-admin: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
     transitivePeerDependencies:
       - "@firebase/app"
       - "@firebase/app-compat"
@@ -13045,23 +13032,23 @@ snapshots:
       - ws
       - zod
 
-  "@google-cloud/aiplatform@3.35.0(encoding@0.1.13)":
+  "@google-cloud/aiplatform@3.35.0(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
-      google-gax: 4.6.1(encoding@0.1.13)
+      google-gax: 4.6.1(encoding@0.1.13)(supports-color@9.4.0)
       protobuf.js: 1.1.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  "@google-cloud/bigquery-data-transfer@5.1.3":
+  "@google-cloud/bigquery-data-transfer@5.1.3(supports-color@9.4.0)":
     dependencies:
-      google-gax: 5.0.8
+      google-gax: 5.0.8(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  "@google-cloud/bigquery@7.9.4(encoding@0.1.13)":
+  "@google-cloud/bigquery@7.9.4(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
-      "@google-cloud/common": 5.0.2(encoding@0.1.13)
+      "@google-cloud/common": 5.0.2(encoding@0.1.13)(supports-color@9.4.0)
       "@google-cloud/paginator": 5.0.2
       "@google-cloud/precise-date": 4.0.0
       "@google-cloud/promisify": 4.0.0
@@ -13076,9 +13063,9 @@ snapshots:
       - encoding
       - supports-color
 
-  "@google-cloud/bigquery@8.3.1":
+  "@google-cloud/bigquery@8.3.1(supports-color@9.4.0)":
     dependencies:
-      "@google-cloud/common": 6.1.0
+      "@google-cloud/common": 6.1.0(supports-color@9.4.0)
       "@google-cloud/paginator": 6.1.0
       "@google-cloud/precise-date": 5.2.0
       "@google-cloud/promisify": 5.1.0
@@ -13087,70 +13074,78 @@ snapshots:
       duplexify: 4.1.3
       extend: 3.0.2
       stream-events: 1.0.5
-      teeny-request: 10.1.4
+      teeny-request: 10.1.4(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  "@google-cloud/common@5.0.2(encoding@0.1.13)":
+  "@google-cloud/common@5.0.2(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
       "@google-cloud/projectify": 4.0.0
       "@google-cloud/promisify": 4.0.0
       arrify: 2.0.1
       duplexify: 4.1.3
       extend: 3.0.2
-      google-auth-library: 9.15.1(encoding@0.1.13)
+      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@9.4.0)
       html-entities: 2.6.0
-      retry-request: 7.0.2(encoding@0.1.13)
-      teeny-request: 9.0.0(encoding@0.1.13)
+      retry-request: 7.0.2(encoding@0.1.13)(supports-color@9.4.0)
+      teeny-request: 9.0.0(encoding@0.1.13)(supports-color@9.4.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  "@google-cloud/common@6.1.0":
+  "@google-cloud/common@6.1.0(supports-color@9.4.0)":
     dependencies:
       "@google-cloud/projectify": 4.0.0
       "@google-cloud/promisify": 4.1.0
       arrify: 2.0.1
       duplexify: 4.1.3
       extend: 3.0.2
-      google-auth-library: 10.9.1
+      google-auth-library: 10.9.1(supports-color@9.4.0)
       html-entities: 2.6.0
-      retry-request: 8.0.4
-      teeny-request: 10.1.4
+      retry-request: 8.0.4(supports-color@9.4.0)
+      teeny-request: 10.1.4(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  "@google-cloud/firestore@7.11.6(encoding@0.1.13)":
+  "@google-cloud/dataflow@3.3.0(encoding@0.1.13)(supports-color@9.4.0)":
+    dependencies:
+      google-gax: 4.6.1(encoding@0.1.13)(supports-color@9.4.0)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  "@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       fast-deep-equal: 3.1.3
       functional-red-black-tree: 1.0.1
-      google-gax: 4.6.1(encoding@0.1.13)
+      google-gax: 4.6.1(encoding@0.1.13)(supports-color@9.4.0)
       protobufjs: 7.6.5
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  "@google-cloud/firestore@8.7.1":
+  "@google-cloud/firestore@8.7.1(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       fast-deep-equal: 3.1.3
       functional-red-black-tree: 1.0.1
-      google-gax: 5.0.8
+      google-gax: 5.0.8(supports-color@9.4.0)
       protobufjs: 7.6.5
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
-  "@google-cloud/logging-api@0.2.0":
+  "@google-cloud/logging-api@0.2.0(supports-color@9.4.0)":
     dependencies:
-      google-gax: 5.0.8
+      google-gax: 5.0.8(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  "@google-cloud/logging-winston@6.0.2(encoding@0.1.13)(winston@3.19.0)":
+  "@google-cloud/logging-winston@6.0.2(encoding@0.1.13)(supports-color@9.4.0)(winston@3.19.0)":
     dependencies:
-      "@google-cloud/logging": 11.4.0(encoding@0.1.13)
-      google-auth-library: 10.9.1
+      "@google-cloud/logging": 11.4.0(encoding@0.1.13)(supports-color@9.4.0)
+      google-auth-library: 10.9.1(supports-color@9.4.0)
       lodash.mapvalues: 4.6.0
       winston: 3.19.0
       winston-transport: 4.9.0
@@ -13158,10 +13153,10 @@ snapshots:
       - encoding
       - supports-color
 
-  "@google-cloud/logging@11.4.0(encoding@0.1.13)":
+  "@google-cloud/logging@11.4.0(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
-      "@google-cloud/common": 6.1.0
-      "@google-cloud/logging-api": 0.2.0
+      "@google-cloud/common": 6.1.0(supports-color@9.4.0)
+      "@google-cloud/logging-api": 0.2.0(supports-color@9.4.0)
       "@google-cloud/paginator": 5.0.2
       "@google-cloud/projectify": 4.0.0
       "@google-cloud/promisify": 4.0.0
@@ -13170,9 +13165,9 @@ snapshots:
       arrify: 2.0.1
       dot-prop: 6.0.1
       extend: 3.0.2
-      gcp-metadata: 6.1.1(encoding@0.1.13)
-      google-auth-library: 10.9.1
-      google-gax: 4.6.1(encoding@0.1.13)
+      gcp-metadata: 6.1.1(encoding@0.1.13)(supports-color@9.4.0)
+      google-auth-library: 10.9.1(supports-color@9.4.0)
+      google-gax: 4.6.1(encoding@0.1.13)(supports-color@9.4.0)
       long: 5.3.2
       on-finished: 2.4.1
       pumpify: 2.0.1
@@ -13181,45 +13176,45 @@ snapshots:
       - encoding
       - supports-color
 
-  "@google-cloud/modelarmor@0.4.1":
+  "@google-cloud/modelarmor@0.4.1(supports-color@9.4.0)":
     dependencies:
-      google-gax: 5.0.8
+      google-gax: 5.0.8(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  "@google-cloud/opentelemetry-cloud-monitoring-exporter@0.19.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)":
+  "@google-cloud/opentelemetry-cloud-monitoring-exporter@0.19.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
-      "@google-cloud/opentelemetry-resource-util": 2.4.0(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)
+      "@google-cloud/opentelemetry-resource-util": 2.4.0(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)(supports-color@9.4.0)
       "@google-cloud/precise-date": 4.0.0
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/resources": 1.25.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/sdk-metrics": 1.25.1(@opentelemetry/api@1.9.1)
-      google-auth-library: 9.15.1(encoding@0.1.13)
-      googleapis: 137.1.0(encoding@0.1.13)
+      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@9.4.0)
+      googleapis: 137.1.0(encoding@0.1.13)(supports-color@9.4.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  "@google-cloud/opentelemetry-cloud-trace-exporter@2.4.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)":
+  "@google-cloud/opentelemetry-cloud-trace-exporter@2.4.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
-      "@google-cloud/opentelemetry-resource-util": 2.4.0(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)
+      "@google-cloud/opentelemetry-resource-util": 2.4.0(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)(supports-color@9.4.0)
       "@grpc/grpc-js": 1.14.4
       "@grpc/proto-loader": 0.7.15
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/resources": 1.25.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/sdk-trace-base": 1.25.1(@opentelemetry/api@1.9.1)
-      google-auth-library: 9.15.1(encoding@0.1.13)
+      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@9.4.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  "@google-cloud/opentelemetry-resource-util@2.4.0(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)":
+  "@google-cloud/opentelemetry-resource-util@2.4.0(@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.1))(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/resources": 1.25.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.43.0
-      gcp-metadata: 6.1.1(encoding@0.1.13)
+      gcp-metadata: 6.1.1(encoding@0.1.13)(supports-color@9.4.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -13245,7 +13240,7 @@ snapshots:
 
   "@google-cloud/promisify@5.1.0": {}
 
-  "@google-cloud/pubsub@4.11.0(encoding@0.1.13)":
+  "@google-cloud/pubsub@4.11.0(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
       "@google-cloud/paginator": 5.0.2
       "@google-cloud/precise-date": 4.0.0
@@ -13255,8 +13250,8 @@ snapshots:
       "@opentelemetry/semantic-conventions": 1.30.0
       arrify: 2.0.1
       extend: 3.0.2
-      google-auth-library: 9.15.1(encoding@0.1.13)
-      google-gax: 4.6.1(encoding@0.1.13)
+      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@9.4.0)
+      google-gax: 4.6.1(encoding@0.1.13)(supports-color@9.4.0)
       heap-js: 2.7.1
       is-stream-ended: 0.1.4
       lodash.snakecase: 4.1.1
@@ -13265,24 +13260,24 @@ snapshots:
       - encoding
       - supports-color
 
-  "@google-cloud/resource-manager@5.3.1(encoding@0.1.13)":
+  "@google-cloud/resource-manager@5.3.1(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
-      google-gax: 4.6.1(encoding@0.1.13)
+      google-gax: 4.6.1(encoding@0.1.13)(supports-color@9.4.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  "@google-cloud/speech@7.5.0":
+  "@google-cloud/speech@7.5.0(supports-color@9.4.0)":
     dependencies:
-      "@google-cloud/common": 6.1.0
+      "@google-cloud/common": 6.1.0(supports-color@9.4.0)
       "@types/pumpify": 1.4.5
-      google-gax: 5.0.8
+      google-gax: 5.0.8(supports-color@9.4.0)
       pumpify: 2.0.1
       stream-events: 1.0.5
     transitivePeerDependencies:
       - supports-color
 
-  "@google-cloud/storage@7.22.0(encoding@0.1.13)":
+  "@google-cloud/storage@7.22.0(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
       "@google-cloud/paginator": 5.0.2
       "@google-cloud/projectify": 4.0.0
@@ -13291,40 +13286,40 @@ snapshots:
       async-retry: 1.3.3
       duplexify: 4.1.3
       fast-xml-parser: 5.10.1
-      gaxios: 6.7.1(encoding@0.1.13)
-      google-auth-library: 9.15.1(encoding@0.1.13)
+      gaxios: 6.7.1(encoding@0.1.13)(supports-color@9.4.0)
+      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@9.4.0)
       html-entities: 2.6.0
       mime: 3.0.0
       p-limit: 3.1.0
-      retry-request: 7.0.2(encoding@0.1.13)
-      teeny-request: 9.0.0(encoding@0.1.13)
+      retry-request: 7.0.2(encoding@0.1.13)(supports-color@9.4.0)
+      teeny-request: 9.0.0(encoding@0.1.13)(supports-color@9.4.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  "@google-cloud/translate@8.5.1(encoding@0.1.13)":
+  "@google-cloud/translate@8.5.1(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
-      "@google-cloud/common": 5.0.2(encoding@0.1.13)
+      "@google-cloud/common": 5.0.2(encoding@0.1.13)(supports-color@9.4.0)
       "@google-cloud/promisify": 4.1.0
       arrify: 2.0.1
       extend: 3.0.2
-      google-gax: 4.6.1(encoding@0.1.13)
+      google-gax: 4.6.1(encoding@0.1.13)(supports-color@9.4.0)
       is-html: 2.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  "@google-cloud/vertexai@0.1.3(encoding@0.1.13)":
+  "@google-cloud/vertexai@0.1.3(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
-      google-auth-library: 9.15.1(encoding@0.1.13)
+      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@9.4.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  "@google-cloud/vertexai@1.12.0(encoding@0.1.13)":
+  "@google-cloud/vertexai@1.12.0(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
-      "@google/genai": 1.52.0
-      google-auth-library: 9.15.1(encoding@0.1.13)
+      "@google/genai": 1.52.0(supports-color@9.4.0)
+      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@9.4.0)
     transitivePeerDependencies:
       - "@modelcontextprotocol/sdk"
       - bufferutil
@@ -13332,9 +13327,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  "@google/genai@1.52.0":
+  "@google/genai@1.52.0(supports-color@9.4.0)":
     dependencies:
-      google-auth-library: 10.9.1
+      google-auth-library: 10.9.1(supports-color@9.4.0)
       p-retry: 4.6.2
       protobufjs: 7.6.5
       ws: 8.21.3
@@ -13488,12 +13483,12 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  "@jest/core@29.7.0":
+  "@jest/core@29.7.0(supports-color@9.4.0)":
     dependencies:
       "@jest/console": 29.7.0
-      "@jest/reporters": 29.7.0
+      "@jest/reporters": 29.7.0(supports-color@9.4.0)
       "@jest/test-result": 29.7.0
-      "@jest/transform": 29.7.0
+      "@jest/transform": 29.7.0(supports-color@9.4.0)
       "@jest/types": 29.6.3
       "@types/node": 26.2.0
       ansi-escapes: 4.3.2
@@ -13502,15 +13497,15 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@26.2.0)
+      jest-config: 29.7.0(@types/node@26.2.0)(supports-color@9.4.0)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
+      jest-resolve-dependencies: 29.7.0(supports-color@9.4.0)
+      jest-runner: 29.7.0(supports-color@9.4.0)
+      jest-runtime: 29.7.0(supports-color@9.4.0)
+      jest-snapshot: 29.7.0(supports-color@9.4.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       jest-watcher: 29.7.0
@@ -13534,10 +13529,10 @@ snapshots:
     dependencies:
       jest-get-type: 29.6.3
 
-  "@jest/expect@29.7.0":
+  "@jest/expect@29.7.0(supports-color@9.4.0)":
     dependencies:
       expect: 29.7.0
-      jest-snapshot: 29.7.0
+      jest-snapshot: 29.7.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13550,21 +13545,21 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  "@jest/globals@29.7.0":
+  "@jest/globals@29.7.0(supports-color@9.4.0)":
     dependencies:
       "@jest/environment": 29.7.0
-      "@jest/expect": 29.7.0
+      "@jest/expect": 29.7.0(supports-color@9.4.0)
       "@jest/types": 29.6.3
       jest-mock: 29.7.0
     transitivePeerDependencies:
       - supports-color
 
-  "@jest/reporters@29.7.0":
+  "@jest/reporters@29.7.0(supports-color@9.4.0)":
     dependencies:
       "@bcoe/v8-coverage": 0.2.3
       "@jest/console": 29.7.0
       "@jest/test-result": 29.7.0
-      "@jest/transform": 29.7.0
+      "@jest/transform": 29.7.0(supports-color@9.4.0)
       "@jest/types": 29.6.3
       "@jridgewell/trace-mapping": 0.3.31
       "@types/node": 26.2.0
@@ -13574,9 +13569,9 @@ snapshots:
       glob: 7.2.3
       graceful-fs: 4.2.11
       istanbul-lib-coverage: 3.2.2
-      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-instrument: 6.0.3(supports-color@9.4.0)
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 4.0.1
+      istanbul-lib-source-maps: 4.0.1(supports-color@9.4.0)
       istanbul-reports: 3.2.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -13612,12 +13607,12 @@ snapshots:
       jest-haste-map: 29.7.0
       slash: 3.0.0
 
-  "@jest/transform@29.7.0":
+  "@jest/transform@29.7.0(supports-color@9.4.0)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@jest/types": 29.6.3
       "@jridgewell/trace-mapping": 0.3.31
-      babel-plugin-istanbul: 6.1.1
+      babel-plugin-istanbul: 6.1.1(supports-color@9.4.0)
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -13670,11 +13665,11 @@ snapshots:
     dependencies:
       jsep: 1.4.0
 
-  "@lerna/add@3.21.0":
+  "@lerna/add@3.21.0(supports-color@9.4.0)":
     dependencies:
-      "@evocateur/pacote": 9.6.5
-      "@lerna/bootstrap": 3.21.0
-      "@lerna/command": 3.21.0
+      "@evocateur/pacote": 9.6.5(supports-color@9.4.0)
+      "@lerna/bootstrap": 3.21.0(supports-color@9.4.0)
+      "@lerna/command": 3.21.0(supports-color@9.4.0)
       "@lerna/filter-options": 3.20.0
       "@lerna/npm-conf": 3.16.0
       "@lerna/validation-error": 3.13.0
@@ -13685,9 +13680,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@lerna/bootstrap@3.21.0":
+  "@lerna/bootstrap@3.21.0(supports-color@9.4.0)":
     dependencies:
-      "@lerna/command": 3.21.0
+      "@lerna/command": 3.21.0(supports-color@9.4.0)
       "@lerna/filter-options": 3.20.0
       "@lerna/has-npm-version": 3.16.5
       "@lerna/npm-install": 3.16.5
@@ -13713,10 +13708,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@lerna/changed@3.21.0":
+  "@lerna/changed@3.21.0(supports-color@9.4.0)":
     dependencies:
       "@lerna/collect-updates": 3.20.0
-      "@lerna/command": 3.21.0
+      "@lerna/command": 3.21.0(supports-color@9.4.0)
       "@lerna/listable": 3.18.5
       "@lerna/output": 3.13.0
     transitivePeerDependencies:
@@ -13734,9 +13729,9 @@ snapshots:
       execa: 1.0.0
       strong-log-transformer: 2.1.0
 
-  "@lerna/clean@3.21.0":
+  "@lerna/clean@3.21.0(supports-color@9.4.0)":
     dependencies:
-      "@lerna/command": 3.21.0
+      "@lerna/command": 3.21.0(supports-color@9.4.0)
       "@lerna/filter-options": 3.20.0
       "@lerna/prompt": 3.18.5
       "@lerna/pulse-till-done": 3.13.0
@@ -13769,11 +13764,11 @@ snapshots:
       npmlog: 4.1.2
       slash: 2.0.0
 
-  "@lerna/command@3.21.0":
+  "@lerna/command@3.21.0(supports-color@9.4.0)":
     dependencies:
       "@lerna/child-process": 3.16.5
       "@lerna/package-graph": 3.18.5
-      "@lerna/project": 3.21.0
+      "@lerna/project": 3.21.0(supports-color@9.4.0)
       "@lerna/validation-error": 3.13.0
       "@lerna/write-log-file": 3.13.0
       clone-deep: 4.0.1
@@ -13804,17 +13799,17 @@ snapshots:
       fs-extra: 8.1.0
       npmlog: 4.1.2
 
-  "@lerna/create@3.22.0":
+  "@lerna/create@3.22.0(supports-color@9.4.0)":
     dependencies:
-      "@evocateur/pacote": 9.6.5
+      "@evocateur/pacote": 9.6.5(supports-color@9.4.0)
       "@lerna/child-process": 3.16.5
-      "@lerna/command": 3.21.0
+      "@lerna/command": 3.21.0(supports-color@9.4.0)
       "@lerna/npm-conf": 3.16.0
       "@lerna/validation-error": 3.13.0
       camelcase: 5.3.1
       dedent: 0.7.0
       fs-extra: 8.1.0
-      globby: 9.2.0
+      globby: 9.2.0(supports-color@9.4.0)
       init-package-json: 1.10.3
       npm-package-arg: 6.1.1
       p-reduce: 1.0.0
@@ -13832,19 +13827,19 @@ snapshots:
       "@lerna/child-process": 3.16.5
       npmlog: 4.1.2
 
-  "@lerna/diff@3.21.0":
+  "@lerna/diff@3.21.0(supports-color@9.4.0)":
     dependencies:
       "@lerna/child-process": 3.16.5
-      "@lerna/command": 3.21.0
+      "@lerna/command": 3.21.0(supports-color@9.4.0)
       "@lerna/validation-error": 3.13.0
       npmlog: 4.1.2
     transitivePeerDependencies:
       - supports-color
 
-  "@lerna/exec@3.21.0":
+  "@lerna/exec@3.21.0(supports-color@9.4.0)":
     dependencies:
       "@lerna/child-process": 3.16.5
-      "@lerna/command": 3.21.0
+      "@lerna/command": 3.21.0(supports-color@9.4.0)
       "@lerna/filter-options": 3.20.0
       "@lerna/profiler": 3.20.0
       "@lerna/run-topologically": 3.18.5
@@ -13903,10 +13898,10 @@ snapshots:
       "@lerna/child-process": 3.16.5
       semver: 6.3.1
 
-  "@lerna/import@3.22.0":
+  "@lerna/import@3.22.0(supports-color@9.4.0)":
     dependencies:
       "@lerna/child-process": 3.16.5
-      "@lerna/command": 3.21.0
+      "@lerna/command": 3.21.0(supports-color@9.4.0)
       "@lerna/prompt": 3.18.5
       "@lerna/pulse-till-done": 3.13.0
       "@lerna/validation-error": 3.13.0
@@ -13916,27 +13911,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@lerna/info@3.21.0":
+  "@lerna/info@3.21.0(supports-color@9.4.0)":
     dependencies:
-      "@lerna/command": 3.21.0
+      "@lerna/command": 3.21.0(supports-color@9.4.0)
       "@lerna/output": 3.13.0
       envinfo: 7.21.0
     transitivePeerDependencies:
       - supports-color
 
-  "@lerna/init@3.21.0":
+  "@lerna/init@3.21.0(supports-color@9.4.0)":
     dependencies:
       "@lerna/child-process": 3.16.5
-      "@lerna/command": 3.21.0
+      "@lerna/command": 3.21.0(supports-color@9.4.0)
       fs-extra: 8.1.0
       p-map: 2.1.0
       write-json-file: 3.2.0
     transitivePeerDependencies:
       - supports-color
 
-  "@lerna/link@3.21.0":
+  "@lerna/link@3.21.0(supports-color@9.4.0)":
     dependencies:
-      "@lerna/command": 3.21.0
+      "@lerna/command": 3.21.0(supports-color@9.4.0)
       "@lerna/package-graph": 3.18.5
       "@lerna/symlink-dependencies": 3.17.0
       p-map: 2.1.0
@@ -13944,9 +13939,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@lerna/list@3.21.0":
+  "@lerna/list@3.21.0(supports-color@9.4.0)":
     dependencies:
-      "@lerna/command": 3.21.0
+      "@lerna/command": 3.21.0(supports-color@9.4.0)
       "@lerna/filter-options": 3.20.0
       "@lerna/listable": 3.18.5
       "@lerna/output": 3.13.0
@@ -13971,9 +13966,9 @@ snapshots:
       config-chain: 1.1.13
       pify: 4.0.1
 
-  "@lerna/npm-dist-tag@3.18.5":
+  "@lerna/npm-dist-tag@3.18.5(supports-color@9.4.0)":
     dependencies:
-      "@evocateur/npm-registry-fetch": 4.0.0
+      "@evocateur/npm-registry-fetch": 4.0.0(supports-color@9.4.0)
       "@lerna/otplease": 3.18.5
       figgy-pudding: 3.5.2
       npm-package-arg: 6.1.1
@@ -13991,9 +13986,9 @@ snapshots:
       signal-exit: 3.0.7
       write-pkg: 3.2.0
 
-  "@lerna/npm-publish@3.18.5":
+  "@lerna/npm-publish@3.18.5(supports-color@9.4.0)":
     dependencies:
-      "@evocateur/libnpmpublish": 1.2.2
+      "@evocateur/libnpmpublish": 1.2.2(supports-color@9.4.0)
       "@lerna/otplease": 3.18.5
       "@lerna/run-lifecycle": 3.16.2
       figgy-pudding: 3.5.2
@@ -14056,7 +14051,7 @@ snapshots:
       npmlog: 4.1.2
       upath: 1.2.0
 
-  "@lerna/project@3.21.0":
+  "@lerna/project@3.21.0(supports-color@9.4.0)":
     dependencies:
       "@lerna/package": 3.16.0
       "@lerna/validation-error": 3.13.0
@@ -14064,7 +14059,7 @@ snapshots:
       dedent: 0.7.0
       dot-prop: 4.2.1
       glob-parent: 5.1.2
-      globby: 9.2.0
+      globby: 9.2.0(supports-color@9.4.0)
       load-json-file: 5.3.0
       npmlog: 4.1.2
       p-map: 2.1.0
@@ -14078,20 +14073,20 @@ snapshots:
       inquirer: 6.5.2
       npmlog: 4.1.2
 
-  "@lerna/publish@3.22.1(@octokit/core@7.0.7)(encoding@0.1.13)":
+  "@lerna/publish@3.22.1(@octokit/core@7.0.7)(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
-      "@evocateur/libnpmaccess": 3.1.2
-      "@evocateur/npm-registry-fetch": 4.0.0
-      "@evocateur/pacote": 9.6.5
+      "@evocateur/libnpmaccess": 3.1.2(supports-color@9.4.0)
+      "@evocateur/npm-registry-fetch": 4.0.0(supports-color@9.4.0)
+      "@evocateur/pacote": 9.6.5(supports-color@9.4.0)
       "@lerna/check-working-tree": 3.16.5
       "@lerna/child-process": 3.16.5
       "@lerna/collect-updates": 3.20.0
-      "@lerna/command": 3.21.0
+      "@lerna/command": 3.21.0(supports-color@9.4.0)
       "@lerna/describe-ref": 3.16.5
       "@lerna/log-packed": 3.16.0
       "@lerna/npm-conf": 3.16.0
-      "@lerna/npm-dist-tag": 3.18.5
-      "@lerna/npm-publish": 3.18.5
+      "@lerna/npm-dist-tag": 3.18.5(supports-color@9.4.0)
+      "@lerna/npm-publish": 3.18.5(supports-color@9.4.0)
       "@lerna/otplease": 3.18.5
       "@lerna/output": 3.13.0
       "@lerna/pack-directory": 3.16.4
@@ -14101,7 +14096,7 @@ snapshots:
       "@lerna/run-lifecycle": 3.16.2
       "@lerna/run-topologically": 3.18.5
       "@lerna/validation-error": 3.13.0
-      "@lerna/version": 3.22.1(@octokit/core@7.0.7)(encoding@0.1.13)
+      "@lerna/version": 3.22.1(@octokit/core@7.0.7)(encoding@0.1.13)(supports-color@9.4.0)
       figgy-pudding: 3.5.2
       fs-extra: 8.1.0
       npm-package-arg: 6.1.1
@@ -14150,9 +14145,9 @@ snapshots:
       figgy-pudding: 3.5.2
       p-queue: 4.0.0
 
-  "@lerna/run@3.21.0":
+  "@lerna/run@3.21.0(supports-color@9.4.0)":
     dependencies:
-      "@lerna/command": 3.21.0
+      "@lerna/command": 3.21.0(supports-color@9.4.0)
       "@lerna/filter-options": 3.20.0
       "@lerna/npm-run-script": 3.16.5
       "@lerna/output": 3.13.0
@@ -14187,12 +14182,12 @@ snapshots:
     dependencies:
       npmlog: 4.1.2
 
-  "@lerna/version@3.22.1(@octokit/core@7.0.7)(encoding@0.1.13)":
+  "@lerna/version@3.22.1(@octokit/core@7.0.7)(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
       "@lerna/check-working-tree": 3.16.5
       "@lerna/child-process": 3.16.5
       "@lerna/collect-updates": 3.20.0
-      "@lerna/command": 3.21.0
+      "@lerna/command": 3.21.0(supports-color@9.4.0)
       "@lerna/conventional-commits": 3.22.0
       "@lerna/github-client": 3.22.0(@octokit/core@7.0.7)(encoding@0.1.13)
       "@lerna/gitlab-client": 3.15.0(encoding@0.1.13)
@@ -14225,9 +14220,9 @@ snapshots:
       npmlog: 4.1.2
       write-file-atomic: 2.4.3
 
-  "@mistralai/mistralai-gcp@1.7.0(encoding@0.1.13)":
+  "@mistralai/mistralai-gcp@1.7.0(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
-      google-auth-library: 9.15.1(encoding@0.1.13)
+      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@9.4.0)
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
@@ -14373,56 +14368,56 @@ snapshots:
 
   "@opentelemetry/api@1.9.1": {}
 
-  "@opentelemetry/auto-instrumentations-node@0.49.2(@opentelemetry/api@1.9.1)(encoding@0.1.13)":
+  "@opentelemetry/auto-instrumentations-node@0.49.2(@opentelemetry/api@1.9.1)(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-amqplib": 0.41.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-aws-lambda": 0.43.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-aws-sdk": 0.43.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-bunyan": 0.40.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-cassandra-driver": 0.40.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-connect": 0.38.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-cucumber": 0.8.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-dataloader": 0.11.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-dns": 0.38.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-express": 0.41.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-fastify": 0.38.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-fs": 0.14.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-generic-pool": 0.38.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-graphql": 0.42.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-grpc": 0.52.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-hapi": 0.40.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-http": 0.52.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-ioredis": 0.42.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-kafkajs": 0.2.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-knex": 0.39.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-koa": 0.42.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-lru-memoizer": 0.39.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-memcached": 0.38.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-mongodb": 0.46.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-mongoose": 0.41.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-mysql": 0.40.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-mysql2": 0.40.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-nestjs-core": 0.39.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-net": 0.38.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-pg": 0.43.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-pino": 0.41.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-redis": 0.41.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-redis-4": 0.41.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-restify": 0.40.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-router": 0.39.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-socket.io": 0.41.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-tedious": 0.13.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-undici": 0.5.0(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation-winston": 0.39.0(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-amqplib": 0.41.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-aws-lambda": 0.43.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-aws-sdk": 0.43.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-bunyan": 0.40.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-cassandra-driver": 0.40.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-connect": 0.38.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-cucumber": 0.8.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-dataloader": 0.11.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-dns": 0.38.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-express": 0.41.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-fastify": 0.38.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-fs": 0.14.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-generic-pool": 0.38.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-graphql": 0.42.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-grpc": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-hapi": 0.40.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-http": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-ioredis": 0.42.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-kafkajs": 0.2.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-knex": 0.39.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-koa": 0.42.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-lru-memoizer": 0.39.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-memcached": 0.38.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-mongodb": 0.46.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-mongoose": 0.41.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-mysql": 0.40.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-mysql2": 0.40.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-nestjs-core": 0.39.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-net": 0.38.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-pg": 0.43.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-pino": 0.41.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-redis": 0.41.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-redis-4": 0.41.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-restify": 0.40.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-router": 0.39.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-socket.io": 0.41.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-tedious": 0.13.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-undici": 0.5.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
+      "@opentelemetry/instrumentation-winston": 0.39.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/resource-detector-alibaba-cloud": 0.29.7(@opentelemetry/api@1.9.1)
       "@opentelemetry/resource-detector-aws": 1.12.0(@opentelemetry/api@1.9.1)
       "@opentelemetry/resource-detector-azure": 0.2.12(@opentelemetry/api@1.9.1)
       "@opentelemetry/resource-detector-container": 0.4.4(@opentelemetry/api@1.9.1)
-      "@opentelemetry/resource-detector-gcp": 0.29.13(@opentelemetry/api@1.9.1)(encoding@0.1.13)
+      "@opentelemetry/resource-detector-gcp": 0.29.13(@opentelemetry/api@1.9.1)(encoding@0.1.13)(supports-color@9.4.0)
       "@opentelemetry/resources": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/sdk-node": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/sdk-node": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -14477,19 +14472,19 @@ snapshots:
       "@opentelemetry/sdk-trace-base": 1.25.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.25.1
 
-  "@opentelemetry/instrumentation-amqplib@0.41.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-amqplib@0.41.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-aws-lambda@0.43.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-aws-lambda@0.43.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/propagator-aws-xray": 1.26.2(@opentelemetry/api@1.9.1)
       "@opentelemetry/resources": 1.25.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.43.0
@@ -14497,239 +14492,239 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-aws-sdk@0.43.1(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-aws-sdk@0.43.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/propagation-utils": 0.30.16(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-bunyan@0.40.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-bunyan@0.40.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/api-logs": 0.52.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@types/bunyan": 1.8.9
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-cassandra-driver@0.40.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-cassandra-driver@0.40.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-connect@0.38.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-connect@0.38.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
       "@types/connect": 3.4.36
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-cucumber@0.8.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-cucumber@0.8.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-dataloader@0.11.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-dataloader@0.11.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-dns@0.38.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-dns@0.38.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-express@0.41.1(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-express@0.41.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-fastify@0.38.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-fastify@0.38.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-fs@0.14.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-fs@0.14.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-generic-pool@0.38.1(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-generic-pool@0.38.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-graphql@0.42.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-graphql@0.42.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-grpc@0.52.1(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-grpc@0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.25.1
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-hapi@0.40.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-hapi@0.40.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-http@0.52.1(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-http@0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.25.1
       semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-ioredis@0.42.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-ioredis@0.42.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/redis-common": 0.36.2
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-kafkajs@0.2.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-kafkajs@0.2.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-knex@0.39.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-knex@0.39.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-koa@0.42.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-koa@0.42.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-lru-memoizer@0.39.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-lru-memoizer@0.39.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-memcached@0.38.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-memcached@0.38.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
       "@types/memcached": 2.2.10
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-mongodb@0.46.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-mongodb@0.46.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/sdk-metrics": 1.25.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-mongoose@0.41.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-mongoose@0.41.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-mysql2@0.40.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-mysql2@0.40.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
       "@opentelemetry/sql-common": 0.40.1(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-mysql@0.40.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-mysql@0.40.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
       "@types/mysql": 2.15.22
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-nestjs-core@0.39.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-nestjs-core@0.39.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-net@0.38.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-net@0.38.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-pg@0.43.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-pg@0.43.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
       "@opentelemetry/sql-common": 0.40.1(@opentelemetry/api@1.9.1)
       "@types/pg": 8.6.1
@@ -14737,90 +14732,90 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-pino@0.41.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-pino@0.41.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/api-logs": 0.52.1
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-redis-4@0.41.1(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-redis-4@0.41.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/redis-common": 0.36.2
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-redis@0.41.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-redis@0.41.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/redis-common": 0.36.2
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-restify@0.40.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-restify@0.40.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-router@0.39.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-router@0.39.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-socket.io@0.41.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-socket.io@0.41.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-tedious@0.13.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-tedious@0.13.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/semantic-conventions": 1.43.0
       "@types/tedious": 4.0.14
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-undici@0.5.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-undici@0.5.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation-winston@0.39.0(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation-winston@0.39.0(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/api-logs": 0.52.1
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  "@opentelemetry/instrumentation@0.52.1(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/instrumentation@0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/api-logs": 0.52.1
       "@types/shimmer": 1.2.0
       import-in-the-middle: 1.15.0
-      require-in-the-middle: 7.5.2
+      require-in-the-middle: 7.5.2(supports-color@9.4.0)
       semver: 7.8.5
       shimmer: 1.2.1
     transitivePeerDependencies:
@@ -14899,13 +14894,13 @@ snapshots:
       "@opentelemetry/resources": 1.25.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.43.0
 
-  "@opentelemetry/resource-detector-gcp@0.29.13(@opentelemetry/api@1.9.1)(encoding@0.1.13)":
+  "@opentelemetry/resource-detector-gcp@0.29.13(@opentelemetry/api@1.9.1)(encoding@0.1.13)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/core": 1.25.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/resources": 1.25.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/semantic-conventions": 1.43.0
-      gcp-metadata: 6.1.1(encoding@0.1.13)
+      gcp-metadata: 6.1.1(encoding@0.1.13)(supports-color@9.4.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -14930,7 +14925,7 @@ snapshots:
       "@opentelemetry/resources": 1.25.1(@opentelemetry/api@1.9.1)
       lodash.merge: 4.6.2
 
-  "@opentelemetry/sdk-node@0.52.1(@opentelemetry/api@1.9.1)":
+  "@opentelemetry/sdk-node@0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)":
     dependencies:
       "@opentelemetry/api": 1.9.1
       "@opentelemetry/api-logs": 0.52.1
@@ -14939,7 +14934,7 @@ snapshots:
       "@opentelemetry/exporter-trace-otlp-http": 0.52.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/exporter-trace-otlp-proto": 0.52.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/exporter-zipkin": 1.25.1(@opentelemetry/api@1.9.1)
-      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)
+      "@opentelemetry/instrumentation": 0.52.1(@opentelemetry/api@1.9.1)(supports-color@9.4.0)
       "@opentelemetry/resources": 1.25.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/sdk-logs": 0.52.1(@opentelemetry/api@1.9.1)
       "@opentelemetry/sdk-metrics": 1.25.1(@opentelemetry/api@1.9.1)
@@ -15077,10 +15072,10 @@ snapshots:
   "@rollup/rollup-win32-x64-msvc@4.62.4":
     optional: true
 
-  "@sendgrid/client@8.1.6":
+  "@sendgrid/client@8.1.6(debug@4.4.3(supports-color@9.4.0))(supports-color@9.4.0)":
     dependencies:
       "@sendgrid/helpers": 8.0.0
-      axios: 1.19.0
+      axios: 1.19.0(debug@4.4.3(supports-color@9.4.0))(supports-color@9.4.0)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -15089,9 +15084,9 @@ snapshots:
     dependencies:
       deepmerge: 4.3.1
 
-  "@sendgrid/mail@8.1.6":
+  "@sendgrid/mail@8.1.6(debug@4.4.3(supports-color@9.4.0))(supports-color@9.4.0)":
     dependencies:
-      "@sendgrid/client": 8.1.6
+      "@sendgrid/client": 8.1.6(debug@4.4.3(supports-color@9.4.0))(supports-color@9.4.0)
       "@sendgrid/helpers": 8.0.0
     transitivePeerDependencies:
       - debug
@@ -15179,26 +15174,12 @@ snapshots:
 
   "@types/estree@1.0.9": {}
 
-  "@types/express-serve-static-core@4.19.9":
-    dependencies:
-      "@types/node": 26.2.0
-      "@types/qs": 6.15.1
-      "@types/range-parser": 1.2.7
-      "@types/send": 1.2.1
-
   "@types/express-serve-static-core@5.1.3":
     dependencies:
       "@types/node": 26.2.0
       "@types/qs": 6.15.1
       "@types/range-parser": 1.2.7
       "@types/send": 1.2.1
-
-  "@types/express@4.17.25":
-    dependencies:
-      "@types/body-parser": 1.19.6
-      "@types/express-serve-static-core": 4.19.9
-      "@types/qs": 6.15.1
-      "@types/serve-static": 1.15.10
 
   "@types/express@5.0.6":
     dependencies:
@@ -15254,8 +15235,6 @@ snapshots:
   "@types/memcached@2.2.10":
     dependencies:
       "@types/node": 26.2.0
-
-  "@types/mime@1.3.5": {}
 
   "@types/minimatch@6.0.0":
     dependencies:
@@ -15316,20 +15295,9 @@ snapshots:
 
   "@types/retry@0.12.0": {}
 
-  "@types/send@0.17.6":
-    dependencies:
-      "@types/mime": 1.3.5
-      "@types/node": 26.2.0
-
   "@types/send@1.2.1":
     dependencies:
       "@types/node": 26.2.0
-
-  "@types/serve-static@1.15.10":
-    dependencies:
-      "@types/http-errors": 2.0.5
-      "@types/node": 26.2.0
-      "@types/send": 0.17.6
 
   "@types/serve-static@2.2.0":
     dependencies:
@@ -15478,7 +15446,7 @@ snapshots:
     dependencies:
       es6-promisify: 5.0.0
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@9.4.0):
     dependencies:
       debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
@@ -15665,35 +15633,35 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.19.0:
+  axios@1.19.0(debug@4.4.3(supports-color@9.4.0))(supports-color@9.4.0):
     dependencies:
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@9.4.0))
       form-data: 4.0.6
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@9.4.0)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
       - supports-color
 
-  babel-jest@29.7.0(@babel/core@7.29.7):
+  babel-jest@29.7.0(@babel/core@7.29.7(supports-color@9.4.0))(supports-color@9.4.0):
     dependencies:
-      "@babel/core": 7.29.7
-      "@jest/transform": 29.7.0
+      "@babel/core": 7.29.7(supports-color@9.4.0)
+      "@jest/transform": 29.7.0(supports-color@9.4.0)
       "@types/babel__core": 7.20.5
-      babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.6.3(@babel/core@7.29.7)
+      babel-plugin-istanbul: 6.1.1(supports-color@9.4.0)
+      babel-preset-jest: 29.6.3(@babel/core@7.29.7(supports-color@9.4.0))
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-istanbul@6.1.1:
+  babel-plugin-istanbul@6.1.1(supports-color@9.4.0):
     dependencies:
       "@babel/helper-plugin-utils": 7.29.7
       "@istanbuljs/load-nyc-config": 1.1.0
       "@istanbuljs/schema": 0.1.6
-      istanbul-lib-instrument: 5.2.1
+      istanbul-lib-instrument: 5.2.1(supports-color@9.4.0)
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
@@ -15705,30 +15673,30 @@ snapshots:
       "@types/babel__core": 7.20.5
       "@types/babel__traverse": 7.28.0
 
-  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.7):
+  babel-preset-current-node-syntax@1.2.0(@babel/core@7.29.7(supports-color@9.4.0)):
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/plugin-syntax-async-generators": 7.8.4(@babel/core@7.29.7)
-      "@babel/plugin-syntax-bigint": 7.8.3(@babel/core@7.29.7)
-      "@babel/plugin-syntax-class-properties": 7.12.13(@babel/core@7.29.7)
-      "@babel/plugin-syntax-class-static-block": 7.14.5(@babel/core@7.29.7)
-      "@babel/plugin-syntax-import-attributes": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-syntax-import-meta": 7.10.4(@babel/core@7.29.7)
-      "@babel/plugin-syntax-json-strings": 7.8.3(@babel/core@7.29.7)
-      "@babel/plugin-syntax-logical-assignment-operators": 7.10.4(@babel/core@7.29.7)
-      "@babel/plugin-syntax-nullish-coalescing-operator": 7.8.3(@babel/core@7.29.7)
-      "@babel/plugin-syntax-numeric-separator": 7.10.4(@babel/core@7.29.7)
-      "@babel/plugin-syntax-object-rest-spread": 7.8.3(@babel/core@7.29.7)
-      "@babel/plugin-syntax-optional-catch-binding": 7.8.3(@babel/core@7.29.7)
-      "@babel/plugin-syntax-optional-chaining": 7.8.3(@babel/core@7.29.7)
-      "@babel/plugin-syntax-private-property-in-object": 7.14.5(@babel/core@7.29.7)
-      "@babel/plugin-syntax-top-level-await": 7.14.5(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@9.4.0)
+      "@babel/plugin-syntax-async-generators": 7.8.4(@babel/core@7.29.7(supports-color@9.4.0))
+      "@babel/plugin-syntax-bigint": 7.8.3(@babel/core@7.29.7(supports-color@9.4.0))
+      "@babel/plugin-syntax-class-properties": 7.12.13(@babel/core@7.29.7(supports-color@9.4.0))
+      "@babel/plugin-syntax-class-static-block": 7.14.5(@babel/core@7.29.7(supports-color@9.4.0))
+      "@babel/plugin-syntax-import-attributes": 7.29.7(@babel/core@7.29.7(supports-color@9.4.0))
+      "@babel/plugin-syntax-import-meta": 7.10.4(@babel/core@7.29.7(supports-color@9.4.0))
+      "@babel/plugin-syntax-json-strings": 7.8.3(@babel/core@7.29.7(supports-color@9.4.0))
+      "@babel/plugin-syntax-logical-assignment-operators": 7.10.4(@babel/core@7.29.7(supports-color@9.4.0))
+      "@babel/plugin-syntax-nullish-coalescing-operator": 7.8.3(@babel/core@7.29.7(supports-color@9.4.0))
+      "@babel/plugin-syntax-numeric-separator": 7.10.4(@babel/core@7.29.7(supports-color@9.4.0))
+      "@babel/plugin-syntax-object-rest-spread": 7.8.3(@babel/core@7.29.7(supports-color@9.4.0))
+      "@babel/plugin-syntax-optional-catch-binding": 7.8.3(@babel/core@7.29.7(supports-color@9.4.0))
+      "@babel/plugin-syntax-optional-chaining": 7.8.3(@babel/core@7.29.7(supports-color@9.4.0))
+      "@babel/plugin-syntax-private-property-in-object": 7.14.5(@babel/core@7.29.7(supports-color@9.4.0))
+      "@babel/plugin-syntax-top-level-await": 7.14.5(@babel/core@7.29.7(supports-color@9.4.0))
 
-  babel-preset-jest@29.6.3(@babel/core@7.29.7):
+  babel-preset-jest@29.6.3(@babel/core@7.29.7(supports-color@9.4.0)):
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7(supports-color@9.4.0))
 
   balanced-match@1.0.2: {}
 
@@ -15764,11 +15732,11 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  body-parser@1.20.6:
+  body-parser@1.20.6(supports-color@9.4.0):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@9.4.0)
       depd: 2.0.0
       destroy: 1.2.0
       http-errors: 2.0.1
@@ -15781,7 +15749,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.3.0:
+  body-parser@2.3.0(supports-color@9.4.0):
     dependencies:
       bytes: 3.1.2
       content-type: 2.1.0
@@ -15808,7 +15776,7 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  braces@2.3.2:
+  braces@2.3.2(supports-color@9.4.0):
     dependencies:
       arr-flatten: 1.1.0
       array-unique: 0.3.2
@@ -15816,7 +15784,7 @@ snapshots:
       fill-range: 4.0.0
       isobject: 3.0.1
       repeat-element: 1.1.4
-      snapdragon: 0.8.2
+      snapdragon: 0.8.2(supports-color@9.4.0)
       snapdragon-node: 2.1.1
       split-string: 3.1.0
       to-regex: 3.0.2
@@ -16037,12 +16005,12 @@ snapshots:
 
   code-point-at@1.1.0: {}
 
-  codecov@3.8.3(encoding@0.1.13):
+  codecov@3.8.3(encoding@0.1.13)(supports-color@9.4.0):
     dependencies:
       argv: 0.0.2
       ignore-walk: 3.0.4
       js-yaml: 3.14.1
-      teeny-request: 7.1.1(encoding@0.1.13)
+      teeny-request: 7.1.1(encoding@0.1.13)(supports-color@9.4.0)
       urlgrey: 1.0.0
     transitivePeerDependencies:
       - encoding
@@ -16245,13 +16213,13 @@ snapshots:
       js-yaml: 3.15.1
       parse-json: 4.0.0
 
-  create-jest@29.7.0(@types/node@26.2.0):
+  create-jest@29.7.0(@types/node@26.2.0)(supports-color@9.4.0):
     dependencies:
       "@jest/types": 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@26.2.0)
+      jest-config: 29.7.0(@types/node@26.2.0)(supports-color@9.4.0)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -16314,17 +16282,23 @@ snapshots:
 
   dateformat@3.0.3: {}
 
-  debug@2.6.9:
+  debug@2.6.9(supports-color@9.4.0):
     dependencies:
       ms: 2.0.0
+    optionalDependencies:
+      supports-color: 9.4.0
 
-  debug@3.1.0:
+  debug@3.1.0(supports-color@9.4.0):
     dependencies:
       ms: 2.0.0
+    optionalDependencies:
+      supports-color: 9.4.0
 
-  debug@3.2.7:
+  debug@3.2.7(supports-color@9.4.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 9.4.0
 
   debug@4.4.3(supports-color@9.4.0):
     dependencies:
@@ -16675,14 +16649,14 @@ snapshots:
 
   exit@0.1.2: {}
 
-  expand-brackets@2.1.4:
+  expand-brackets@2.1.4(supports-color@9.4.0):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@9.4.0)
       define-property: 0.2.5
       extend-shallow: 2.0.1
       posix-character-classes: 0.1.1
       regex-not: 1.0.2
-      snapdragon: 0.8.2
+      snapdragon: 0.8.2(supports-color@9.4.0)
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -16697,21 +16671,21 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
-  express@4.22.2:
+  express@4.22.2(supports-color@9.4.0):
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.6
+      body-parser: 1.20.6(supports-color@9.4.0)
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.0.7
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@9.4.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.2
+      finalhandler: 1.3.2(supports-color@9.4.0)
       fresh: 0.5.2
       http-errors: 2.0.1
       merge-descriptors: 1.0.3
@@ -16723,8 +16697,8 @@ snapshots:
       qs: 6.15.3
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.19.2
-      serve-static: 1.16.3
+      send: 0.19.2(supports-color@9.4.0)
+      serve-static: 1.16.3(supports-color@9.4.0)
       setprototypeof: 1.2.0
       statuses: 2.0.2
       type-is: 1.6.18
@@ -16733,10 +16707,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.2.1:
+  express@5.2.1(supports-color@9.4.0):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.3.0
+      body-parser: 2.3.0(supports-color@9.4.0)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -16746,7 +16720,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@9.4.0)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -16757,9 +16731,9 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.3
       range-parser: 1.3.0
-      router: 2.2.0
-      send: 1.2.1
-      serve-static: 2.2.1
+      router: 2.2.0(supports-color@9.4.0)
+      send: 1.2.1(supports-color@9.4.0)
+      serve-static: 2.2.1(supports-color@9.4.0)
       statuses: 2.0.2
       type-is: 2.1.0
       vary: 1.1.2
@@ -16783,15 +16757,15 @@ snapshots:
       iconv-lite: 0.4.24
       tmp: 0.0.33
 
-  extglob@2.0.4:
+  extglob@2.0.4(supports-color@9.4.0):
     dependencies:
       array-unique: 0.3.2
       define-property: 1.0.0
-      expand-brackets: 2.1.4
+      expand-brackets: 2.1.4(supports-color@9.4.0)
       extend-shallow: 2.0.1
       fragment-cache: 0.2.1
       regex-not: 1.0.2
-      snapdragon: 0.8.2
+      snapdragon: 0.8.2(supports-color@9.4.0)
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -16802,14 +16776,14 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-glob@2.2.7:
+  fast-glob@2.2.7(supports-color@9.4.0):
     dependencies:
       "@mrmlnc/readdir-enhanced": 2.2.1
       "@nodelib/fs.stat": 1.1.3
       glob-parent: 3.1.0
       is-glob: 4.0.3
       merge2: 1.4.1
-      micromatch: 3.1.10
+      micromatch: 3.1.10(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -16873,9 +16847,9 @@ snapshots:
 
   filter-obj@1.1.0: {}
 
-  finalhandler@1.3.2:
+  finalhandler@1.3.2(supports-color@9.4.0):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@9.4.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -16885,7 +16859,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@9.4.0):
     dependencies:
       debug: 4.4.3(supports-color@9.4.0)
       encodeurl: 2.0.0
@@ -16914,72 +16888,72 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
-  firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13):
+  firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0):
     dependencies:
       "@fastify/busboy": 3.2.1
       "@firebase/database-compat": 2.1.6(@firebase/app@0.16.0)
       "@firebase/database-types": 1.0.21
       farmhash-modern: 1.1.0
       fast-deep-equal: 3.1.3
-      google-auth-library: 10.9.1
+      google-auth-library: 10.9.1(supports-color@9.4.0)
       jsonwebtoken: 9.0.3
-      jwks-rsa: 3.2.2
+      jwks-rsa: 3.2.2(supports-color@9.4.0)
     optionalDependencies:
-      "@google-cloud/firestore": 7.11.6(encoding@0.1.13)
-      "@google-cloud/storage": 7.22.0(encoding@0.1.13)
+      "@google-cloud/firestore": 7.11.6(encoding@0.1.13)(supports-color@9.4.0)
+      "@google-cloud/storage": 7.22.0(encoding@0.1.13)(supports-color@9.4.0)
     transitivePeerDependencies:
       - "@firebase/app"
       - "@firebase/app-compat"
       - encoding
       - supports-color
 
-  firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13):
+  firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0):
     dependencies:
       "@fastify/busboy": 3.2.1
       "@firebase/database-compat": 2.1.6(@firebase/app@0.16.0)
       "@firebase/database-types": 1.0.21
       fast-deep-equal: 3.1.3
-      google-auth-library: 10.9.1
+      google-auth-library: 10.9.1(supports-color@9.4.0)
       jsonwebtoken: 9.0.3
-      jwks-rsa: 4.1.0
+      jwks-rsa: 4.1.0(supports-color@9.4.0)
     optionalDependencies:
-      "@google-cloud/firestore": 8.7.1
-      "@google-cloud/storage": 7.22.0(encoding@0.1.13)
+      "@google-cloud/firestore": 8.7.1(supports-color@9.4.0)
+      "@google-cloud/storage": 7.22.0(encoding@0.1.13)(supports-color@9.4.0)
     transitivePeerDependencies:
       - "@firebase/app"
       - "@firebase/app-compat"
       - encoding
       - supports-color
 
-  firebase-functions@6.6.0(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)):
-    dependencies:
-      "@types/cors": 2.8.19
-      "@types/express": 4.17.25
-      cors: 2.8.6
-      express: 4.22.2
-      firebase-admin: 13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)
-      protobufjs: 7.6.5
-    transitivePeerDependencies:
-      - supports-color
-
-  firebase-functions@7.3.2(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)):
+  firebase-functions@7.3.2(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0):
     dependencies:
       "@types/cors": 2.8.19
       "@types/express": 5.0.6
       cors: 2.8.6
-      express: 5.2.1
-      firebase-admin: 13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)
+      express: 5.2.1(supports-color@9.4.0)
+      firebase-admin: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
       protobufjs: 7.6.5
     transitivePeerDependencies:
       - supports-color
 
-  firebase-functions@7.3.2(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)):
+  firebase-functions@7.3.3-rc.1(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0):
     dependencies:
       "@types/cors": 2.8.19
       "@types/express": 5.0.6
       cors: 2.8.6
-      express: 5.2.1
-      firebase-admin: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)
+      express: 5.2.1(supports-color@9.4.0)
+      firebase-admin: 13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
+      protobufjs: 7.6.5
+    transitivePeerDependencies:
+      - supports-color
+
+  firebase-functions@7.3.3-rc.1(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0):
+    dependencies:
+      "@types/cors": 2.8.19
+      "@types/express": 5.0.6
+      cors: 2.8.6
+      express: 5.2.1(supports-color@9.4.0)
+      firebase-admin: 14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0)
       protobufjs: 7.6.5
     transitivePeerDependencies:
       - supports-color
@@ -16996,7 +16970,9 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  follow-redirects@1.16.0: {}
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@9.4.0)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@9.4.0)
 
   for-each@0.3.5:
     dependencies:
@@ -17111,10 +17087,10 @@ snapshots:
       strip-ansi: 3.0.1
       wide-align: 1.1.5
 
-  gaxios@6.7.1(encoding@0.1.13):
+  gaxios@6.7.1(encoding@0.1.13)(supports-color@9.4.0):
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@9.4.0)
       is-stream: 2.0.1
       node-fetch: 2.7.0(encoding@0.1.13)
       uuid: 9.0.1
@@ -17122,43 +17098,43 @@ snapshots:
       - encoding
       - supports-color
 
-  gaxios@7.1.3:
+  gaxios@7.1.3(supports-color@9.4.0):
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@9.4.0)
       node-fetch: 3.3.2
       rimraf: 5.0.10
     transitivePeerDependencies:
       - supports-color
 
-  gaxios@7.3.1:
+  gaxios@7.3.1(supports-color@9.4.0):
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@9.4.0)
       node-fetch: 3.3.2
     transitivePeerDependencies:
       - supports-color
 
-  gcp-metadata@6.1.1(encoding@0.1.13):
+  gcp-metadata@6.1.1(encoding@0.1.13)(supports-color@9.4.0):
     dependencies:
-      gaxios: 6.7.1(encoding@0.1.13)
+      gaxios: 6.7.1(encoding@0.1.13)(supports-color@9.4.0)
       google-logging-utils: 0.0.2
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  gcp-metadata@8.1.2:
+  gcp-metadata@8.1.2(supports-color@9.4.0):
     dependencies:
-      gaxios: 7.3.1
+      gaxios: 7.3.1(supports-color@9.4.0)
       google-logging-utils: 1.1.3
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - supports-color
 
-  gcp-metadata@8.1.4:
+  gcp-metadata@8.1.4(supports-color@9.4.0):
     dependencies:
-      gaxios: 7.1.3
+      gaxios: 7.1.3(supports-color@9.4.0)
       google-logging-utils: 1.1.3
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -17173,10 +17149,10 @@ snapshots:
 
   genfun@5.0.0: {}
 
-  genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)):
+  genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0):
     dependencies:
-      "@genkit-ai/ai": 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))
-      "@genkit-ai/core": 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))
+      "@genkit-ai/ai": 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)
+      "@genkit-ai/core": 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)
       uuid: 10.0.0
     transitivePeerDependencies:
       - "@google-cloud/firestore"
@@ -17187,24 +17163,10 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)):
+  genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0):
     dependencies:
-      "@genkit-ai/ai": 1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)))
-      "@genkit-ai/core": 1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@13.10.0(@firebase/app@0.16.0)(encoding@0.1.13)))
-      uuid: 10.0.0
-    transitivePeerDependencies:
-      - "@google-cloud/firestore"
-      - bufferutil
-      - encoding
-      - firebase
-      - firebase-admin
-      - supports-color
-      - utf-8-validate
-
-  genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)):
-    dependencies:
-      "@genkit-ai/ai": 1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))
-      "@genkit-ai/core": 1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13))(genkit@1.41.0(@google-cloud/firestore@8.7.1)(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)))
+      "@genkit-ai/ai": 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)
+      "@genkit-ai/core": 1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(genkit@1.41.0(@google-cloud/firestore@7.11.6(encoding@0.1.13)(supports-color@9.4.0))(encoding@0.1.13)(firebase-admin@14.2.0(@firebase/app@0.16.0)(encoding@0.1.13)(supports-color@9.4.0))(supports-color@9.4.0))(supports-color@9.4.0)
       uuid: 10.0.0
     transitivePeerDependencies:
       - "@google-cloud/firestore"
@@ -17336,12 +17298,12 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
-  globby@9.2.0:
+  globby@9.2.0(supports-color@9.4.0):
     dependencies:
       "@types/glob": 7.2.0
       array-union: 1.0.2
       dir-glob: 2.2.2
-      fast-glob: 2.2.7
+      fast-glob: 2.2.7(supports-color@9.4.0)
       glob: 7.2.3
       ignore: 4.0.6
       pify: 4.0.1
@@ -17349,71 +17311,71 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  google-auth-library@10.5.0:
+  google-auth-library@10.5.0(supports-color@9.4.0):
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.3.1
-      gcp-metadata: 8.1.4
+      gaxios: 7.3.1(supports-color@9.4.0)
+      gcp-metadata: 8.1.4(supports-color@9.4.0)
       google-logging-utils: 1.1.3
-      gtoken: 8.0.0
+      gtoken: 8.0.0(supports-color@9.4.0)
       jws: 4.0.1
     transitivePeerDependencies:
       - supports-color
 
-  google-auth-library@10.9.1:
+  google-auth-library@10.9.1(supports-color@9.4.0):
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.3.1
-      gcp-metadata: 8.1.2
+      gaxios: 7.3.1(supports-color@9.4.0)
+      gcp-metadata: 8.1.2(supports-color@9.4.0)
       google-logging-utils: 1.1.3
       jws: 4.0.1
     transitivePeerDependencies:
       - supports-color
 
-  google-auth-library@9.15.1(encoding@0.1.13):
+  google-auth-library@9.15.1(encoding@0.1.13)(supports-color@9.4.0):
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 6.7.1(encoding@0.1.13)
-      gcp-metadata: 6.1.1(encoding@0.1.13)
-      gtoken: 7.1.0(encoding@0.1.13)
+      gaxios: 6.7.1(encoding@0.1.13)(supports-color@9.4.0)
+      gcp-metadata: 6.1.1(encoding@0.1.13)(supports-color@9.4.0)
+      gtoken: 7.1.0(encoding@0.1.13)(supports-color@9.4.0)
       jws: 4.0.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  google-gax@4.6.1(encoding@0.1.13):
+  google-gax@4.6.1(encoding@0.1.13)(supports-color@9.4.0):
     dependencies:
       "@grpc/grpc-js": 1.14.4
       "@grpc/proto-loader": 0.7.15
       "@types/long": 4.0.2
       abort-controller: 3.0.0
       duplexify: 4.1.3
-      google-auth-library: 9.15.1(encoding@0.1.13)
+      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@9.4.0)
       node-fetch: 2.7.0(encoding@0.1.13)
       object-hash: 3.0.0
       proto3-json-serializer: 2.0.2
       protobufjs: 7.6.5
-      retry-request: 7.0.2(encoding@0.1.13)
+      retry-request: 7.0.2(encoding@0.1.13)(supports-color@9.4.0)
       uuid: 9.0.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  google-gax@5.0.8:
+  google-gax@5.0.8(supports-color@9.4.0):
     dependencies:
       "@grpc/grpc-js": 1.14.4
       "@grpc/proto-loader": 0.8.1
       duplexify: 4.1.3
-      google-auth-library: 10.5.0
+      google-auth-library: 10.5.0(supports-color@9.4.0)
       google-logging-utils: 1.1.3
       node-fetch: 3.3.2
       object-hash: 3.0.0
       proto3-json-serializer: 3.0.4
       protobufjs: 7.6.5
-      retry-request: 8.0.4
+      retry-request: 8.0.4(supports-color@9.4.0)
       rimraf: 5.0.10
     transitivePeerDependencies:
       - supports-color
@@ -17422,11 +17384,11 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
-  googleapis-common@7.2.0(encoding@0.1.13):
+  googleapis-common@7.2.0(encoding@0.1.13)(supports-color@9.4.0):
     dependencies:
       extend: 3.0.2
-      gaxios: 6.7.1(encoding@0.1.13)
-      google-auth-library: 9.15.1(encoding@0.1.13)
+      gaxios: 6.7.1(encoding@0.1.13)(supports-color@9.4.0)
+      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@9.4.0)
       qs: 6.15.3
       url-template: 2.0.8
       uuid: 9.0.1
@@ -17434,18 +17396,18 @@ snapshots:
       - encoding
       - supports-color
 
-  googleapis@137.1.0(encoding@0.1.13):
+  googleapis@137.1.0(encoding@0.1.13)(supports-color@9.4.0):
     dependencies:
-      google-auth-library: 9.15.1(encoding@0.1.13)
-      googleapis-common: 7.2.0(encoding@0.1.13)
+      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@9.4.0)
+      googleapis-common: 7.2.0(encoding@0.1.13)(supports-color@9.4.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  googleapis@140.0.1(encoding@0.1.13):
+  googleapis@140.0.1(encoding@0.1.13)(supports-color@9.4.0):
     dependencies:
-      google-auth-library: 9.15.1(encoding@0.1.13)
-      googleapis-common: 7.2.0(encoding@0.1.13)
+      google-auth-library: 9.15.1(encoding@0.1.13)(supports-color@9.4.0)
+      googleapis-common: 7.2.0(encoding@0.1.13)(supports-color@9.4.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -17454,17 +17416,17 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  gtoken@7.1.0(encoding@0.1.13):
+  gtoken@7.1.0(encoding@0.1.13)(supports-color@9.4.0):
     dependencies:
-      gaxios: 6.7.1(encoding@0.1.13)
+      gaxios: 6.7.1(encoding@0.1.13)(supports-color@9.4.0)
       jws: 4.0.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  gtoken@8.0.0:
+  gtoken@8.0.0(supports-color@9.4.0):
     dependencies:
-      gaxios: 7.3.1
+      gaxios: 7.3.1(supports-color@9.4.0)
       jws: 4.0.1
     transitivePeerDependencies:
       - supports-color
@@ -17558,30 +17520,30 @@ snapshots:
 
   http-parser-js@0.5.10: {}
 
-  http-proxy-agent@2.1.0:
+  http-proxy-agent@2.1.0(supports-color@9.4.0):
     dependencies:
       agent-base: 4.3.0
-      debug: 3.1.0
+      debug: 3.1.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-agent@4.0.1:
+  http-proxy-agent@4.0.1(supports-color@9.4.0):
     dependencies:
       "@tootallnate/once": 1.1.2
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@9.4.0)
       debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-agent@5.0.0:
+  http-proxy-agent@5.0.0(supports-color@9.4.0):
     dependencies:
       "@tootallnate/once": 2.0.1
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@9.4.0)
       debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@9.4.0):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@9.4.0)
@@ -17594,21 +17556,21 @@ snapshots:
       jsprim: 1.4.2
       sshpk: 1.18.0
 
-  https-proxy-agent@2.2.4:
+  https-proxy-agent@2.2.4(supports-color@9.4.0):
     dependencies:
       agent-base: 4.3.0
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@9.4.0):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@9.4.0)
       debug: 4.4.3(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@9.4.0):
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@9.4.0)
@@ -17956,9 +17918,9 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
-  istanbul-lib-instrument@5.2.1:
+  istanbul-lib-instrument@5.2.1(supports-color@9.4.0):
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/parser": 7.29.8
       "@istanbuljs/schema": 0.1.6
       istanbul-lib-coverage: 3.2.2
@@ -17966,9 +17928,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  istanbul-lib-instrument@6.0.3:
+  istanbul-lib-instrument@6.0.3(supports-color@9.4.0):
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/parser": 7.29.8
       "@istanbuljs/schema": 0.1.6
       istanbul-lib-coverage: 3.2.2
@@ -17982,7 +17944,7 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@4.0.1:
+  istanbul-lib-source-maps@4.0.1(supports-color@9.4.0):
     dependencies:
       debug: 4.4.3(supports-color@9.4.0)
       istanbul-lib-coverage: 3.2.2
@@ -18007,10 +17969,10 @@ snapshots:
       jest-util: 29.7.0
       p-limit: 3.1.0
 
-  jest-circus@29.7.0:
+  jest-circus@29.7.0(supports-color@9.4.0):
     dependencies:
       "@jest/environment": 29.7.0
-      "@jest/expect": 29.7.0
+      "@jest/expect": 29.7.0(supports-color@9.4.0)
       "@jest/test-result": 29.7.0
       "@jest/types": 29.6.3
       "@types/node": 26.2.0
@@ -18021,8 +17983,8 @@ snapshots:
       jest-each: 29.7.0
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
+      jest-runtime: 29.7.0(supports-color@9.4.0)
+      jest-snapshot: 29.7.0(supports-color@9.4.0)
       jest-util: 29.7.0
       p-limit: 3.1.0
       pretty-format: 29.7.0
@@ -18033,16 +17995,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@26.2.0):
+  jest-cli@29.7.0(@types/node@26.2.0)(supports-color@9.4.0):
     dependencies:
-      "@jest/core": 29.7.0
+      "@jest/core": 29.7.0(supports-color@9.4.0)
       "@jest/test-result": 29.7.0
       "@jest/types": 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@26.2.0)
+      create-jest: 29.7.0(@types/node@26.2.0)(supports-color@9.4.0)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@26.2.0)
+      jest-config: 29.7.0(@types/node@26.2.0)(supports-color@9.4.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.3
@@ -18052,23 +18014,23 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@26.2.0):
+  jest-config@29.7.0(@types/node@26.2.0)(supports-color@9.4.0):
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@jest/test-sequencer": 29.7.0
       "@jest/types": 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.7)
+      babel-jest: 29.7.0(@babel/core@7.29.7(supports-color@9.4.0))(supports-color@9.4.0)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      jest-circus: 29.7.0
+      jest-circus: 29.7.0(supports-color@9.4.0)
       jest-environment-node: 29.7.0
       jest-get-type: 29.6.3
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-runner: 29.7.0
+      jest-runner: 29.7.0(supports-color@9.4.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       micromatch: 4.0.8
@@ -18164,10 +18126,10 @@ snapshots:
 
   jest-regex-util@29.6.3: {}
 
-  jest-resolve-dependencies@29.7.0:
+  jest-resolve-dependencies@29.7.0(supports-color@9.4.0):
     dependencies:
       jest-regex-util: 29.6.3
-      jest-snapshot: 29.7.0
+      jest-snapshot: 29.7.0(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18183,12 +18145,12 @@ snapshots:
       resolve.exports: 2.0.3
       slash: 3.0.0
 
-  jest-runner@29.7.0:
+  jest-runner@29.7.0(supports-color@9.4.0):
     dependencies:
       "@jest/console": 29.7.0
       "@jest/environment": 29.7.0
       "@jest/test-result": 29.7.0
-      "@jest/transform": 29.7.0
+      "@jest/transform": 29.7.0(supports-color@9.4.0)
       "@jest/types": 29.6.3
       "@types/node": 26.2.0
       chalk: 4.1.2
@@ -18200,7 +18162,7 @@ snapshots:
       jest-leak-detector: 29.7.0
       jest-message-util: 29.7.0
       jest-resolve: 29.7.0
-      jest-runtime: 29.7.0
+      jest-runtime: 29.7.0(supports-color@9.4.0)
       jest-util: 29.7.0
       jest-watcher: 29.7.0
       jest-worker: 29.7.0
@@ -18209,14 +18171,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-runtime@29.7.0:
+  jest-runtime@29.7.0(supports-color@9.4.0):
     dependencies:
       "@jest/environment": 29.7.0
       "@jest/fake-timers": 29.7.0
-      "@jest/globals": 29.7.0
+      "@jest/globals": 29.7.0(supports-color@9.4.0)
       "@jest/source-map": 29.6.3
       "@jest/test-result": 29.7.0
-      "@jest/transform": 29.7.0
+      "@jest/transform": 29.7.0(supports-color@9.4.0)
       "@jest/types": 29.6.3
       "@types/node": 26.2.0
       chalk: 4.1.2
@@ -18229,24 +18191,24 @@ snapshots:
       jest-mock: 29.7.0
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-snapshot: 29.7.0
+      jest-snapshot: 29.7.0(supports-color@9.4.0)
       jest-util: 29.7.0
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
-  jest-snapshot@29.7.0:
+  jest-snapshot@29.7.0(supports-color@9.4.0):
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@9.4.0)
       "@babel/generator": 7.29.8
-      "@babel/plugin-syntax-jsx": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-syntax-typescript": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-syntax-jsx": 7.29.7(@babel/core@7.29.7(supports-color@9.4.0))
+      "@babel/plugin-syntax-typescript": 7.29.7(@babel/core@7.29.7(supports-color@9.4.0))
       "@babel/types": 7.29.8
       "@jest/expect-utils": 29.7.0
-      "@jest/transform": 29.7.0
+      "@jest/transform": 29.7.0(supports-color@9.4.0)
       "@jest/types": 29.6.3
-      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7)
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7(supports-color@9.4.0))
       chalk: 4.1.2
       expect: 29.7.0
       graceful-fs: 4.2.11
@@ -18297,12 +18259,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@26.2.0):
+  jest@29.7.0(@types/node@26.2.0)(supports-color@9.4.0):
     dependencies:
-      "@jest/core": 29.7.0
+      "@jest/core": 29.7.0(supports-color@9.4.0)
       "@jest/types": 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@26.2.0)
+      jest-cli: 29.7.0(@types/node@26.2.0)(supports-color@9.4.0)
     transitivePeerDependencies:
       - "@types/node"
       - babel-plugin-macros
@@ -18396,7 +18358,7 @@ snapshots:
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
 
-  jwks-rsa@3.2.2:
+  jwks-rsa@3.2.2(supports-color@9.4.0):
     dependencies:
       "@types/jsonwebtoken": 9.0.10
       debug: 4.4.3(supports-color@9.4.0)
@@ -18406,7 +18368,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jwks-rsa@4.1.0:
+  jwks-rsa@4.1.0(supports-color@9.4.0):
     dependencies:
       "@types/jsonwebtoken": 9.0.10
       debug: 4.4.3(supports-color@9.4.0)
@@ -18436,24 +18398,24 @@ snapshots:
 
   kuler@2.0.0: {}
 
-  lerna@3.22.1(@octokit/core@7.0.7)(encoding@0.1.13):
+  lerna@3.22.1(@octokit/core@7.0.7)(encoding@0.1.13)(supports-color@9.4.0):
     dependencies:
-      "@lerna/add": 3.21.0
-      "@lerna/bootstrap": 3.21.0
-      "@lerna/changed": 3.21.0
-      "@lerna/clean": 3.21.0
+      "@lerna/add": 3.21.0(supports-color@9.4.0)
+      "@lerna/bootstrap": 3.21.0(supports-color@9.4.0)
+      "@lerna/changed": 3.21.0(supports-color@9.4.0)
+      "@lerna/clean": 3.21.0(supports-color@9.4.0)
       "@lerna/cli": 3.18.5
-      "@lerna/create": 3.22.0
-      "@lerna/diff": 3.21.0
-      "@lerna/exec": 3.21.0
-      "@lerna/import": 3.22.0
-      "@lerna/info": 3.21.0
-      "@lerna/init": 3.21.0
-      "@lerna/link": 3.21.0
-      "@lerna/list": 3.21.0
-      "@lerna/publish": 3.22.1(@octokit/core@7.0.7)(encoding@0.1.13)
-      "@lerna/run": 3.21.0
-      "@lerna/version": 3.22.1(@octokit/core@7.0.7)(encoding@0.1.13)
+      "@lerna/create": 3.22.0(supports-color@9.4.0)
+      "@lerna/diff": 3.21.0(supports-color@9.4.0)
+      "@lerna/exec": 3.21.0(supports-color@9.4.0)
+      "@lerna/import": 3.22.0(supports-color@9.4.0)
+      "@lerna/info": 3.21.0(supports-color@9.4.0)
+      "@lerna/init": 3.21.0(supports-color@9.4.0)
+      "@lerna/link": 3.21.0(supports-color@9.4.0)
+      "@lerna/list": 3.21.0(supports-color@9.4.0)
+      "@lerna/publish": 3.22.1(@octokit/core@7.0.7)(encoding@0.1.13)(supports-color@9.4.0)
+      "@lerna/run": 3.21.0(supports-color@9.4.0)
+      "@lerna/version": 3.22.1(@octokit/core@7.0.7)(encoding@0.1.13)(supports-color@9.4.0)
       import-local: 2.0.0
       npmlog: 4.1.2
     transitivePeerDependencies:
@@ -18657,13 +18619,13 @@ snapshots:
 
   make-error@1.3.6: {}
 
-  make-fetch-happen@5.0.2:
+  make-fetch-happen@5.0.2(supports-color@9.4.0):
     dependencies:
       agentkeepalive: 3.5.3
       cacache: 12.0.4
       http-cache-semantics: 3.8.1
-      http-proxy-agent: 2.1.0
-      https-proxy-agent: 2.2.4
+      http-proxy-agent: 2.1.0(supports-color@9.4.0)
+      https-proxy-agent: 2.2.4(supports-color@9.4.0)
       lru-cache: 5.1.1
       mississippi: 3.0.0
       node-fetch-npm: 2.0.4
@@ -18744,20 +18706,20 @@ snapshots:
 
   methods@1.1.2: {}
 
-  micromatch@3.1.10:
+  micromatch@3.1.10(supports-color@9.4.0):
     dependencies:
       arr-diff: 4.0.0
       array-unique: 0.3.2
-      braces: 2.3.2
+      braces: 2.3.2(supports-color@9.4.0)
       define-property: 2.0.2
       extend-shallow: 3.0.2
-      extglob: 2.0.4
+      extglob: 2.0.4(supports-color@9.4.0)
       fragment-cache: 0.2.1
       kind-of: 6.0.3
-      nanomatch: 1.2.13
+      nanomatch: 1.2.13(supports-color@9.4.0)
       object.pick: 1.3.0
       regex-not: 1.0.2
-      snapdragon: 0.8.2
+      snapdragon: 0.8.2(supports-color@9.4.0)
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -18889,7 +18851,7 @@ snapshots:
 
   nanoid@3.3.18: {}
 
-  nanomatch@1.2.13:
+  nanomatch@1.2.13(supports-color@9.4.0):
     dependencies:
       arr-diff: 4.0.0
       array-unique: 0.3.2
@@ -18900,7 +18862,7 @@ snapshots:
       kind-of: 6.0.3
       object.pick: 1.3.0
       regex-not: 1.0.2
-      snapdragon: 0.8.2
+      snapdragon: 0.8.2(supports-color@9.4.0)
       to-regex: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -19657,7 +19619,7 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  require-in-the-middle@7.5.2:
+  require-in-the-middle@7.5.2(supports-color@9.4.0):
     dependencies:
       debug: 4.4.3(supports-color@9.4.0)
       module-details-from-path: 1.0.4
@@ -19704,19 +19666,19 @@ snapshots:
 
   ret@0.1.15: {}
 
-  retry-request@7.0.2(encoding@0.1.13):
+  retry-request@7.0.2(encoding@0.1.13)(supports-color@9.4.0):
     dependencies:
       "@types/request": 2.48.13
       extend: 3.0.2
-      teeny-request: 9.0.0(encoding@0.1.13)
+      teeny-request: 9.0.0(encoding@0.1.13)(supports-color@9.4.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  retry-request@8.0.4:
+  retry-request@8.0.4(supports-color@9.4.0):
     dependencies:
       extend: 3.0.2
-      teeny-request: 10.1.4
+      teeny-request: 10.1.4(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -19766,7 +19728,7 @@ snapshots:
       "@rollup/rollup-win32-x64-msvc": 4.62.4
       fsevents: 2.3.3
 
-  router@2.2.0:
+  router@2.2.0(supports-color@9.4.0):
     dependencies:
       debug: 4.4.3(supports-color@9.4.0)
       depd: 2.0.0
@@ -19827,9 +19789,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@0.19.2:
+  send@0.19.2(supports-color@9.4.0):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@9.4.0)
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 2.0.0
@@ -19845,7 +19807,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.2.1:
+  send@1.2.1(supports-color@9.4.0):
     dependencies:
       debug: 4.4.3(supports-color@9.4.0)
       encodeurl: 2.0.0
@@ -19861,21 +19823,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@1.16.3:
+  serve-static@1.16.3(supports-color@9.4.0):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.2
+      send: 0.19.2(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.2.1:
+  serve-static@2.2.1(supports-color@9.4.0):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -20034,10 +19996,10 @@ snapshots:
     dependencies:
       kind-of: 3.2.2
 
-  snapdragon@0.8.2:
+  snapdragon@0.8.2(supports-color@9.4.0):
     dependencies:
       base: 0.11.2
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@9.4.0)
       define-property: 0.2.5
       extend-shallow: 2.0.1
       map-cache: 0.2.2
@@ -20329,19 +20291,19 @@ snapshots:
       safe-buffer: 5.2.1
       yallist: 3.1.1
 
-  teeny-request@10.1.4:
+  teeny-request@10.1.4(supports-color@9.4.0):
     dependencies:
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@9.4.0)
+      https-proxy-agent: 7.0.6(supports-color@9.4.0)
       node-fetch: 3.3.2
       stream-events: 1.0.5
     transitivePeerDependencies:
       - supports-color
 
-  teeny-request@7.1.1(encoding@0.1.13):
+  teeny-request@7.1.1(encoding@0.1.13)(supports-color@9.4.0):
     dependencies:
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.1
+      http-proxy-agent: 4.0.1(supports-color@9.4.0)
+      https-proxy-agent: 5.0.1(supports-color@9.4.0)
       node-fetch: 2.7.0(encoding@0.1.13)
       stream-events: 1.0.5
       uuid: 8.3.2
@@ -20349,10 +20311,10 @@ snapshots:
       - encoding
       - supports-color
 
-  teeny-request@9.0.0(encoding@0.1.13):
+  teeny-request@9.0.0(encoding@0.1.13)(supports-color@9.4.0):
     dependencies:
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
+      http-proxy-agent: 5.0.0(supports-color@9.4.0)
+      https-proxy-agent: 5.0.1(supports-color@9.4.0)
       node-fetch: 2.7.0(encoding@0.1.13)
       stream-events: 1.0.5
       uuid: 9.0.1
@@ -20481,12 +20443,12 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
-  ts-jest@29.4.11(@babel/core@7.29.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7))(jest-util@29.7.0)(jest@29.7.0(@types/node@26.2.0))(typescript@5.9.3):
+  ts-jest@29.4.11(@babel/core@7.29.7(supports-color@9.4.0))(@jest/transform@29.7.0(supports-color@9.4.0))(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.7(supports-color@9.4.0))(supports-color@9.4.0))(esbuild@0.28.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@26.2.0)(supports-color@9.4.0))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 29.7.0(@types/node@26.2.0)
+      jest: 29.7.0(@types/node@26.2.0)(supports-color@9.4.0)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -20495,10 +20457,11 @@ snapshots:
       typescript: 5.9.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      "@babel/core": 7.29.7
-      "@jest/transform": 29.7.0
+      "@babel/core": 7.29.7(supports-color@9.4.0)
+      "@jest/transform": 29.7.0(supports-color@9.4.0)
       "@jest/types": 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.7)
+      babel-jest: 29.7.0(@babel/core@7.29.7(supports-color@9.4.0))(supports-color@9.4.0)
+      esbuild: 0.28.2
       jest-util: 29.7.0
 
   tslib@1.14.1: {}
@@ -20703,7 +20666,7 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  vite-node@3.2.4(@types/node@26.2.0)(yaml@2.9.0):
+  vite-node@3.2.4(@types/node@26.2.0)(supports-color@9.4.0)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@9.4.0)
@@ -20737,7 +20700,7 @@ snapshots:
       fsevents: 2.3.3
       yaml: 2.9.0
 
-  vitest@3.2.7(@types/node@26.2.0)(yaml@2.9.0):
+  vitest@3.2.7(@types/node@26.2.0)(supports-color@9.4.0)(yaml@2.9.0):
     dependencies:
       "@types/chai": 5.2.3
       "@vitest/expect": 3.2.7
@@ -20760,7 +20723,7 @@ snapshots:
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 7.3.6(@types/node@26.2.0)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@26.2.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@26.2.0)(supports-color@9.4.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       "@types/node": 26.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "kits/*"


### PR DESCRIPTION
Follow-up to #3160, stacked on it so the diff stays clean. Merge #3160 first; this retargets to `kits` automatically.

## Changes

- Add `pnpm-workspace.yaml` with `packages: ["kits/*"]`.
- Regenerate `pnpm-lock.yaml` against it, prettier-formatted.

## Why the workspace file

`pnpm-lock.yaml` had drifted: importers pinned `firebase-functions` at an exact `7.3.2` against `^7.3.3-rc.x` in the kits, `kits/firestore-incremental-capture` had no importer at all, and `firestore-bigquery-change-tracker` was locked at `2.0.4` against a `^2.2.1` dependency.

It could not be regenerated as it stood. With no `pnpm-workspace.yaml` and no `workspaces` field, `pnpm install --lockfile-only` only sees the root package and rewrites the file without reading a single kit, leaving all three problems in place. The workspace file makes pnpm report `Scope: all 14 workspace projects` and fixes them. `kits/*` is exactly the importer set the lockfile already described.

Scoping to `kits/*` leaves the legacy top-level extensions to lerna and npm. That matters for one case: the in-repo `firestore-bigquery-export/firestore-bigquery-change-tracker` is `2.0.4` and `kits/firestore-bigquery-export` wants `^2.2.1`. Keeping it outside the workspace means the kit resolves `2.2.1` from the registry rather than linking the older local copy. The lockfile has no `link:` entries.

## Reading the diff

Content changes are small: 2678 package/snapshot entries before, 2666 after, with 12 `integrity` lines moving.

- in: `firebase-functions@7.3.3-rc.1`, `firestore-bigquery-change-tracker@2.2.1`, `@google-cloud/dataflow@3.3.0` (from the newly visible incremental-capture importer).
- out: `firestore-bigquery-change-tracker@2.0.4`, its transitive `firebase-functions@6.6.0`, and five `@types/*` entries that came with it.

About 711 of the remaining lines are a `(supports-color@9.4.0)` peer suffix on snapshot keys, a rekey rather than a version change. All 13 kit importers now read `specifier: ^7.3.3-rc.1`.

Both files are prettier-formatted because Validate's `npm run lint` globs `**/*.yaml`. Without that, raw pnpm output differs from the committed style by ~5k lines and buries the real diff.

## Verification

- `pnpm install --lockfile-only` is idempotent; a second run produces no further change.
- `prettier --list-different` is clean on both files.
- `pnpm install --frozen-lockfile` verifies except under a local `minimumReleaseAge` policy that rejects `firebase-functions@7.3.3-rc.1` and `firestore-bigquery-change-tracker@2.2.1` as too recently published. Both are the versions the kit `package.json` files already request.

## Note

No CI reads this lockfile: kit tests install per kit with `npm ci` against `npm-shrinkwrap.json`, and `grep -rn pnpm .github/workflows/` returns nothing. This is housekeeping so the file stops drifting. Deleting it and `pnpm-workspace.yaml` is a reasonable alternative if it is not worth maintaining.
