### PR TITLE
fix(storage-resize-images): reject unsupported IMAGE_TYPE values

### DIFF
--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -250,6 +250,10 @@ params:
         value: false
     default: false
     required: true
+    validationRegex: "^((false|jpg|jpeg|png|tif|tiff|webp|gif|avif|jfif)(,(false|jpg|jpeg|png|tif|tiff|webp|gif|avif|jfif))*)?$"
+    validationErrorMessage: >
+      Invalid image type. Supported values are: jpeg, webp, png, tiff, gif,
+      avif, or "original" (false) to keep the original file type.
 
   - param: OUTPUT_OPTIONS
     label: Output options for selected formats

--- a/storage-resize-images/extension.yaml
+++ b/storage-resize-images/extension.yaml
@@ -252,8 +252,8 @@ params:
     required: true
     validationRegex: "^((false|jpg|jpeg|png|tif|tiff|webp|gif|avif|jfif)(,(false|jpg|jpeg|png|tif|tiff|webp|gif|avif|jfif))*)?$"
     validationErrorMessage: >
-      Invalid image type. Supported values are: jpeg, webp, png, tiff, gif,
-      avif, or "original" (false) to keep the original file type.
+      Invalid image type. Supported values are: jpg, jpeg, png, tif, tiff,
+      webp, gif, avif, jfif, or "original" (false) to keep the original file type.
 
   - param: OUTPUT_OPTIONS
     label: Output options for selected formats

--- a/storage-resize-images/functions/__tests__/config.test.ts
+++ b/storage-resize-images/functions/__tests__/config.test.ts
@@ -70,3 +70,58 @@ describe("extension", () => {
     expect(config.deleteOriginalFile).toEqual(deleteImage.onSuccess);
   });
 });
+
+describe("IMAGE_TYPE validation", () => {
+  let restoreImageTypeEnv;
+
+  beforeEach(() => {
+    jest.resetModules();
+    delete process.env.IMAGE_TYPE;
+  });
+
+  afterEach(() => {
+    if (restoreImageTypeEnv) {
+      restoreImageTypeEnv();
+      restoreImageTypeEnv = undefined;
+    }
+    delete process.env.IMAGE_TYPE;
+  });
+
+  test("accepts supported image types", () => {
+    restoreImageTypeEnv = mockedEnv({
+      ...environment,
+      IMAGE_TYPE: "jpeg,webp,false",
+    });
+    const { config: imageTypeConfig } = jest.requireActual("../src/config");
+    expect(imageTypeConfig.imageTypes).toEqual(["jpeg", "webp", "false"]);
+  });
+
+  test("leaves imageTypes undefined when IMAGE_TYPE is not set", () => {
+    restoreImageTypeEnv = mockedEnv(environment);
+    const { config: imageTypeConfig } = jest.requireActual("../src/config");
+    expect(imageTypeConfig.imageTypes).toBeUndefined();
+  });
+
+  test("ignores empty entries from an unselected multiSelect", () => {
+    restoreImageTypeEnv = mockedEnv({ ...environment, IMAGE_TYPE: "" });
+    const { config: imageTypeConfig } = jest.requireActual("../src/config");
+    expect(imageTypeConfig.imageTypes).toEqual([]);
+  });
+
+  test("rejects an unsupported image type", () => {
+    restoreImageTypeEnv = mockedEnv({ ...environment, IMAGE_TYPE: "bogus" });
+    expect(() => jest.requireActual("../src/config")).toThrow(
+      /Invalid IMAGE_TYPE value\(s\): bogus/
+    );
+  });
+
+  test("rejects a list containing an unsupported image type", () => {
+    restoreImageTypeEnv = mockedEnv({
+      ...environment,
+      IMAGE_TYPE: "jpeg,bogus",
+    });
+    expect(() => jest.requireActual("../src/config")).toThrow(
+      /Invalid IMAGE_TYPE value\(s\): bogus/
+    );
+  });
+});

--- a/storage-resize-images/functions/src/config.ts
+++ b/storage-resize-images/functions/src/config.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { supportedImageContentTypeMap } from "./global";
+
 export type SafetyThreshold =
   | "BLOCK_LOW_AND_ABOVE"
   | "BLOCK_MEDIUM_AND_ABOVE"
