### PR TITLE
chore(firestore-bigquery-export): Restore kit dependencies for firebase-admin and firebase-functions.

### DIFF
--- a/kits/firestore-bigquery-export/npm-shrinkwrap.json
+++ b/kits/firestore-bigquery-export/npm-shrinkwrap.json
@@ -11,22 +11,18 @@
       "dependencies": {
         "@firebaseextensions/firestore-bigquery-change-tracker": "^2.2.1",
         "@google-cloud/bigquery": "^7.6.0",
+        "firebase-admin": "^14.4.0",
+        "firebase-functions": "^7.3.3-rc.3",
         "generate-schema": "^2.6.0",
         "lodash": "^4.17.14"
       },
       "devDependencies": {
         "@types/lodash": "^4.17.0",
-        "firebase-admin": "^14.4.0",
-        "firebase-functions": "^7.3.3-rc.3",
         "typescript": "^5.9.3",
         "vitest": "^3.2.4"
       },
       "engines": {
         "node": ">=22"
-      },
-      "peerDependencies": {
-        "firebase-admin": "^14.3.0",
-        "firebase-functions": "^7.3.3-rc.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -608,6 +604,42 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@firebaseextensions/firestore-bigquery-change-tracker/node_modules/firebase-functions": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-7.3.2.tgz",
+      "integrity": "sha512-DTa5CtCNxFE1gPjkjlhl5uh8AcNWXLKORAMRenfkecP8zGstbje+r2TaNh4Ehdxp0qTPvTUe/sS23VESW32Gbg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.5",
+        "@types/express": "^5.0.0",
+        "cors": "^2.8.5",
+        "express": "^5.2.1",
+        "protobufjs": "^7.2.2"
+      },
+      "bin": {
+        "firebase-functions": "lib/bin/firebase-functions.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@apollo/server": "^5.2.0",
+        "@as-integrations/express4": "^1.1.2",
+        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0 || ^14.0.0",
+        "graphql": "^16.12.0"
+      },
+      "peerDependenciesMeta": {
+        "@apollo/server": {
+          "optional": true
+        },
+        "@as-integrations/express4": {
+          "optional": true
+        },
+        "graphql": {
+          "optional": true
+        }
       }
     },
     "node_modules/@google-cloud/bigquery": {

--- a/kits/firestore-bigquery-export/package.json
+++ b/kits/firestore-bigquery-export/package.json
@@ -33,6 +33,8 @@
   "dependencies": {
     "@firebaseextensions/firestore-bigquery-change-tracker": "^2.2.1",
     "@google-cloud/bigquery": "^7.6.0",
+    "firebase-admin": "^14.4.0",
+    "firebase-functions": "^7.3.3-rc.3",
     "generate-schema": "^2.6.0",
     "lodash": "^4.17.14"
   },
@@ -43,13 +45,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.17.0",
-    "firebase-admin": "^14.4.0",
-    "firebase-functions": "^7.3.3-rc.3",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"
-  },
-  "peerDependencies": {
-    "firebase-admin": "^14.3.0",
-    "firebase-functions": "^7.3.3-rc.3"
   }
 }


### PR DESCRIPTION
Changed as part of testing the workflow to flip dependencies to peer
during release.
