### PR TITLE
fix(firestore-translate-text): route a null input like the extension

### DIFF
--- a/kits/firestore-translate-text/CHANGELOG.md
+++ b/kits/firestore-translate-text/CHANGELOG.md
@@ -1,3 +1,4 @@
+- fix: a `null` input on update now fails the same way as the extension (a `TypeError` from `translateMultiple`, one error event, no write), instead of being sent to the translation API as a single value.
 - fix: `onStart` and `onCompletion` are now published on every invocation, including a write event that arrives without change data; that path used to return before either event was recorded, so subscribers missed a lifecycle pair the extension always emitted.
 - Construct the translation client once per process instead of on every invocation, matching the legacy extension. This changes the exported `HandlerContext` type from `{ firestore, config, googleAiApiKey? }` to `{ config, service }`: `handleDocumentWrite` no longer builds the `TranslationService` itself and instead expects it on the context (build one with `createTranslationService`)
 - Initial release of kit, see README for differences between the legacy extension and this kit

--- a/kits/firestore-translate-text/CHANGELOG.md
+++ b/kits/firestore-translate-text/CHANGELOG.md
@@ -1,4 +1,4 @@
-- fix: a `null` input on update now fails the same way as the extension (a `TypeError` from `translateMultiple`, one error event, no write), instead of being sent to the translation API as a single value.
+- fix: a `null` input on update now fails the same way as the extension (a `TypeError` from `translateMultiple`, one error event, no write), instead of being routed to `translateSingle`.
 - fix: `onStart` and `onCompletion` are now published on every invocation, including a write event that arrives without change data; that path used to return before either event was recorded, so subscribers missed a lifecycle pair the extension always emitted.
 - Construct the translation client once per process instead of on every invocation, matching the legacy extension. This changes the exported `HandlerContext` type from `{ firestore, config, googleAiApiKey? }` to `{ config, service }`: `handleDocumentWrite` no longer builds the `TranslationService` itself and instead expects it on the context (build one with `createTranslationService`)
 - Initial release of kit, see README for differences between the legacy extension and this kit

--- a/kits/firestore-translate-text/src/translate/translateDocument.ts
+++ b/kits/firestore-translate-text/src/translate/translateDocument.ts
@@ -41,7 +41,7 @@ export const translateDocument = async (
     return;
   }
 
