### PR TITLE
docs(kits): note the accepted extension-to-kit divergences

### DIFF
--- a/kits/README.md
+++ b/kits/README.md
@@ -78,6 +78,44 @@ to you is the configuration itself, so check the kit's README against your
 installed instance's settings before deploying, rather than copying the `.env`
 across unchanged.
 
+### Differences that apply to every kit
+
+Each kit's README has a "Differences" section covering the behaviour specific
+to that kit. The four below come from the platform rather than from any one
+kit, and are accepted: there is no kit equivalent to restore.
+
+**Resource names use a `kit-` prefix.** The CLI names every function, task
+queue and Pub/Sub topic `kit-<instance id>-<name>`, where an extension
+instance used `ext-<instance id>-<name>`. Nothing an extension instance
+created is reused, so an installed extension keeps running on its own
+resources until you uninstall it, and its old resources can be deleted once
+you have migrated.
+
+**There is no billing declaration.** Extensions set `billingRequired: true` in
+`extension.yaml`, which is why the console refused to install them on a Spark
+plan project. There is no kit equivalent, but the requirement itself is
+unchanged: kits deploy 2nd gen functions, so the project still needs the Blaze
+plan. You find out at `firebase deploy` rather than up front.
+
+**There is no deploy-time status surface.** Extensions reported install,
+update and backfill progress by calling
+`getExtensions().runtime().setProcessingState(...)`, and the Firebase console
+showed that state on the instance. Kits have no equivalent, so the outcome of
+a post-deploy task, including a failure, is only visible in that function's
+logs. This affects the lifecycle and backfill tasks in
+`bigquery-firestore-export`, `firestore-bigquery-export`,
+`firestore-incremental-capture` and `firestore-vector-search`.
+
+**Settings are checked at deploy time, not at install.** An extension
+validated your values in the install prompt using `extension.yaml`
+(`required`, `validationRegex`), and one extension also threw at startup when
+an environment variable was missing. Kits declare settings with
+`firebase-functions/params`, so the CLI still prompts for a required setting
+that has no value and still refuses to deploy while a bound secret does not
+exist. What is gone is the per-value checking: a malformed but present value
+now deploys and fails at runtime. Each kit's README lists the checks its
+extension used to run.
+
 Extensions themselves are unaffected and remain available. To learn more about
 Firebase Extensions, including how to install them, visit the
 [Firebase documentation](https://firebase.google.com/docs/extensions).

--- a/kits/README.md
+++ b/kits/README.md
@@ -86,8 +86,8 @@ kit, and are accepted: there is no kit equivalent to restore.
 
 **Resource names use a `kit-` prefix.** The CLI names every function, task
 queue and Pub/Sub topic `kit-<instance id>-<name>`, where an extension
-instance used `ext-<instance id>-<name>`. Nothing an extension instance
-created is reused, so an installed extension keeps running on its own
+instance used `ext-<instance id>-<name>`. No resources created by an extension
+instance are reused, so an installed extension keeps running on its own
 resources until you uninstall it, and its old resources can be deleted once
 you have migrated.
 

--- a/kits/firestore-bigquery-export/README.md
+++ b/kits/firestore-bigquery-export/README.md
@@ -366,6 +366,14 @@ inside that window. That property is gone by design - a row that exhausts the
 queue without a configured `BACKUP_COLLECTION` is dropped, exactly as in the
 extension. Set `BACKUP_COLLECTION`.
 
+### The lifecycle tasks report only to your logs
+
+`initBigQuerySync` and `setupBigQuerySync` are ordinary task functions. The
+extension's install and update hooks finished by setting the instance's
+processing state, so `Sync setup completed`, or a provisioning failure, showed
+on the instance in the Firebase console. Kits have no equivalent surface. Read
+the task function's logs to confirm the dataset, table and views were created.
+
 ### Events
 
 Events are published under `firebase.extensions.firestore-bigquery-export.v1.*`

--- a/kits/firestore-genai-chatbot/README.md
+++ b/kits/firestore-genai-chatbot/README.md
@@ -194,6 +194,21 @@ document therefore decides the field for that message, and a discussion that
 overrides `candidateCount` to 1 gets no `candidates` field even when
 `CANDIDATE_COUNT` is higher.
 
+### Missing settings no longer stop the module loading
+
+The extension's config module threw
+`Missing required environment variables: ...` as it loaded if `MODEL`,
+`LOCATION`, `PROJECT_ID` or `EXT_INSTANCE_ID` was unset. That check is gone,
+and for three of those four there is nothing left to check: `MODEL` has a
+default, `LOCATION` no longer exists, and this kit does not use the instance
+id. The project id is still read from `FIREBASE_CONFIG` and still throws
+`Missing required environment variables: PROJECT_ID` when it is absent.
+
+The rest of that checking moved to deploy time. The Firebase CLI prompts for a
+setting that has no value and no default, and refuses to deploy until the
+`API_KEY` secret exists, so an incomplete config is caught before the function
+is deployed rather than on its first run.
+
 ### Bad numbers are no longer rejected up front
 
 `TEMPERATURE`, `TOP_P`, `TOP_K`, `CANDIDATE_COUNT`, `MAX_OUTPUT_TOKENS` and

--- a/kits/firestore-incremental-capture/README.md
+++ b/kits/firestore-incremental-capture/README.md
@@ -334,6 +334,11 @@ correctly. Everything around the format moved:
   default bucket rather than guessing `<projectId>.appspot.com`.
   `BACKUP_INSTANCE_ID=(default)` is rejected at startup instead of letting a
   restoration write over its own source.
+- **Setup status.** The extension's `runInitialSetup` and
+  `onFirestoreBackupInit` handlers reported their progress and their failures
+  on the instance in the Firebase console, through the extensions runtime.
+  Kits have no equivalent surface, so the outcome of `initIncrementalCapture`
+  is only visible in its function logs.
 - **Serializer.** BigInt field values are stringified instead of throwing.
 - **Status documents.** Restoration run status lives at
   `_<instance id>/runs/restorations`, not the extension's `_ext-<instance id>`

--- a/kits/firestore-translate-text/README.md
+++ b/kits/firestore-translate-text/README.md
@@ -202,6 +202,11 @@ collection. The extension carried the same limitation (its backfill task queue
 was disabled and never deployed), so this is not a regression, but the code is
 gone rather than dormant: only documents written after you deploy are translated.
 
+The status reporting went with it. That backfill ended by writing its translated
+and error counts to the instance's processing state, which the Firebase console
+displayed. Kits have no deploy-time status surface at all, so nothing here
+reports into one.
+
 ### The trigger is 2nd gen
 
 `fstranslate` is a 2nd gen Firestore function where the extension was 1st gen.


### PR DESCRIPTION
Writes the Notes entries for the accepted divergences in #3035, the ones with no kit equivalent to restore. Four are platform-level, so they go in `kits/README.md` under "Migrating from an extension" rather than being repeated in every kit; the per-kit specifics go in the kit that has them.

## Changes

- `kits/README.md`: new "Differences that apply to every kit" section covering the `ext-` to `kit-` resource-name prefix, the missing `billingRequired` declaration, the missing deploy-time status surface, and validation moving from the install prompt to deploy time.
- `firestore-bigquery-export`: note that `initBigQuerySync` / `setupBigQuerySync` only report to logs, where the extension's install and update hooks set the instance's processing state.
- `firestore-incremental-capture`: note the same loss for `runInitialSetup` and `onFirestoreBackupInit`.
- `firestore-translate-text`: note that the extension's backfill status counts went with the backfill.
- `firestore-genai-chatbot`: note that `validateRequiredEnvVars()` is gone, that only `PROJECT_ID` still has anything to check, and that the rest is enforced by the CLI at deploy.

No entry added for `NODE_PATH` to `RTDB_NODE_PATH` or the `ext-` to `kit-` topic rename: `rtdb-limit-child-nodes`, `delete-user-data` and `bigquery-firestore-export` already document those. `firestore-vector-search` already notes its missing backfill progress reporting.

Two corrections to the ledger's list while writing these. `storage-resize-images` is not affected by the status surface: its four `setProcessingState` calls are commented out (`functions/src/index.ts:213-278`). `firestore-incremental-capture` is affected and was not listed (5 calls in `functions/src/tasks/`). `billingRequired: true` is declared by 11 of the 13 predecessor extensions, not just `firestore-translate-text` and `rtdb-limit-child-nodes`; `speech-to-text` and `firestore-bundle-builder` never declared it.

Docs only, no code change. `prettier --list-different` is clean.
