### PR TITLE
refactor(storage-resize-images): use Node built-ins for uuid and mkdir

### DIFF
--- a/kits/storage-resize-images/npm-shrinkwrap.json
+++ b/kits/storage-resize-images/npm-shrinkwrap.json
@@ -14,10 +14,8 @@
         "firebase-admin": "^13.2.0",
         "firebase-functions": "^7.3.3-rc.2",
         "genkit": "^1.2.0",
-        "mkdirp": "^3.0.1",
         "p-queue": "^6.6.2",
-        "sharp": "^0.35.3",
-        "uuid": "^11.0.5"
+        "sharp": "^0.35.3"
       },
       "devDependencies": {
         "typescript": "^5.9.3",
@@ -7072,21 +7070,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
@@ -8600,19 +8583,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/kits/storage-resize-images/package.json
+++ b/kits/storage-resize-images/package.json
@@ -36,10 +36,8 @@
     "firebase-admin": "^13.2.0",
     "firebase-functions": "^7.3.3-rc.2",
     "genkit": "^1.2.0",
-    "mkdirp": "^3.0.1",
     "p-queue": "^6.6.2",
-    "sharp": "^0.35.3",
-    "uuid": "^11.0.5"
+    "sharp": "^0.35.3"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/kits/storage-resize-images/src/file-operations.ts
+++ b/kits/storage-resize-images/src/file-operations.ts
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Bucket, File } from "@google-cloud/storage";
-import { mkdirp } from "mkdirp";
-import { v4 as uuidv4 } from "uuid";
 import type { ResolvedResizeImagesConfig } from "./export-config";
 import * as logs from "./logs";
 import { countNegativeTraversals, type StorageObjectMetadata } from "./util";
@@ -29,11 +28,11 @@ export async function downloadOriginalFile(
   filePath: string,
   verbose: boolean
 ): Promise<[string, File]> {
-  const localFile = path.join(os.tmpdir(), uuidv4());
+  const localFile = path.join(os.tmpdir(), crypto.randomUUID());
   const tempLocalDir = path.dirname(localFile);
 
   if (verbose) logs.tempDirectoryCreating(tempLocalDir);
-  await mkdirp(tempLocalDir);
+  await fs.promises.mkdir(tempLocalDir, { recursive: true });
   if (verbose) logs.tempDirectoryCreated(tempLocalDir);
 
   const remoteFile = bucket.file(filePath);

--- a/kits/storage-resize-images/src/resize-image.ts
+++ b/kits/storage-resize-images/src/resize-image.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Bucket } from "@google-cloud/storage";
 import sharp from "sharp";
-import { v4 as uuidv4 } from "uuid";
 import type { ResolvedResizeImagesConfig } from "./export-config";
 import {
   SUPPORTED_EXTENSIONS,
@@ -124,7 +124,7 @@ export const modifyImage = async ({
   let modifiedFile: string | undefined;
 
   try {
-    modifiedFile = path.join(os.tmpdir(), uuidv4());
+    modifiedFile = path.join(os.tmpdir(), crypto.randomUUID());
     const metadata = constructMetadata(
       modifiedFileName,
       imageContentType,
@@ -204,7 +204,7 @@ export const constructMetadata = (
     config.cacheControlHeader || objectMetadata.cacheControl;
 
   if (config.regenerateToken && customMetadata.firebaseStorageDownloadTokens) {
-    customMetadata.firebaseStorageDownloadTokens = uuidv4();
+    customMetadata.firebaseStorageDownloadTokens = crypto.randomUUID();
   }
   return metadata;
 };

--- a/kits/storage-resize-images/src/util.ts
+++ b/kits/storage-resize-images/src/util.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { Bucket, FileMetadata } from "@google-cloud/storage";
 import { logger } from "firebase-functions";
 import sharp from "sharp";
-import { v4 as uuidv4 } from "uuid";
 import { SUPPORTED_CONTENT_TYPES, SUPPORTED_EXTENSIONS } from "./global";
 import * as logs from "./logs";
 
@@ -105,7 +105,7 @@ export async function replaceWithConfiguredPlaceholder(
     );
 
     const placeholderFile = bucket.file(placeholderPath);
-    const tempPlaceholder = path.join(os.tmpdir(), uuidv4());
+    const tempPlaceholder = path.join(os.tmpdir(), crypto.randomUUID());
 
     await placeholderFile.download({ destination: tempPlaceholder });
 
@@ -125,7 +125,7 @@ export async function replaceWithDefaultPlaceholder(
   localFile: string
 ): Promise<void> {
   const localPlaceholderFile = path.join(__dirname, "placeholder.png");
-  const tempPlaceholder = path.join(os.tmpdir(), uuidv4());
+  const tempPlaceholder = path.join(os.tmpdir(), crypto.randomUUID());
   fs.copyFileSync(localPlaceholderFile, tempPlaceholder);
   fs.unlinkSync(localFile);
   fs.renameSync(tempPlaceholder, localFile);

--- a/kits/storage-resize-images/tests/file-operations.test.ts
+++ b/kits/storage-resize-images/tests/file-operations.test.ts
@@ -27,8 +27,6 @@ import * as path from "node:path";
 
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-vi.mock("mkdirp", () => ({ mkdirp: vi.fn().mockResolvedValue(undefined) }));
-
 vi.mock("node:fs", async () => {
   const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
   return { ...actual, unlinkSync: vi.fn() };


### PR DESCRIPTION
#2947 was merged into its base branch, `fix/storage-resize-images-sharp-0.35`, after that branch had already landed on `kits` via #2946. Its changes went onto a dead branch, so none of them reached `kits`. GitHub shows #2947 as merged, which makes it look shipped.

**What changed:** the same net change, replayed onto current `kits`. Six call sites move to `crypto.randomUUID()` and `fs.promises.mkdir(dir, { recursive: true })`, matching the extension, which dropped both dependencies in `9bb0c1fa` and `c6fbf3b7`. `mkdirp` and `uuid` come out of `package.json`. The tests added on `kits` since #2947 was opened mock `mkdirp`, so that mock goes too.

`mkdirp` leaves the tree entirely; `uuid` remains transitively via genkit and the Google client libraries, so this is dependency hygiene rather than a fix for the `uuid` advisory. The lockfile diff is only those two removals, with no other package added or changed.

**Verification:** `npm run build` is clean and the suite is green (192 passed, 3 skipped). Confirmed `fs.promises.mkdir` with `recursive` succeeds on an already-existing directory, matching `mkdirp`, and that `crypto.randomUUID()` returns distinct v4 values. The full Storage upload path was not exercised.