-  if (typeof input === "object" && input !== null) {
+  if (typeof input === "object") {
     return translateMultiple(
       input as Record<string, unknown>,
       languages,

--- a/kits/firestore-translate-text/tests/handlers.test.ts
+++ b/kits/firestore-translate-text/tests/handlers.test.ts
@@ -342,6 +342,24 @@ describe("handleDocumentWrite", () => {
     expect(translateClassMethod).not.toHaveBeenCalled();
   });
 
+  test("fails without writing when an update sets the input to null", async () => {
+    const after = makeSnapshot({ input: null });
+
+    await expect(
+      handleDocumentWrite(
+        makeEvent(makeSnapshot({ input: "hello" }), after),
+        context()
+      )
+    ).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      ...messages.error(expect.any(TypeError))
+    );
+    expect(events.recordErrorEvent).toHaveBeenCalledWith(expect.any(TypeError));
+    expect(translateClassMethod).not.toHaveBeenCalled();
+    expect(firestore.update).not.toHaveBeenCalled();
+  });
+
   test("skips processing if there is no input on the before and after snapshots", async () => {
     const snapshot = makeSnapshot({ notTheInput: "hello" });
 

--- a/kits/firestore-translate-text/tests/handlers.test.ts
+++ b/kits/firestore-translate-text/tests/handlers.test.ts
@@ -355,7 +355,15 @@ describe("handleDocumentWrite", () => {
     expect(logger.error).toHaveBeenCalledWith(
       ...messages.error(expect.any(TypeError))
     );
+    expect(logger.error).toHaveBeenCalledTimes(1);
     expect(events.recordErrorEvent).toHaveBeenCalledWith(expect.any(TypeError));
+    expect(events.recordErrorEvent).toHaveBeenCalledTimes(1);
+    expect(logger.log).not.toHaveBeenCalledWith(
+      messages.translateInputStringToAllLanguages(
+        null as never,
+        defaultLanguages
+      )
+    );
     expect(translateClassMethod).not.toHaveBeenCalled();
     expect(firestore.update).not.toHaveBeenCalled();
   });

--- a/kits/firestore-translate-text/tests/translate-document.test.ts
+++ b/kits/firestore-translate-text/tests/translate-document.test.ts
@@ -104,16 +104,19 @@ describe("translateDocument", () => {
     );
   });
 
-  test("treats a null input as a single translation, uncoerced", async () => {
+  test("routes a null input through translateMultiple, as the extension does", async () => {
     const snapshot = makeSnapshot({ input: null });
 
-    await translateDocument(
-      snapshot,
-      makeService({ extractLanguages: vi.fn(() => ["en"]) }),
-      makeConfig()
-    );
+    await expect(
+      translateDocument(
+        snapshot,
+        makeService({ extractLanguages: vi.fn(() => ["en"]) }),
+        makeConfig()
+      )
+    ).rejects.toThrow(TypeError);
 
-    expect(translateString).toHaveBeenCalledWith(null, "en");
+    expect(translateString).not.toHaveBeenCalled();
+    expect(updateTranslations).not.toHaveBeenCalled();
   });
 
   test("exits early when the input field is a translation output path", async () => {

--- a/kits/firestore-translate-text/tests/translate-document.test.ts
+++ b/kits/firestore-translate-text/tests/translate-document.test.ts
@@ -18,11 +18,18 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("firebase-functions", () => import("./mocks/firebase-functions"));
 vi.mock("../src/events");
+vi.mock("../src/translate/translateMultiple", async (importOriginal) => {
+  const mod = await importOriginal<
+    typeof import("../src/translate/translateMultiple")
+  >();
+  return { ...mod, translateMultiple: vi.fn(mod.translateMultiple) };
+});
 
 import * as events from "../src/events";
 import { messages } from "../src/logs/messages";
 import type { TranslationService } from "../src/translate";
 import { translateDocument } from "../src/translate/translateDocument";
+import { translateMultiple } from "../src/translate/translateMultiple";
 import { translateSingle } from "../src/translate/translateSingle";
 import {
   defaultLanguages,
@@ -106,15 +113,18 @@ describe("translateDocument", () => {
 
   test("routes a null input through translateMultiple, as the extension does", async () => {
     const snapshot = makeSnapshot({ input: null });
+    const service = makeService({ extractLanguages: vi.fn(() => ["en"]) });
 
     await expect(
-      translateDocument(
-        snapshot,
-        makeService({ extractLanguages: vi.fn(() => ["en"]) }),
-        makeConfig()
-      )
+      translateDocument(snapshot, service, makeConfig())
     ).rejects.toThrow(TypeError);
 
+    expect(translateMultiple).toHaveBeenCalledWith(
+      null,
+      ["en"],
+      snapshot,
+      service
+    );
     expect(translateString).not.toHaveBeenCalled();
     expect(updateTranslations).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
The kit guarded its object branch with `input !== null`, so a `null` input on the update path went to `translateSingle` and was handed to the translation API as a single value. The extension routes on `typeof input === "object"` alone, so `null` goes to `translateMultiple` and throws a `TypeError` out of `Object.entries(null)`. Same "no write" outcome, different route: one error event per target language plus two more, and a wasted API call on the Google Translate path, instead of one error event.

The decision on #3142 was parity, so this drops the guard. A `null` input now reproduces the extension's failure exactly - a `TypeError` from `translateMultiple`, one error event recorded by the handler catch, and nothing written to Firestore.

Two tests pin it. The unit test wraps the real `translateMultiple` in a spy and asserts it is called with `null`, that the call rejects with a `TypeError`, and that neither `translateString` nor `updateTranslations` runs. The handler test covers the only reachable path (before `input: "hello"`, after `input: null`), asserting exactly one error log and one error event, that `translateSingle`'s opening log never fires, that no write happens, and that nothing throws out of the handler. Six mutations were tried against them, including restoring the guard and throwing from `translateSingle` instead; each fails at least one test.

Ran in `kits/firestore-translate-text`: `vitest run` (122 passed, 13 files), `tsc --noEmit` clean, `prettier --list-different` clean on the changed files.

This is parity, not a fix. The inherited gap - `null` neither clears translations nor gets skipped, because `typeof null === "object"` dodges the delete branch in `handleUpdateDocument` - is tracked in #3182 against both codebases.

Fixes #3142
