### PR TITLE
fix(firestore-send-email): anchor the SMTP_CONNECTION_URI validation regex

### DIFF
--- a/firestore-send-email/CHANGELOG.md
+++ b/firestore-send-email/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 0.2.11
+
+fixed - anchor the `SMTP_CONNECTION_URI` validation regex so a valid prefix followed by trailing text is rejected
+
 ## Version 0.2.10
 
 chore: bump nodemailer to v9 and remove unused rimraf dependency

--- a/firestore-send-email/extension.yaml
+++ b/firestore-send-email/extension.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 name: firestore-send-email
-version: 0.2.10
+version: 0.2.11
 specVersion: v1beta
 
 displayName: Trigger Email from Firestore
@@ -229,7 +229,7 @@ params:
     type: string
     example: smtps://username@smtp.hostname.com:465
     validationRegex:
-      "^(smtp[s]*://(.*?(:[^:@]*)?@)?[^:@]+:[0-9]+(\\?[^ ]*)?)|^$"
+      "^(smtp[s]*://(.*?(:[^:@]*)?@)?[^:@]+:[0-9]+(\\?[^ ]*)?)$|^$"
     validationErrorMessage:
       Invalid SMTP connection URI. Must be in the form
       `smtp(s)://username:password@hostname:port` or

--- a/kits/firestore-send-email/src/config.ts
+++ b/kits/firestore-send-email/src/config.ts
@@ -169,7 +169,7 @@ const params = {
         example: "smtps://username@smtp.hostname.com:465",
 
         validationRegex:
-          /^(smtp[s]*:\/\/(.*?(:[^:@]*)?@)?[^:@]+:[0-9]+(\?[^ ]*)?)|^$/,
+          /^(smtp[s]*:\/\/(.*?(:[^:@]*)?@)?[^:@]+:[0-9]+(\?[^ ]*)?)$|^$/,
         validationErrorMessage:
           "Invalid SMTP connection URI. Must be in the form `smtp(s)://username:password@hostname:port` or `smtp(s)://username@hostname:port` or to be left blank.",
       },

--- a/kits/firestore-send-email/tests/config.test.ts
+++ b/kits/firestore-send-email/tests/config.test.ts
@@ -164,6 +164,8 @@ describe("SMTP_CONNECTION_URI validationRegex", () => {
       "smtps://smtp.gmail.com:465",
       "smtps://username@gmail.com:password@smtp.gmail.com:465",
       "smtp://smtp.gmail.com:587?pool=true",
+      // Password containing the separator characters the regex reasons about.
+      "smtp://fakeemail@gmail.com:4,h?dhuNTbv9zMrP4&7&7%*3@smtp.gmail.com:465?pool=true&service=gmail",
       "",
     ]) {
       expect(connectionUriRegex().test(uri)).toBe(true);
@@ -175,13 +177,15 @@ describe("SMTP_CONNECTION_URI validationRegex", () => {
     expect(connectionUriRegex().test("smtp://smtp.gmail.com")).toBe(false);
   });
 
-  // Inherited from the legacy extension.yaml regex; anchoring is tracked in #3067.
-  test("accepts trailing garbage after a valid prefix because the first alternative is unanchored", () => {
+  // #3067: the first alternative used to be unanchored, so anything following a
+  // valid prefix was accepted. The legacy suite already asserted the first case
+  // is invalid, but against an anchored copy of the regex that never shipped.
+  test("rejects trailing text after an otherwise valid URI", () => {
     for (const uri of [
       "smtp://fakeemail@gmail.com:4,h?dhuNTbv9zMrP4&7&7%*3:smtp.gmail.com:465?pool=true&service=gmail",
       "smtps://smtp.gmail.com:465 and then total garbage",
     ]) {
-      expect(connectionUriRegex().test(uri)).toBe(true);
+      expect(connectionUriRegex().test(uri)).toBe(false);
     }
   });
 });


### PR DESCRIPTION
The `SMTP_CONNECTION_URI` validation regex had no `$` on its first alternative, so anything after a valid prefix was accepted: `smtps://smtp.gmail.com:465 and then total garbage` passed, as did the malformed `...:smtp.gmail.com:465` form that uses `:` instead of `@` as the userinfo separator. The bug is inherited, so this fixes the kit and the legacy `extension.yaml` together. Fixes #3067.

## Changes

- `kits/firestore-send-email/src/config.ts`: `...(\?[^ ]*)?)|^$/` -> `...(\?[^ ]*)?)$|^$/`.
- `firestore-send-email/extension.yaml`: same anchor, plus version bump to 0.2.11 and a CHANGELOG entry.
- `kits/firestore-send-email/tests/config.test.ts`: flip the #3057 characterization test from "accepts trailing garbage" to "rejects trailing text", and add a URI whose password contains `,`, `?`, `&`, `%` and `*` to the accept list so the anchor cannot over-tighten.

The legacy suite already asserted the malformed separator form is invalid (`firestore-send-email/functions/__tests__/helpers.test.ts`), but against a locally anchored copy of the regex that never shipped. That copy is now byte-identical to the shipped pattern.

Verified: `npm test` in `kits/firestore-send-email` (160 passed) and a probe of the yaml-decoded pattern against the documented forms plus the garbage forms.

Caveat: this rejects previously accepted values, so an existing install with a malformed URI will fail validation on its next reconfigure. That is the intended fix, and such values already failed at runtime with "Invalid URI: please reconfigure with a valid SMTP connection URI".
