### PR TITLE
ci(firestore-bigquery-change-tracker): run offline test suites in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,3 +41,26 @@ jobs:
           echo SMTP_PASSWORD=${{ secrets.SENDGRID_API_KEY }} >> _emulator/extensions/firestore-send-email-sendgrid.secret.local
       - name: npm test
         run: npm run test:ci
+
+  change_tracker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    name: firestore-bigquery-change-tracker_offline_test
+    defaults:
+      run:
+        working-directory: firestore-bigquery-export/firestore-bigquery-change-tracker
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
+        with:
+          persist-credentials: false
+      - name: Setup node
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: "firestore-bigquery-export/firestore-bigquery-change-tracker/package-lock.json"
+      - name: npm ci
+        run: npm ci
+      - name: Run offline test suites
+        run: npm run test:offline

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/jest.offline.config.js
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/jest.offline.config.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const baseConfig = require("./jest.config");
+
+/**
+ * CI configuration for the change tracker.
+ *
+ * The default `jest.config.js` runs every suite, and most of them create real
+ * datasets, tables and views in BigQuery (or write to a real Firestore), so
+ * they need credentials for a live GCP project and cannot run on a pull
+ * request. This config runs only the suites that pass without credentials, so
+ * the offline regression coverage for this shared package is visible to CI.
+ *
+ * Every suite not listed below runs in CI. When you add a suite that needs a
+ * live project, add it here.
+ */
+const liveProjectSuites = [
+  "src/__tests__/bigquery/alternativeProject.test.ts",
+  "src/__tests__/bigquery/checkUpdates.test.ts",
+  "src/__tests__/bigquery/clustering.test.ts",
+  "src/__tests__/bigquery/e2e.test.ts",
+  "src/__tests__/bigquery/failedTransaction.test.ts",
+  "src/__tests__/bigquery/partitioning.test.ts",
+  "src/__tests__/bigquery/stresstest.test.ts",
+  "src/__tests__/bigquery/wildcardDocument.test.ts",
+  "src/__tests__/bigquery/materializedViews/initializeLatestMaterializedView.test.ts",
+  "src/__tests__/bigquery/materializedViews/integration.test.ts",
+  "src/__tests__/bigquery/materializedViews/shouldRecreateMaterializedView.test.ts",
+];
+
+// Jest matches these against absolute paths, which use "\" on Windows, so
+// anchor on the separator rather than on rootDir.
+const toIgnorePattern = (suite) =>
+  "[/\\\\]" + suite.replace(/\./g, "\\.").replace(/\//g, "[/\\\\]") + "$";
+
+module.exports = {
+  ...baseConfig,
+  testPathIgnorePatterns: [
+    "/node_modules/",
+    ...liveProjectSuites.map(toIgnorePattern),
+  ],
+};

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/jest.offline.config.js
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/jest.offline.config.js
@@ -44,8 +44,9 @@ const liveProjectSuites = [
 
 // Jest matches these against absolute paths, which use "\" on Windows, so
 // anchor on the separator rather than on rootDir.
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 const toIgnorePattern = (suite) =>
-  "[/\\\\]" + suite.replace(/\./g, "\\.").replace(/\//g, "[/\\\\]") + "$";
+  "[/\\\\]" + escapeRegExp(suite).replace(/\//g, "[/\\\\]") + "$";
 
 module.exports = {
   ...baseConfig,

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/jest.offline.config.js
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/jest.offline.config.js
@@ -51,7 +51,7 @@ const toIgnorePattern = (suite) =>
 module.exports = {
   ...baseConfig,
   testPathIgnorePatterns: [
-    "/node_modules/",
+    ...(baseConfig.testPathIgnorePatterns || ["/node_modules/"]),
     ...liveProjectSuites.map(toIgnorePattern),
   ],
 };

--- a/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
+++ b/firestore-bigquery-export/firestore-bigquery-change-tracker/package.json
@@ -16,6 +16,7 @@
     "clean": "node -e \"require('fs').rmSync('lib', { recursive: true, force: true })\"",
     "compile": "tsc",
     "test:local": "jest",
+    "test:offline": "jest --config jest.offline.config.js",
     "prepare": "npm run build",
     "generate-stresstest-table": "bq query --project_id=extensions-testing  --use_legacy_sql=false < ./src/__tests__/fixtures/sql/generateSnapshotStresstestTable.sql"
   },


### PR DESCRIPTION
The change tracker's jest suites ran in no CI workflow, so the shared package both the legacy extension and the kit depend on had no regression protection, including the offline tests #2937 added for the insert retry guard. Root `jest.config.js` only picks up `*/functions/jest.config.js` and gen-schema-view, and nothing invoked the package's `test:local`.

Most of the tracker's suites create real BigQuery datasets/tables/views or write to a real Firestore, so they can't run on a PR. This adds a CI job that runs the suites that pass without credentials.

## Changes

- Add `jest.offline.config.js`, which reuses `jest.config.js` and ignores the 11 suites that need a live GCP project.
- Add a `test:offline` npm script to the tracker package.
- Add a `change_tracker` job to `.github/workflows/test.yml` that runs `npm ci && npm run test:offline` in the package directory.

Verification: `npm run test:offline` passes, 8 suites / 137 tests in ~43s. The excluded list was determined by running every suite with no credentials, not from the file names, so `clustering` and `checkUpdates` are excluded despite the pattern suggested in the issue.

- The exclusion list is a denylist, so a new offline suite is picked up automatically; a new live-project suite must be added to the list.
- Pre-existing `Unknown option "types"` jest validation warning from `jest.config.js` is left alone, out of scope.

Fixes #3053