@@ -38,6 +40,47 @@ function deleteOriginalFile(deleteType) {
 
 function paramToArray(param) {
   return typeof param === "string" ? param.split(",") : undefined;
+}
+
+/**
+ * IMAGE_TYPE value that keeps the original file type instead of converting
+ * to a preferred type. See extension.yaml for the declared options.
+ */
+const KEEP_ORIGINAL_IMAGE_TYPE = "false";
+
+const supportedImageTypes = new Set([
+  ...Object.keys(supportedImageContentTypeMap),
+  KEEP_ORIGINAL_IMAGE_TYPE,
+]);
+
+/**
+ * Parses the IMAGE_TYPE parameter and rejects values that are not a
+ * supported image type. Without this check, an out-of-band value (for
+ * example from a hand-edited .env file) silently produces an unconverted
+ * file with a bogus extension instead of failing fast.
+ *
+ * Empty entries are ignored: they are what a deployed function receives
+ * when the multiSelect parameter has nothing selected.
+ */
+function paramToImageTypes(param) {
+  const imageTypes = paramToArray(param)?.filter(
+    (imageType) => imageType !== ""
+  );
+  if (imageTypes) {
+    const invalidTypes = imageTypes.filter(
+      (imageType) => !supportedImageTypes.has(imageType)
+    );
+    if (invalidTypes.length > 0) {
+      throw new Error(
+        `Invalid IMAGE_TYPE value(s): ${invalidTypes.join(
+          ", "
+        )}. Supported values are: ${Array.from(supportedImageTypes).join(
+          ", "
+        )}.`
+      );
+    }
+  }
+  return imageTypes;
 }
 
 function allowAnimated(sharpOptions = "{}", overrideIsAnimated) {
@@ -82,7 +125,7 @@ export const config = {
   excludePathList: paramToArray(process.env.EXCLUDE_PATH_LIST),
   failedImagesPath: process.env.FAILED_IMAGES_PATH,
   deleteOriginalFile: deleteOriginalFile(process.env.DELETE_ORIGINAL_FILE),
-  imageTypes: paramToArray(process.env.IMAGE_TYPE),
+  imageTypes: paramToImageTypes(process.env.IMAGE_TYPE),
   sharpOptions: process.env.SHARP_OPTIONS || "{}",
   outputOptions: process.env.OUTPUT_OPTIONS,
   animated: allowAnimated(process.env.SHARP_OPTIONS, process.env.IS_ANIMATED),


### PR DESCRIPTION
Fixes #3168.

## Problem

An `IMAGE_TYPE` value that is not a supported image format was never validated. It reached the resize path, produced an unconverted file with a bogus extension (e.g. `<name>_<size>.bogus` with `contentType: undefined`, served as `application/octet-stream`), and the run reported success. This is reachable via an out-of-band value, for example a hand-edited `.env` file.

## Changes

- `storage-resize-images/functions/src/config.ts`: validate `IMAGE_TYPE` against the keys of `supportedImageContentTypeMap` (plus `"false"` for keeping the original type) when the config is resolved. An unknown value now throws a descriptive error — `Invalid IMAGE_TYPE value(s): bogus. Supported values are: jpg, jpeg, png, tif, tiff, webp, gif, avif, jfif, false.` — instead of silently producing broken output. Empty entries are ignored, since that is what a deployed function receives when the multiSelect parameter has nothing selected (per the discussion in #3124).
- `storage-resize-images/extension.yaml`: added `validationRegex` / `validationErrorMessage` to the `IMAGE_TYPE` param so out-of-band values are also rejected at install/reconfigure time.
- `storage-resize-images/functions/__tests__/config.test.ts`: new `IMAGE_TYPE validation` test block covering accepted values, unset param, empty (nothing selected), and rejected values including mixed lists.

Note: #3168 asks for the same change in the kit (`kits/storage-resize-images`), but no `kits/` directory exists in this repository (checked on both `next` and `main`), so only the extension half can land here.

## Test evidence

- `npx jest __tests__/config.test.ts`: 9/9 pass (4 pre-existing + 5 new); existing snapshot unchanged.
- Broader unit run (`--testPathIgnorePatterns e2e integration vulnerability function.test`): 54/54 tests pass. The only 2 failing suites (`unit/modifyImage`, `unit/generateResizedImageHandler`) fail identically on the pristine `next` branch — a pre-existing `IMG_SIZES` env issue unrelated to this change.
- `npx tsc --noEmit`: clean.
- Manual repro of the issue scenario against the compiled config: `IMAGE_TYPE=bogus` now throws `Invalid IMAGE_TYPE value(s): bogus. ...` at startup; `jpeg,webp,false` resolves to `["jpeg","webp","false"]` unchanged.
