### PR TITLE
fix(firestore-incremental-capture): allow Node >=22 in engines

### DIFF
--- a/kits/firestore-incremental-capture/npm-shrinkwrap.json
+++ b/kits/firestore-incremental-capture/npm-shrinkwrap.json
@@ -20,7 +20,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": "22"
+        "node": ">=22"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/kits/firestore-incremental-capture/package.json
+++ b/kits/firestore-incremental-capture/package.json
@@ -22,7 +22,7 @@
     }
   },
   "engines": {
-    "node": "22"
+    "node": ">=22"
   },
   "scripts": {
     "build": "tsc -b",


### PR DESCRIPTION
`kits/firestore-incremental-capture` declared `engines.node` as `"22"` (exact match), while the other 12 kits declare `">=22"`. On Node 24 that blocks installation: pnpm and npm with `engine-strict` fail with `EBADENGINE`, plain npm warns. Nothing in the kit needs Node 22 specifically, so this aligns it with the rest.

## Changes

- `kits/firestore-incremental-capture/package.json`: `engines.node` `"22"` -> `">=22"`.
- `kits/firestore-incremental-capture/npm-shrinkwrap.json`: same change in the root package entry.

## Verification

Reproduced on Node v24.3.0: `npm ci --engine-strict --dry-run` fails with `EBADENGINE ... Required: {"node":"22"}` before the change and succeeds after. `npm ci`, `npm run build` and `npm test` (75 tests) pass.

Note: the root `pnpm-lock.yaml` does not record importer engines, so no lockfile regeneration is needed.
