### PR TITLE
fix(bigquery-firestore-export): remove the TRANSFER_CONFIG_NAME link path

### DIFF
--- a/kits/bigquery-firestore-export/CHANGELOG.md
+++ b/kits/bigquery-firestore-export/CHANGELOG.md
@@ -1,3 +1,4 @@
+- **Breaking:** `TRANSFER_CONFIG_NAME` and the link-an-existing-transfer-config path are removed for parity with the extension, which never exposed them. Re-adding adoption is tracked in #3185
 - Initial release of kit, see README for differences between the legacy extension and this kit
 - The instance id now comes from `FIREBASE_KIT_INSTANCE_ID`, which the Firebase CLI (15.27.0 or later) provides to each kit instance; `INSTANCE_ID` is no longer a configuration parameter
 - A BigQuery `TIME` column no longer crashes a run: its value is written to Firestore as the string BigQuery returned (`"10:30:00"`) rather than passed to `Timestamp.fromDate`, which threw and lost the whole run. This is a deliberate divergence from the legacy extension, which throws on the same line

--- a/kits/bigquery-firestore-export/README.md
+++ b/kits/bigquery-firestore-export/README.md
@@ -58,8 +58,8 @@ SCHEDULE=every 24 hours
 ```
 
 - `processMessages` consumes BigQuery Data Transfer completion messages.
-- `upsertTransferConfig` is the idempotent lifecycle task that creates, links,
-  or updates the scheduled query and its notification topic.
+- `upsertTransferConfig` is the idempotent lifecycle task that creates or
+  updates the scheduled query and its notification topic.
 
 Importing the package without exporting its functions deploys nothing—the CLI
 only deploys what your entry file exports.
@@ -111,7 +111,6 @@ overridden there.
 | Field                     | Env var                     | Required | Default           | Description                                                  |
 | ------------------------- | --------------------------- | -------- | ----------------- | ------------------------------------------------------------ |
 | `bigqueryDatasetLocation` | `BIGQUERY_DATASET_LOCATION` | no       | `US`              | BigQuery destination dataset location                        |
-| `transferConfigName`      | `TRANSFER_CONFIG_NAME`      | no       | (empty)           | Existing DTS config resource to link instead of creating one |
 | `datasetId`               | `DATASET_ID`                | yes      | —                 | BigQuery destination dataset id                              |
 | `tableName`               | `TABLE_NAME`                | yes      | —                 | Prefix for per-run destination tables                        |
 | `queryString`             | `QUERY_STRING`              | yes      | —                 | Scheduled Standard SQL query                                 |
@@ -157,11 +156,10 @@ query on first deploy, then reconciles supported query, table, schedule,
 dataset, partitioning, and topic changes on later deploys. It retries transient
 failures up to five times with at least 30 seconds of backoff.
 
-Set `TRANSFER_CONFIG_NAME` to link an existing scheduled-query config without
-changing it. Otherwise the kit stores `extInstanceId` on the Firestore config
-document and uses that value to find the config on later deploys. BigQuery DTS
-does not support clearing a partitioning field once set; create a new transfer
-config to remove partitioning.
+The kit stores `extInstanceId` on the Firestore config document and uses that
+value to find the config on later deploys. BigQuery DTS does not support
+clearing a partitioning field once set; create a new transfer config to remove
+partitioning.
 
 ## Firestore layout
 
@@ -217,10 +215,6 @@ there are two ways to migrate:
   `kit-<instance id>-processMessages`, which stops notifications reaching the
   extension and any other subscriber on the old topic. Do this once the extension
   is uninstalled, and the old topic can then be deleted.
-
-`TRANSFER_CONFIG_NAME` is the exception. A linked config is adopted as-is and is
-never repointed, so if it notifies a topic other than `PUB_SUB_TOPIC` the kit
-logs a warning and its runs never reach the kit's `processMessages` function.
 
 ### Repeated BigQuery columns are now written as arrays
 
@@ -281,15 +275,6 @@ update; it only applies to a config the kit creates.
 
 Removing `PARTITIONING_FIELD` once it has been set still fails, with the same
 explanation, because the BigQuery Data Transfer API cannot clear it.
-
-### You can link an existing scheduled query
-
-`TRANSFER_CONFIG_NAME` is a new setting. Point it at the full resource name of a
-scheduled query you already have
-(`projects/<project>/locations/<location>/transferConfigs/<id>`) and the kit
-records that config in Firestore and consumes its notifications instead of
-creating one of its own. The extension carried the code for this but no setting to
-reach it. Leave it empty for the create-or-reconcile behaviour described above.
 
 ### Region, and no location setting
 

--- a/kits/bigquery-firestore-export/src/config.ts
+++ b/kits/bigquery-firestore-export/src/config.ts
@@ -89,7 +89,6 @@ const params = {
       "EU Mutli-Region (EU)": "EU",
     }),
   }),
-  transferConfigName: defineString("TRANSFER_CONFIG_NAME", { default: "" }),
   pubSubTopic: defineString("PUB_SUB_TOPIC", {
     label: "Pub/Sub Topic",
     description:
@@ -219,7 +218,6 @@ export function configFromEnv(): BigqueryFirestoreExportConfig {
     bigqueryDatasetLocation: params.bigqueryDatasetLocation.value(),
     projectId: projectID.value(),
     instanceId: instanceIdFromEnv(),
-    transferConfigName: optional(params.transferConfigName.value()),
     datasetId: params.datasetId.value(),
     tableName: params.tableName.value(),
     queryString: params.queryString.value(),

--- a/kits/bigquery-firestore-export/src/export-config.ts
+++ b/kits/bigquery-firestore-export/src/export-config.ts
@@ -27,8 +27,6 @@ export interface BigqueryFirestoreExportConfig {
   projectId: string;
   /** Stable id used to associate a DTS config with this deployment. */
   instanceId: string;
-  /** Link this existing DTS config instead of creating one. */
-  transferConfigName?: string;
   /** BigQuery destination dataset id. */
   datasetId: string;
   /** Prefix for per-run destination tables. */
@@ -54,7 +52,6 @@ export interface ResolvedBigqueryFirestoreExportConfig {
   bigqueryDatasetLocation: string;
   projectId: string;
   instanceId: string;
-  transferConfigName?: string;
   datasetId: string;
   tableName: string;
   queryString: string;
@@ -103,7 +100,6 @@ export function resolveConfig(
     ),
     projectId: required(config.projectId, "projectId"),
     instanceId,
-    transferConfigName: optional(config.transferConfigName),
     datasetId: required(config.datasetId, "datasetId"),
     tableName: required(config.tableName, "tableName"),
     queryString: required(config.queryString, "queryString"),

--- a/kits/bigquery-firestore-export/src/handlers.ts
+++ b/kits/bigquery-firestore-export/src/handlers.ts
@@ -22,9 +22,8 @@ import type { MessagePublishedData } from "firebase-functions/v2/pubsub";
 import {
   createTransferConfig,
   type DataTransferClient,
-  getTransferConfig,
-  notificationTopicName,
   PARTITIONING_FIELD_REMOVAL_ERROR_PREFIX,
+  type TransferConfig,
   updateTransferConfig,
 } from "./dts";
 import type { ResolvedBigqueryFirestoreExportConfig } from "./export-config";
@@ -75,9 +74,9 @@ function isPartitioningFieldRemovalError(err: unknown): err is Error {
 
 async function storeTransferConfig(
   ctx: HandlerContext,
-  transferConfig: Awaited<ReturnType<typeof getTransferConfig>>
+  transferConfig: TransferConfig
 ): Promise<void> {
-  if (!transferConfig?.name) {
+  if (!transferConfig.name) {
     throw new Error("BigQuery transfer config is missing its resource name");
   }
   const { transferConfigId } = parseTransferConfigName(transferConfig.name);
@@ -102,36 +101,11 @@ export async function handleMessagePublished(
   }
 }
 
-/** Idempotently creates, links, or updates this deployment's DTS config. */
+/** Idempotently creates or updates this deployment's DTS config. */
 export async function handleUpsertTransferConfig(
   ctx: HandlerContext
 ): Promise<void> {
   await ensureNotificationTopic(ctx);
-
-  if (ctx.config.transferConfigName) {
-    const linked = await getTransferConfig(
-      ctx.dataTransfer,
-      ctx.config.transferConfigName
-    );
-    if (!linked) {
-      // Only a redeploy with a corrected TRANSFER_CONFIG_NAME can resolve this,
-      // so retrying the task cannot help.
-      logs.linkedTransferConfigMissing(ctx.config.transferConfigName);
-      return;
-    }
-    // A linked config is adopted as-is, so a topic mismatch is the user's to
-    // resolve: rewriting it would repoint a config this deployment did not create.
-    const expectedTopic = notificationTopicName(ctx.config);
-    if (linked.notificationPubsubTopic !== expectedTopic) {
-      logs.linkedTopicMismatch(
-        ctx.config.transferConfigName,
-        linked.notificationPubsubTopic,
-        expectedTopic
-      );
-    }
-    await storeTransferConfig(ctx, linked);
-    return;
-  }
 
   const existing = await ctx.db
     .collection(ctx.config.firestoreCollection)

--- a/kits/bigquery-firestore-export/src/index.ts
+++ b/kits/bigquery-firestore-export/src/index.ts
@@ -120,7 +120,7 @@ export const processMessages = onMessagePublished<TransferRunPayload>(
   (event) => handleMessagePublished(event, getContext())
 );
 
-/** Creates, links, or reconciles this deployment's scheduled query. */
+/** Creates or reconciles this deployment's scheduled query. */
 export const upsertTransferConfig = onTaskDispatched(
   {
     memory: "1GiB",

--- a/kits/bigquery-firestore-export/src/logs.ts
+++ b/kits/bigquery-firestore-export/src/logs.ts
@@ -144,13 +144,6 @@ export function partitioningFieldRemovalAttempted(
   });
 }
 
-export function linkedTransferConfigMissing(name: string): void {
-  logger.error(
-    "The scheduled query named by TRANSFER_CONFIG_NAME does not exist, so nothing was linked. Set it to a scheduled query that exists in this project and redeploy, or clear it to have this deployment create its own.",
-    { name }
-  );
-}
-
 // The reason carries the remediation, and an Error passed as structured data
 // serialises to {}, so it goes in the message.
 export function partitioningFieldRemovalAborted(reason: string): void {
@@ -159,15 +152,4 @@ export function partitioningFieldRemovalAborted(reason: string): void {
 
 export function topicCreated(name: string): void {
   logger.info("Created Pub/Sub topic for transfer notifications", { name });
-}
-
-export function linkedTopicMismatch(
-  name: string,
-  linkedTopic: string | null | undefined,
-  expectedTopic: string
-): void {
-  logger.warn(
-    "Linked transfer config notifies a different Pub/Sub topic, so its runs will not reach this kit. Set PUB_SUB_TOPIC to the linked topic, or point the transfer config at the configured one.",
-    { name, linkedTopic: linkedTopic ?? "", expectedTopic }
-  );
 }

--- a/kits/bigquery-firestore-export/tests/config.test.ts
+++ b/kits/bigquery-firestore-export/tests/config.test.ts
@@ -117,6 +117,15 @@ describe("instance id", () => {
   });
 });
 
+describe("declared params", () => {
+  test("does not declare a transfer config name param", async () => {
+    await importConfig(INSTANCE_ID);
+
+    const declared = declaredParams.map((param) => param.name);
+    expect(declared).not.toContain("TRANSFER_CONFIG_NAME");
+  });
+});
+
 describe("configFromEnv", () => {
   test("reads runtime parameters and derives the same topic", async () => {
     const { configFromEnv } = await importConfig(INSTANCE_ID);

--- a/kits/bigquery-firestore-export/tests/export-config.test.ts
+++ b/kits/bigquery-firestore-export/tests/export-config.test.ts
@@ -44,13 +44,9 @@ describe("resolveConfig", () => {
   test("normalizes optional strings", () => {
     const resolved = resolveConfig({
       ...minimal,
-      transferConfigName: "  projects/p/locations/us/transferConfigs/c  ",
       partitioningField: "  created_at  ",
     });
 
-    expect(resolved.transferConfigName).toBe(
-      "projects/p/locations/us/transferConfigs/c"
-    );
     expect(resolved.partitioningField).toBe("created_at");
   });
 

--- a/kits/bigquery-firestore-export/tests/handlers.test.ts
+++ b/kits/bigquery-firestore-export/tests/handlers.test.ts
@@ -23,9 +23,7 @@ const mocks = vi.hoisted(() => ({
   getTransferConfig: vi.fn(),
   updateTransferConfig: vi.fn(),
   handleTransferRunMessage: vi.fn(),
-  linkedTransferConfigMissing: vi.fn(),
   partitioningFieldRemovalAborted: vi.fn(),
-  linkedTopicMismatch: vi.fn(),
 }));
 
 // The error constants come from the real module so the handler's prefix match
@@ -36,7 +34,6 @@ vi.mock("../src/dts", async (importOriginal) => {
     createTransferConfig: mocks.createTransferConfig,
     getTransferConfig: mocks.getTransferConfig,
     updateTransferConfig: mocks.updateTransferConfig,
-    notificationTopicName: actual.notificationTopicName,
     PARTITIONING_FIELD_REMOVAL_ERROR: actual.PARTITIONING_FIELD_REMOVAL_ERROR,
     PARTITIONING_FIELD_REMOVAL_ERROR_PREFIX:
       actual.PARTITIONING_FIELD_REMOVAL_ERROR_PREFIX,
@@ -53,11 +50,9 @@ vi.mock("../src/helper", () => ({
 vi.mock("../src/logs", () => ({
   complete: vi.fn(),
   error: vi.fn(),
-  linkedTransferConfigMissing: mocks.linkedTransferConfigMissing,
   partitioningFieldRemovalAborted: mocks.partitioningFieldRemovalAborted,
   start: vi.fn(),
   topicCreated: vi.fn(),
-  linkedTopicMismatch: mocks.linkedTopicMismatch,
 }));
 
 import { PARTITIONING_FIELD_REMOVAL_ERROR } from "../src/dts";
@@ -76,7 +71,6 @@ const config = resolveConfig({
 
 function makeContext(options: {
   existing?: { empty: boolean; docs: Array<{ data(): object }> };
-  transferConfigName?: string;
 }) {
   const set = vi.fn();
   const get = vi.fn().mockResolvedValue(
@@ -102,7 +96,7 @@ function makeContext(options: {
       bigquery: {},
       dataTransfer: {},
       pubsub: { topic, createTopic },
-      config: { ...config, transferConfigName: options.transferConfigName },
+      config,
     } as unknown as HandlerContext,
     set,
   };
@@ -160,68 +154,6 @@ describe("handleUpsertTransferConfig", () => {
       extInstanceId: "users-export",
       ...updated,
     });
-  });
-
-  test("links an explicitly named transfer config without updating it", async () => {
-    const linked = {
-      name: "projects/p/locations/us/transferConfigs/config-2",
-      notificationPubsubTopic:
-        "projects/test-project/topics/kit-users-export-processMessages",
-    };
-    mocks.getTransferConfig.mockResolvedValue(linked);
-    const { ctx, set } = makeContext({
-      transferConfigName: linked.name,
-    });
-
-    await handleUpsertTransferConfig(ctx);
-
-    expect(mocks.getTransferConfig).toHaveBeenCalledWith(
-      ctx.dataTransfer,
-      linked.name
-    );
-    expect(mocks.updateTransferConfig).not.toHaveBeenCalled();
-    expect(mocks.linkedTopicMismatch).not.toHaveBeenCalled();
-    expect(set).toHaveBeenCalledWith({
-      extInstanceId: "users-export",
-      ...linked,
-    });
-  });
-
-  test("warns instead of repointing a linked config on another topic", async () => {
-    const linked = {
-      name: "projects/p/locations/us/transferConfigs/config-3",
-      notificationPubsubTopic:
-        "projects/test-project/topics/ext-users-export-processMessages",
-    };
-    mocks.getTransferConfig.mockResolvedValue(linked);
-    const { ctx, set } = makeContext({ transferConfigName: linked.name });
-
-    await handleUpsertTransferConfig(ctx);
-
-    expect(mocks.linkedTopicMismatch).toHaveBeenCalledWith(
-      linked.name,
-      linked.notificationPubsubTopic,
-      "projects/test-project/topics/kit-users-export-processMessages"
-    );
-    expect(mocks.updateTransferConfig).not.toHaveBeenCalled();
-    expect(set).toHaveBeenCalledWith({
-      extInstanceId: "users-export",
-      ...linked,
-    });
-  });
-
-  test("reports a missing linked transfer config without retrying", async () => {
-    mocks.getTransferConfig.mockResolvedValue(null);
-    const { ctx, set } = makeContext({
-      transferConfigName: "projects/p/locations/us/transferConfigs/gone",
-    });
-
-    await expect(handleUpsertTransferConfig(ctx)).resolves.toBeUndefined();
-
-    expect(mocks.linkedTransferConfigMissing).toHaveBeenCalledWith(
-      "projects/p/locations/us/transferConfigs/gone"
-    );
-    expect(set).not.toHaveBeenCalled();
   });
 
   test("reports a rejected partitioning-field removal without retrying", async () => {


### PR DESCRIPTION
The bigquery-firestore-export extension hard-codes `transferConfigName: undefined` in its `functions/src/config.ts` and exposes no param for it, so the `if (config.transferConfigName)` branch in `upsertTransferConfig` is dead code there. The kit made that branch live by adding a `TRANSFER_CONFIG_NAME` param and taking the link path in `handleUpsertTransferConfig`.

The ruling on #3165 is parity. Nobody is on `kits` yet, so nothing depends on it, and the only time the path was exercised it turned out to be broken (#2970). Shipping a kit-only feature that the extension never offered, in the state it is in, is not worth it.

Removed: the param, `transferConfigName` on both config interfaces and in `resolveConfig`, the link branch, and the `linkedTransferConfigMissing` and `linkedTopicMismatch` log helpers. Kept: `getTransferConfig` in `dts.ts`, which the update path still uses through `constructUpdateTransferConfigRequest`. README rows and the adoption sections are gone.

Tests now pin that `TRANSFER_CONFIG_NAME` is not a declared param, and the existing test that an instance with a Firestore config document carrying `name` goes down the update path. 81 tests pass, `tsc --noEmit` is clean, prettier reports no differences. Nothing was deployed or run live.

This is a breaking config change for anyone who set `TRANSFER_CONFIG_NAME` on `kits`; the CHANGELOG entry is marked breaking. Re-adding adoption as a deliberate feature is tracked in #3185, with PR #2960 as the starting point; none of it is implemented here.

This PR targets `kits`, not the default branch, so the issue will need closing by hand on merge.

Fixes #3165
